### PR TITLE
Break providers into subpackages

### DIFF
--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -27,6 +27,7 @@ import (
 	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/errors"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
+	rt "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers/runtime"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -62,7 +63,7 @@ func (r *ClowdEnvironmentReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 		Env:    &env,
 	}
 
-	err = provider.SetUpEnvironment()
+	err = rt.SetUpEnvironment(&provider)
 	requeue := errors.HandleError(r.Log, err)
 	return ctrl.Result{Requeue: requeue}, nil
 }

--- a/controllers/cloud.redhat.com/makers/maker.go
+++ b/controllers/cloud.redhat.com/makers/maker.go
@@ -27,6 +27,7 @@ import (
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/config"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/errors"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
+	rt "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers/runtime"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/utils"
 
 	apps "k8s.io/api/apps/v1"
@@ -422,7 +423,7 @@ func (m *Maker) runProviders() (*config.AppConfig, error) {
 	c.MetricsPort = int(m.Env.Spec.Metrics.Port)
 	c.MetricsPath = m.Env.Spec.Metrics.Path
 
-	objectStoreProvider, err := provider.GetObjectStore()
+	objectStoreProvider, err := rt.GetObjectStore(&provider)
 
 	if err != nil {
 		return &c, err
@@ -439,7 +440,7 @@ func (m *Maker) runProviders() (*config.AppConfig, error) {
 	dbSpec := m.App.Spec.Database
 
 	if dbSpec.Name != "" {
-		databaseProvider, err := provider.GetDatabase()
+		databaseProvider, err := rt.GetDatabase(&provider)
 
 		if err != nil {
 			return &c, errors.Wrap("Failed to init db provider", err)
@@ -452,7 +453,7 @@ func (m *Maker) runProviders() (*config.AppConfig, error) {
 		databaseProvider.Configure(&c)
 	}
 
-	kafkaProvider, err := provider.GetKafka()
+	kafkaProvider, err := rt.GetKafka(&provider)
 
 	if err != nil {
 		return &c, errors.Wrap("Failed to init kafka provider", err)
@@ -474,7 +475,7 @@ func (m *Maker) runProviders() (*config.AppConfig, error) {
 	kafkaProvider.Configure(&c)
 
 	if m.App.Spec.InMemoryDB {
-		inMemoryDbProvider, err := provider.GetInMemoryDB()
+		inMemoryDbProvider, err := rt.GetInMemoryDB(&provider)
 
 		if err != nil {
 			return &c, errors.Wrap("Failed to init in-memory db provider", err)
@@ -487,7 +488,7 @@ func (m *Maker) runProviders() (*config.AppConfig, error) {
 		inMemoryDbProvider.Configure(&c)
 	}
 
-	loggingProvider, err := provider.GetLogging()
+	loggingProvider, err := rt.GetLogging(&provider)
 
 	if err != nil {
 		return &c, errors.Wrap("Failed to init logging provider", err)

--- a/controllers/cloud.redhat.com/providers/database/localdb.go
+++ b/controllers/cloud.redhat.com/providers/database/localdb.go
@@ -1,4 +1,4 @@
-package providers
+package database
 
 import (
 	"fmt"
@@ -8,6 +8,7 @@ import (
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/errors"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/utils"
 
+	p "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,7 +16,7 @@ import (
 )
 
 type localDbProvider struct {
-	Provider
+	p.Provider
 	Config *config.DatabaseConfig
 }
 
@@ -23,7 +24,7 @@ func (db *localDbProvider) Configure(c *config.AppConfig) {
 	c.Database = db.Config
 }
 
-func NewLocalDBProvider(p *Provider) (DatabaseProvider, error) {
+func NewLocalDBProvider(p *p.Provider) (p.DatabaseProvider, error) {
 	return &localDbProvider{Provider: *p}, nil
 }
 
@@ -176,9 +177,9 @@ func makeLocalService(s *core.Service, nn types.NamespacedName, app *crd.ClowdAp
 		Port:     5432,
 		Protocol: "TCP",
 	}}
-	utils.MakeService(s, nn, labels{"service": "db"}, servicePorts, app)
+	utils.MakeService(s, nn, p.Labels{"service": "db"}, servicePorts, app)
 }
 
 func makeLocalPVC(pvc *core.PersistentVolumeClaim, nn types.NamespacedName, app *crd.ClowdApp) {
-	utils.MakePVC(pvc, nn, labels{"service": "db"}, "1Gi", app)
+	utils.MakePVC(pvc, nn, p.Labels{"service": "db"}, "1Gi", app)
 }

--- a/controllers/cloud.redhat.com/providers/database/localdb_test.go
+++ b/controllers/cloud.redhat.com/providers/database/localdb_test.go
@@ -1,4 +1,4 @@
-package providers
+package database
 
 import (
 	"fmt"
@@ -12,6 +12,7 @@ import (
 
 	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/config"
+	p "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/utils"
 )
 
@@ -24,7 +25,7 @@ func getBaseElements() (types.NamespacedName, crd.ClowdApp) {
 	objMeta := metav1.ObjectMeta{
 		Name:      "reqapp",
 		Namespace: "default",
-		Labels: labels{
+		Labels: p.Labels{
 			"app": "test",
 		},
 	}

--- a/controllers/cloud.redhat.com/providers/inmemorydb/redis.go
+++ b/controllers/cloud.redhat.com/providers/inmemorydb/redis.go
@@ -1,10 +1,12 @@
-package providers
+package inmemorydb
 
 import (
 	"fmt"
 
 	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/config"
+	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
+	p "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/utils"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
@@ -12,7 +14,7 @@ import (
 )
 
 type localRedis struct {
-	Provider
+	p.Provider
 	Config config.InMemoryDBConfig
 }
 
@@ -21,10 +23,10 @@ func (r *localRedis) Configure(config *config.AppConfig) {
 }
 
 func (r *localRedis) CreateInMemoryDB(app *crd.ClowdApp) error {
-	return makeComponent(r.Ctx, r.Client, app, "redis", makeLocalRedis)
+	return providers.MakeComponent(r.Ctx, r.Client, app, "redis", makeLocalRedis)
 }
 
-func NewLocalRedis(p *Provider) (InMemoryDBProvider, error) {
+func NewLocalRedis(p *providers.Provider) (providers.InMemoryDBProvider, error) {
 	config := config.InMemoryDBConfig{
 		Hostname: fmt.Sprintf("%v.%v.svc", p.Env.Name, p.Env.Spec.Namespace),
 		Port:     6379,
@@ -36,7 +38,7 @@ func NewLocalRedis(p *Provider) (InMemoryDBProvider, error) {
 }
 
 func makeLocalRedis(o utils.ClowdObject, dd *apps.Deployment, svc *core.Service, pvc *core.PersistentVolumeClaim) {
-	nn := getNamespacedName(o, "redis")
+	nn := providers.GetNamespacedName(o, "redis")
 
 	oneReplica := int32(1)
 

--- a/controllers/cloud.redhat.com/providers/inmemorydb/redis_test.go
+++ b/controllers/cloud.redhat.com/providers/inmemorydb/redis_test.go
@@ -1,4 +1,4 @@
-package providers
+package inmemorydb
 
 import (
 	"testing"

--- a/controllers/cloud.redhat.com/providers/kafka/localkafka_test.go
+++ b/controllers/cloud.redhat.com/providers/kafka/localkafka_test.go
@@ -1,4 +1,4 @@
-package providers
+package kafka
 
 import (
 	"testing"

--- a/controllers/cloud.redhat.com/providers/kafka/strimzi.go
+++ b/controllers/cloud.redhat.com/providers/kafka/strimzi.go
@@ -1,4 +1,4 @@
-package providers
+package kafka
 
 import (
 	"fmt"
@@ -8,6 +8,7 @@ import (
 
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/config"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/errors"
+	p "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/utils"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -20,7 +21,7 @@ var conversionMap = map[string]func([]string) (string, error){
 }
 
 type strimziProvider struct {
-	Provider
+	p.Provider
 	Config config.KafkaConfig
 }
 
@@ -57,7 +58,7 @@ func (s *strimziProvider) configureBrokers() error {
 	return nil
 }
 
-func NewStrimzi(p *Provider) (KafkaProvider, error) {
+func NewStrimzi(p *p.Provider) (p.KafkaProvider, error) {
 	kafkaProvider := &strimziProvider{
 		Provider: *p,
 		Config: config.KafkaConfig{
@@ -91,7 +92,7 @@ func (s *strimziProvider) CreateTopic(nn types.NamespacedName, topic *strimzi.Ka
 		return err
 	}
 
-	labels := labels{
+	labels := p.Labels{
 		"strimzi.io/cluster": s.Env.Spec.Kafka.ClusterName,
 		"app":                nn.Name,
 		// If we label it with the app name, since app names should be

--- a/controllers/cloud.redhat.com/providers/logging/appinterface_logging.go
+++ b/controllers/cloud.redhat.com/providers/logging/appinterface_logging.go
@@ -1,4 +1,4 @@
-package providers
+package logging
 
 import (
 	"fmt"
@@ -6,13 +6,14 @@ import (
 	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/config"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/errors"
+	p "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/utils"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 type AppInterfaceLoggingProvider struct {
-	Provider
+	p.Provider
 	Config config.LoggingConfig
 }
 
@@ -20,7 +21,7 @@ func (a *AppInterfaceLoggingProvider) Configure(c *config.AppConfig) {
 	c.Logging = a.Config
 }
 
-func NewAppInterfaceLogging(p *Provider) (LoggingProvider, error) {
+func NewAppInterfaceLogging(p *p.Provider) (p.LoggingProvider, error) {
 	provider := AppInterfaceLoggingProvider{Provider: *p}
 
 	return &provider, nil
@@ -31,7 +32,7 @@ func (a *AppInterfaceLoggingProvider) SetUpLogging(app *crd.ClowdApp) error {
 	return setCloudwatchSecret(app.Namespace, &a.Provider, &a.Config)
 }
 
-func setCloudwatchSecret(ns string, p *Provider, c *config.LoggingConfig) error {
+func setCloudwatchSecret(ns string, p *p.Provider, c *config.LoggingConfig) error {
 
 	name := types.NamespacedName{
 		Name:      "cloudwatch",

--- a/controllers/cloud.redhat.com/providers/objectstore/appinterface_objectstore.go
+++ b/controllers/cloud.redhat.com/providers/objectstore/appinterface_objectstore.go
@@ -1,4 +1,4 @@
-package providers
+package objectstore
 
 import (
 	"fmt"
@@ -7,12 +7,13 @@ import (
 	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/config"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/errors"
+	p "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 	core "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type AppInterfaceObjectstoreProvider struct {
-	Provider
+	p.Provider
 	Config config.ObjectStoreConfig
 }
 
@@ -20,7 +21,7 @@ func (a *AppInterfaceObjectstoreProvider) Configure(c *config.AppConfig) {
 	c.ObjectStore = &a.Config
 }
 
-func NewAppInterfaceObjectstore(p *Provider) (ObjectStoreProvider, error) {
+func NewAppInterfaceObjectstore(p *p.Provider) (p.ObjectStoreProvider, error) {
 	provider := AppInterfaceObjectstoreProvider{Provider: *p}
 
 	return &provider, nil
@@ -91,8 +92,8 @@ func genObjStoreConfig(secrets []core.Secret) (*config.ObjectStoreConfig, error)
 
 		if accessKeyOk && secretKeyOk && nameOk {
 			bucketConfig := config.ObjectStoreBucket{
-				AccessKey: strPtr(string(accessKey)),
-				SecretKey: strPtr(string(secretKey)),
+				AccessKey: p.StrPtr(string(accessKey)),
+				SecretKey: p.StrPtr(string(secretKey)),
 				Name:      string(name),
 			}
 			if endpointOk {

--- a/controllers/cloud.redhat.com/providers/objectstore/appinterface_objectstore_test.go
+++ b/controllers/cloud.redhat.com/providers/objectstore/appinterface_objectstore_test.go
@@ -1,10 +1,11 @@
-package providers
+package objectstore
 
 import (
 	"fmt"
 	"testing"
 
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/config"
+	p "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/utils"
 	core "k8s.io/api/core/v1"
 )
@@ -71,8 +72,8 @@ func TestAppInterfaceObjectStore(t *testing.T) {
 		Port:     443,
 		Hostname: testSecretSpecs.ExactKeys["endpoint"],
 		Buckets: []config.ObjectStoreBucket{{
-			AccessKey: strPtr(testSecretSpecs.ExactKeys["aws_access_key_id"]),
-			SecretKey: strPtr(testSecretSpecs.ExactKeys["aws_secret_access_key"]),
+			AccessKey: p.StrPtr(testSecretSpecs.ExactKeys["aws_access_key_id"]),
+			SecretKey: p.StrPtr(testSecretSpecs.ExactKeys["aws_secret_access_key"]),
 			Name:      testSecretSpecs.ExactKeys["bucket"],
 		}},
 	}

--- a/controllers/cloud.redhat.com/providers/objectstore/minio.go
+++ b/controllers/cloud.redhat.com/providers/objectstore/minio.go
@@ -1,4 +1,4 @@
-package providers
+package objectstore
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/config"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/errors"
+	p "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/utils"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -70,7 +71,7 @@ func (m *minioProvider) CreateBuckets(app *crd.ClowdApp) error {
 }
 
 // NewMinIO constructs a new minio for the given config
-func NewMinIO(p *Provider) (ObjectStoreProvider, error) {
+func NewMinIO(p *p.Provider) (p.ObjectStoreProvider, error) {
 	nn := types.NamespacedName{
 		Namespace: p.Env.Spec.Namespace,
 		Name:      p.Env.Name + "-minio",

--- a/controllers/cloud.redhat.com/providers/runtime/runtime.go
+++ b/controllers/cloud.redhat.com/providers/runtime/runtime.go
@@ -1,0 +1,100 @@
+package runtime
+
+import (
+	"fmt"
+
+	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/errors"
+	p "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
+	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers/database"
+	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers/inmemorydb"
+	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers/kafka"
+	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers/logging"
+	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers/objectstore"
+)
+
+func GetObjectStore(c *p.Provider) (p.ObjectStoreProvider, error) {
+	objectStoreProvider := c.Env.Spec.ObjectStore.Provider
+	switch objectStoreProvider {
+	case "minio":
+		return objectstore.NewMinIO(c)
+	case "app-interface":
+		return &objectstore.AppInterfaceObjectstoreProvider{Provider: *c}, nil
+	default:
+		errStr := fmt.Sprintf("No matching object store provider for %s", objectStoreProvider)
+		return nil, errors.New(errStr)
+	}
+}
+
+func GetDatabase(c *p.Provider) (p.DatabaseProvider, error) {
+	dbProvider := c.Env.Spec.Database.Provider
+	switch dbProvider {
+	case "local":
+		return database.NewLocalDBProvider(c)
+	default:
+		errStr := fmt.Sprintf("No matching db provider for %s", dbProvider)
+		return nil, errors.New(errStr)
+	}
+}
+
+func GetKafka(c *p.Provider) (p.KafkaProvider, error) {
+	kafkaProvider := c.Env.Spec.Kafka.Provider
+	switch kafkaProvider {
+	case "operator":
+		return kafka.NewStrimzi(c)
+	case "local":
+		return kafka.NewLocalKafka(c)
+	default:
+		errStr := fmt.Sprintf("No matching kafka provider for %s", kafkaProvider)
+		return nil, errors.New(errStr)
+	}
+}
+
+func GetInMemoryDB(c *p.Provider) (p.InMemoryDBProvider, error) {
+	dbProvider := c.Env.Spec.InMemoryDB.Provider
+	switch dbProvider {
+	case "redis":
+		return inmemorydb.NewLocalRedis(c)
+	default:
+		errStr := fmt.Sprintf("No matching in-memory db provider for %s", dbProvider)
+		return nil, errors.New(errStr)
+	}
+}
+
+func GetLogging(c *p.Provider) (p.LoggingProvider, error) {
+	logProvider := c.Env.Spec.Logging.Provider
+	switch logProvider {
+	case "app-interface":
+		return logging.NewAppInterfaceLogging(c)
+	case "none":
+		return nil, nil
+	default:
+		errStr := fmt.Sprintf("No matching logging provider for %s", logProvider)
+		return nil, errors.New(errStr)
+	}
+}
+
+func SetUpEnvironment(c *p.Provider) error {
+	var err error
+
+	if _, err = GetObjectStore(c); err != nil {
+		return errors.Wrap("setupenv: getobjectstore", err)
+	}
+
+	if _, err = GetDatabase(c); err != nil {
+		return errors.Wrap("setupenv: getdatabase", err)
+	}
+
+	if _, err = GetKafka(c); err != nil {
+		return errors.Wrap("setupenv: getkafka", err)
+	}
+
+	if _, err = GetInMemoryDB(c); err != nil {
+		return errors.Wrap("setupenv: getinmemorydb", err)
+	}
+
+	if _, err = GetLogging(c); err != nil {
+		return errors.Wrap("setupenv: getlogging", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Had to pull much of providers.go into runtime subpackage to avoid
circular dependencies.  Probably indicative of mixed purposes.