### PR TITLE
Consolidated PVC and Service creation

### DIFF
--- a/controllers/cloud.redhat.com/makers/maker.go
+++ b/controllers/cloud.redhat.com/makers/maker.go
@@ -169,12 +169,7 @@ func (m *Maker) makeService(pod crd.PodSpec) error {
 		ports = append(ports, webPort)
 	}
 
-	labels := m.App.GetLabels()
-	labels["pod"] = nn.Name
-	m.App.SetObjectMeta(&s, crd.Name(pod.Name), crd.Labels(labels))
-
-	s.Spec.Selector = labels
-	s.Spec.Ports = ports
+	utils.MakeService(&s, nn, map[string]string{"pod": nn.Name}, ports, m.App)
 
 	return update.Apply(m.Ctx, m.Client, &s)
 }

--- a/controllers/cloud.redhat.com/providers/localdb_test.go
+++ b/controllers/cloud.redhat.com/providers/localdb_test.go
@@ -24,7 +24,7 @@ func getBaseElements() (types.NamespacedName, crd.ClowdApp) {
 	objMeta := metav1.ObjectMeta{
 		Name:      "reqapp",
 		Namespace: "default",
-		Labels: map[string]string{
+		Labels: labels{
 			"app": "test",
 		},
 	}

--- a/controllers/cloud.redhat.com/providers/localkafka.go
+++ b/controllers/cloud.redhat.com/providers/localkafka.go
@@ -10,7 +10,6 @@ import (
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/utils"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -185,19 +184,10 @@ func makeLocalKafka(env *crd.ClowdEnvironment, dd *apps.Deployment, svc *core.Se
 	dd.Spec.Template.Spec.Containers = []core.Container{c}
 	dd.Spec.Template.SetLabels(labels)
 
-	labeler(svc)
+	servicePorts := []core.ServicePort{{Name: "kafka", Port: 29092, Protocol: "TCP"}}
 
-	svc.Spec.Selector = labels
-	svc.Spec.Ports = []core.ServicePort{{Name: "kafka", Port: 29092, Protocol: "TCP"}}
-
-	labeler(pvc)
-
-	pvc.Spec.AccessModes = []core.PersistentVolumeAccessMode{core.ReadWriteOnce}
-	pvc.Spec.Resources = core.ResourceRequirements{
-		Requests: core.ResourceList{
-			core.ResourceName(core.ResourceStorage): resource.MustParse("1Gi"),
-		},
-	}
+	utils.MakeService(svc, nn, labels, servicePorts, env)
+	utils.MakePVC(pvc, nn, labels, "1Gi", env)
 }
 
 func makeLocalZookeeper(env *crd.ClowdEnvironment, dd *apps.Deployment, svc *core.Service, pvc *core.PersistentVolumeClaim) {
@@ -306,17 +296,6 @@ func makeLocalZookeeper(env *crd.ClowdEnvironment, dd *apps.Deployment, svc *cor
 		},
 	}
 
-	labeler(svc)
-
-	svc.Spec.Selector = labels
-	svc.Spec.Ports = servicePorts
-
-	labeler(pvc)
-
-	pvc.Spec.AccessModes = []core.PersistentVolumeAccessMode{core.ReadWriteOnce}
-	pvc.Spec.Resources = core.ResourceRequirements{
-		Requests: core.ResourceList{
-			core.ResourceName(core.ResourceStorage): resource.MustParse("1Gi"),
-		},
-	}
+	utils.MakeService(svc, nn, labels, servicePorts, env)
+	utils.MakePVC(pvc, nn, labels, "1Gi", env)
 }

--- a/controllers/cloud.redhat.com/providers/localkafka_test.go
+++ b/controllers/cloud.redhat.com/providers/localkafka_test.go
@@ -33,6 +33,14 @@ func TestLocalKafka(t *testing.T) {
 	if dd.Name != "env-kafka" {
 		t.Errorf("Wrong deployment name %s; expected %s", dd.Name, "env-kafka")
 	}
+
+	if svc.Name != "env-kafka" {
+		t.Errorf("Wrong service name %s; expected %s", svc.Name, "env-kafka")
+	}
+
+	if pvc.Name != "env-kafka" {
+		t.Errorf("Wrong pvc name %s; expected %s", pvc.Name, "env-kafka")
+	}
 }
 
 func TestLocalZookeeper(t *testing.T) {
@@ -43,6 +51,14 @@ func TestLocalZookeeper(t *testing.T) {
 	makeLocalZookeeper(&env, &dd, &svc, &pvc)
 
 	if dd.Name != "env-zookeeper" {
-		t.Errorf("Wrong deployment name %s; expected %s", dd.Name, "env-kafka")
+		t.Errorf("Wrong deployment name %s; expected %s", dd.Name, "env-zookeeper")
+	}
+
+	if svc.Name != "env-zookeeper" {
+		t.Errorf("Wrong service name %s; expected %s", svc.Name, "env-zookeeper")
+	}
+
+	if pvc.Name != "env-zookeeper" {
+		t.Errorf("Wrong pvc name %s; expected %s", pvc.Name, "env-zookeeper")
 	}
 }

--- a/controllers/cloud.redhat.com/providers/providers.go
+++ b/controllers/cloud.redhat.com/providers/providers.go
@@ -12,6 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type labels map[string]string
+
 type Provider struct {
 	Client client.Client
 	Ctx    context.Context

--- a/controllers/cloud.redhat.com/providers/redis.go
+++ b/controllers/cloud.redhat.com/providers/redis.go
@@ -44,21 +44,14 @@ func makeRedisDeployment(dd *apps.Deployment, nn types.NamespacedName, pp *crd.C
 	}}
 }
 
-func makeRedisService(s *core.Service, nn types.NamespacedName, pp *crd.ClowdApp) {
+func makeRedisService(s *core.Service, nn types.NamespacedName, app *crd.ClowdApp) {
 	servicePorts := []core.ServicePort{{
 		Name:     "redis",
 		Port:     6379,
 		Protocol: "TCP",
 	}}
 
-	pp.SetObjectMeta(
-		s,
-		crd.Name(nn.Name),
-		crd.Namespace(nn.Namespace),
-	)
-
-	s.Spec.Selector = pp.GetLabels()
-	s.Spec.Ports = servicePorts
+	utils.MakeService(s, nn, nil, servicePorts, app)
 }
 
 func (r *redisProvider) CreateInMemoryDB(app *crd.ClowdApp) error {

--- a/controllers/cloud.redhat.com/providers/strimzi.go
+++ b/controllers/cloud.redhat.com/providers/strimzi.go
@@ -91,7 +91,7 @@ func (s *strimziProvider) CreateTopic(nn types.NamespacedName, topic *strimzi.Ka
 		return err
 	}
 
-	labels := map[string]string{
+	labels := labels{
 		"strimzi.io/cluster": s.Env.Spec.Kafka.ClusterName,
 		"app":                nn.Name,
 		// If we label it with the app name, since app names should be


### PR DESCRIPTION
* In all cases it was possible to pull out the common pvc and service
  pieces and generalize them.
* A new interface, ClowdObject was  created, to allow the MakeLabeler
  function to take either an App or an Env as its obj argument.