### PR TITLE
Fix target namespace handling

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
@@ -15,6 +15,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
+
 	core "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -180,7 +182,7 @@ type InMemoryDBConfig struct {
 type ClowdEnvironmentSpec struct {
 	// TargetNamespace describes the namespace where any generated environmental
 	// resources should end up, this is particularly important in (*_local_*) mode.
-	TargetNamespace string `json:"targetNamespace"`
+	TargetNamespace string `json:"targetNamespace,omitempty"`
 
 	// A ProvidersConfig object, detailing the setup and configuration of all the
 	// providers used in this ClowdEnvironment.
@@ -227,20 +229,11 @@ type MinioStatus struct {
 	Port int32 `json:"port"`
 }
 
-// ObjectStoreStatus defines the status of a Minio setup in local mode, including buckets.
-type ObjectStoreStatus struct {
-	// A MinioStatus object.
-	Minio MinioStatus `json:"minio,omitempty"`
-
-	// A list of buckets provided by the Minio instance.
-	Buckets []string `json:"buckets"`
-}
-
 // ClowdEnvironmentStatus defines the observed state of ClowdEnvironment
 type ClowdEnvironmentStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	ObjectStore ObjectStoreStatus `json:"objectStore"`
+	TargetNamespace string `json:"targetNamespace"`
 }
 
 // +kubebuilder:object:root=true
@@ -290,10 +283,15 @@ func (i *ClowdEnvironment) MakeOwnerReference() metav1.OwnerReference {
 
 // GetClowdNamespace returns the namespace of the ClowdApp object.
 func (i *ClowdEnvironment) GetClowdNamespace() string {
-	return i.Spec.TargetNamespace
+	return i.Status.TargetNamespace
 }
 
 // GetClowdName returns the name of the ClowdApp object.
 func (i *ClowdEnvironment) GetClowdName() string {
 	return i.Name
+}
+
+// GetGeneratedTargetNamespace gets a generated target namespace if one is not provided
+func (i *ClowdEnvironment) GetGeneratedTargetNamespace() string {
+	return fmt.Sprintf("clowdenv-%s", i.Name)
 }

--- a/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
@@ -16,7 +16,9 @@ package v1alpha1
 
 import (
 	"fmt"
+	"strings"
 
+	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/utils"
 	core "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -292,6 +294,6 @@ func (i *ClowdEnvironment) GetClowdName() string {
 }
 
 // GetGeneratedTargetNamespace gets a generated target namespace if one is not provided
-func (i *ClowdEnvironment) GetGeneratedTargetNamespace() string {
-	return fmt.Sprintf("clowdenv-%s", i.Name)
+func (i *ClowdEnvironment) GenerateTargetNamespace() string {
+	return fmt.Sprintf("clowdenv-%s-%s", i.Name, strings.ToLower(utils.RandString(6)))
 }

--- a/bundle/tests/scorecard/kuttl/test-target-namespace/00-install.yaml
+++ b/bundle/tests/scorecard/kuttl/test-target-namespace/00-install.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-target-namespace
+spec:
+  finalizers:
+  - kubernetes

--- a/bundle/tests/scorecard/kuttl/test-target-namespace/01-pods.yaml
+++ b/bundle/tests/scorecard/kuttl/test-target-namespace/01-pods.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdEnvironment
+metadata:
+  name: test-target-namespace
+spec:
+  providers:
+    web:
+      port: 8000
+      mode: operator
+    metrics:
+      port: 9000
+      mode: operator
+      path: "/metrics"
+    kafka:
+      namespace: kafka
+      clusterName: my-cluster
+      mode: local
+    db:
+      image: "registry.redhat.io/rhel8/postgresql-12:1-36"
+      mode: local
+    logging:
+      mode: none
+    objectStore:
+      mode: minio
+      #Possibly need to specify a port here
+    inMemoryDb:
+      mode: redis
+  resourceDefaults:
+    limits:
+      cpu: 400m
+      memory: 1024Mi
+    requests:
+      cpu: 30m
+      memory: 512Mi

--- a/bundle/tests/scorecard/kuttl/test-target-namespace/02-json-asserts.yaml
+++ b/bundle/tests/scorecard/kuttl/test-target-namespace/02-json-asserts.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kudo.dev/v1alpha1
+kind: TestStep
+commands:
+- script: sleep 10
+- script: kubectl get clowdenvironment test-target-namespace -o json > /tmp/target_namespace
+- script: cat /tmp/target_namespace | jq -r '.status.targetNamespace != ""' -e > /tmp/target_namespace

--- a/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
@@ -256,54 +256,17 @@ spec:
           required:
           - providers
           - resourceDefaults
-          - targetNamespace
           type: object
         status:
           description: ClowdEnvironmentStatus defines the observed state of ClowdEnvironment
           properties:
-            objectStore:
+            targetNamespace:
               description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
                 of cluster Important: Run "make" to regenerate code after modifying
                 this file'
-              properties:
-                buckets:
-                  description: A list of buckets provided by the Minio instance.
-                  items:
-                    type: string
-                  type: array
-                minio:
-                  description: A MinioStatus object.
-                  properties:
-                    credentials:
-                      description: A reference to standard k8s secret.
-                      properties:
-                        name:
-                          description: Name is unique within a namespace to reference
-                            a secret resource.
-                          type: string
-                        namespace:
-                          description: Namespace defines the space within which the
-                            secret name must be unique.
-                          type: string
-                      type: object
-                    hostname:
-                      description: The hostname of a Minio instance.
-                      type: string
-                    port:
-                      description: The port number the Minio instance is to be served
-                        on.
-                      format: int32
-                      type: integer
-                  required:
-                  - credentials
-                  - hostname
-                  - port
-                  type: object
-              required:
-              - buckets
-              type: object
+              type: string
           required:
-          - objectStore
+          - targetNamespace
           type: object
       type: object
   version: v1alpha1

--- a/controllers/cloud.redhat.com/clowdapp_controller.go
+++ b/controllers/cloud.redhat.com/clowdapp_controller.go
@@ -50,7 +50,7 @@ type ClowdAppReconciler struct {
 
 // +kubebuilder:rbac:groups=cloud.redhat.com,resources=clowdapps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cloud.redhat.com,resources=clowdapps/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups="",resources=services;persistentvolumeclaims;secrets;events,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=services;persistentvolumeclaims;secrets;events;namespaces,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkatopics,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkas,verbs=get;list;watch

--- a/controllers/cloud.redhat.com/clowdapp_controller.go
+++ b/controllers/cloud.redhat.com/clowdapp_controller.go
@@ -83,7 +83,7 @@ func (r *ClowdAppReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	}, &env)
 
 	if err != nil {
-		r.Recorder.Eventf(&app, "warning", "ClowdEnvMissing", "Clowder Environment [%s] is missing", app.Spec.EnvName)
+		r.Recorder.Eventf(&app, "Warning", "ClowdEnvMissing", "Clowder Environment [%s] is missing", app.Spec.EnvName)
 		return ctrl.Result{}, err
 	}
 

--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -18,8 +18,10 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
+	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -65,6 +67,24 @@ func (r *ClowdEnvironmentReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
+	}
+
+	if env.Status.TargetNamespace == "" {
+		if env.Spec.TargetNamespace != "" {
+			env.Status.TargetNamespace = env.Spec.TargetNamespace
+		} else {
+			env.Status.TargetNamespace = env.GetGeneratedTargetNamespace()
+			namespace := &core.Namespace{}
+			namespace.SetName(env.Status.TargetNamespace)
+			err := r.Client.Create(ctx, namespace)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		err := r.Client.Status().Update(ctx, &env)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	ctx = context.WithValue(ctx, errors.ClowdKey("obj"), &env)
@@ -148,6 +168,13 @@ func (r *ClowdEnvironmentReconciler) finalizeEnvironment(reqLogger logr.Logger, 
 
 	if _, ok := managedEnvironments[e.Name]; ok == true {
 		delete(managedEnvironments, e.Name)
+	}
+	if e.Spec.TargetNamespace == "" {
+		namespace := &core.Namespace{}
+		namespace.SetName(e.GetGeneratedTargetNamespace())
+		reqLogger.Info(fmt.Sprintf("Removing auto-generated namespace for %s", e.Name))
+		r.Recorder.Eventf(e, "Warning", "NamespaceDeletion", "Clowder Environment [%s] had no targetNamespace, deleting generated namespace", e.Name)
+		r.Delete(context.TODO(), namespace)
 	}
 	managedEnvsMetric.Set(float64(len(managedEnvironments)))
 	reqLogger.Info("Successfully finalized ClowdEnvironment")

--- a/controllers/cloud.redhat.com/utils/utils.go
+++ b/controllers/cloud.redhat.com/utils/utils.go
@@ -193,7 +193,7 @@ func MakeLabeler(nn types.NamespacedName, labels map[string]string, obj obj.Clow
 	}
 }
 
-func getCustomLabeler(labels map[string]string, nn types.NamespacedName, baseResource obj.ClowdObject) func(metav1.Object) {
+func GetCustomLabeler(labels map[string]string, nn types.NamespacedName, baseResource obj.ClowdObject) func(metav1.Object) {
 	appliedLabels := baseResource.GetLabels()
 	if labels != nil {
 		for k, v := range labels {
@@ -204,14 +204,14 @@ func getCustomLabeler(labels map[string]string, nn types.NamespacedName, baseRes
 }
 
 func MakeService(service *core.Service, nn types.NamespacedName, labels map[string]string, ports []core.ServicePort, baseResource obj.ClowdObject) {
-	labeler := getCustomLabeler(labels, nn, baseResource)
+	labeler := GetCustomLabeler(labels, nn, baseResource)
 	labeler(service)
 	service.Spec.Selector = labels
 	service.Spec.Ports = ports
 }
 
 func MakePVC(pvc *core.PersistentVolumeClaim, nn types.NamespacedName, labels map[string]string, size string, baseResource obj.ClowdObject) {
-	labeler := getCustomLabeler(labels, nn, baseResource)
+	labeler := GetCustomLabeler(labels, nn, baseResource)
 	labeler(pvc)
 	pvc.Spec.AccessModes = []core.PersistentVolumeAccessMode{core.ReadWriteOnce}
 	pvc.Spec.Resources = core.ResourceRequirements{

--- a/controllers/cloud.redhat.com/utils/utils_test.go
+++ b/controllers/cloud.redhat.com/utils/utils_test.go
@@ -1,4 +1,4 @@
-package utils
+package utils_test
 
 import (
 	"testing"
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
+	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/utils"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -20,19 +21,19 @@ func TestKafkaReconcilerFns(t *testing.T) {
 
 func TestConverterFuncs(t *testing.T) {
 	t.Run("Test intMin", func(t *testing.T) {
-		answer, _ := IntMin([]string{"4", "6", "7"})
+		answer, _ := utils.IntMin([]string{"4", "6", "7"})
 		if answer != "4" {
 			t.Errorf("Min function should have returned 4, returned %s", answer)
 		}
 	})
 	t.Run("Test intMax", func(t *testing.T) {
-		answer, _ := IntMax([]string{"4", "6", "7"})
+		answer, _ := utils.IntMax([]string{"4", "6", "7"})
 		if answer != "7" {
 			t.Errorf("Min function should have returned 7, returned %s", answer)
 		}
 	})
 	t.Run("Test ListMerge", func(t *testing.T) {
-		answer, _ := ListMerge([]string{"4,5,6", "6", "7,2"})
+		answer, _ := utils.ListMerge([]string{"4,5,6", "6", "7,2"})
 		if answer != "2,4,5,6,7" {
 			t.Errorf("Min function should have returned 2,4,5,6,7 returned %s", answer)
 		}
@@ -76,7 +77,7 @@ func TestMakeService(t *testing.T) {
 			EnvName: "testing-env",
 		},
 	}
-	MakeService(&svc, nn, labels, ports, baseResource)
+	utils.MakeService(&svc, nn, labels, ports, baseResource)
 	assert.Equal(t, svc.Labels["app"], baseResource.Name, "should have app label")
 	assert.Equal(t, svc.Labels["customLabel"], "5", "should have custom label")
 	assert.Equal(t, svc.Spec.Ports[0], ports[0], "ports should be equal")
@@ -110,7 +111,7 @@ func TestMakePVC(t *testing.T) {
 	}
 	size := resource.MustParse("1Gi")
 
-	MakePVC(&pvc, nn, labels, "1Gi", baseResource)
+	utils.MakePVC(&pvc, nn, labels, "1Gi", baseResource)
 	assert.Equal(t, pvc.Labels["app"], baseResource.Name, "should have app label")
 	assert.Equal(t, pvc.Labels["customLabel"], "5", "should have custom label")
 	assert.Equal(t, pvc.Spec.Resources.Requests["storage"], size, "should have size set correctly")
@@ -143,7 +144,7 @@ func TestGetCustomLabeler(t *testing.T) {
 		},
 	}
 
-	labeler := getCustomLabeler(labels, nn, baseResource)
+	labeler := utils.GetCustomLabeler(labels, nn, baseResource)
 
 	pvc := &core.PersistentVolumeClaim{}
 
@@ -159,12 +160,12 @@ func TestBase64Decode(t *testing.T) {
 			"key": []byte("bnVtYmVy"),
 		},
 	}
-	decodedValue, _ := B64Decode(&s, "key")
+	decodedValue, _ := utils.B64Decode(&s, "key")
 	assert.Equal(t, decodedValue, "number", "should decode the right value")
 }
 
 func TestRandString(t *testing.T) {
-	a := RandString(12)
-	b := RandString(12)
+	a := utils.RandString(12)
+	b := utils.RandString(12)
 	assert.NotEqual(t, a, b)
 }


### PR DESCRIPTION
* Used to rely on the targetNamespace field being set but now it's
  optional.
* The targetNamespace is set to cloudenv-[ClowdEnvironment.Name] which
  should be safe to be unique because the ClowdEnvironment name
  is unique in a single cluster anyway
* ObjectStore in the status was not being used as status seems to be
  invalid for cluster scoped resources