### PR TITLE
Fix pod service sharing incorrectly

### DIFF
--- a/controllers/cloud.redhat.com/providers/database/localdb.go
+++ b/controllers/cloud.redhat.com/providers/database/localdb.go
@@ -193,9 +193,9 @@ func makeLocalService(s *core.Service, nn types.NamespacedName, app *crd.ClowdAp
 		Port:     5432,
 		Protocol: "TCP",
 	}}
-	utils.MakeService(s, nn, p.Labels{"service": "db"}, servicePorts, app)
+	utils.MakeService(s, nn, p.Labels{"service": "db", "app": app.Name}, servicePorts, app)
 }
 
 func makeLocalPVC(pvc *core.PersistentVolumeClaim, nn types.NamespacedName, app *crd.ClowdApp) {
-	utils.MakePVC(pvc, nn, p.Labels{"service": "db"}, "1Gi", app)
+	utils.MakePVC(pvc, nn, p.Labels{"service": "db", "app": app.Name}, "1Gi", app)
 }

--- a/controllers/cloud.redhat.com/providers/database/localdb_test.go
+++ b/controllers/cloud.redhat.com/providers/database/localdb_test.go
@@ -92,6 +92,9 @@ func TestLocalDBService(t *testing.T) {
 	if s.Spec.Selector["service"] != "db" {
 		t.Fatal("db selector was not set")
 	}
+	if s.Spec.Selector["app"] != app.Name {
+		t.Fatal("db app name selector was not set")
+	}
 }
 
 func TestLocalDBDeployment(t *testing.T) {


### PR DESCRIPTION
* The label selector for the local database pod was too generic, as a
  result, if multiple databases were running in the same namespace
  the service would erroneously link to either one
  in a load balaned type effect, making connections sporadically fail.