### PR TITLE
Start of refactor

### DIFF
--- a/controllers/cloud.redhat.com/clowdapp_controller.go
+++ b/controllers/cloud.redhat.com/clowdapp_controller.go
@@ -35,6 +35,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	// Import the providers to initialize them
+	_ "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers/database"
+	_ "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers/inmemorydb"
+	_ "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers/kafka"
+	_ "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers/logging"
+	_ "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers/objectstore"
+
 	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/errors"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/makers"

--- a/controllers/cloud.redhat.com/providers/database/localdb.go
+++ b/controllers/cloud.redhat.com/providers/database/localdb.go
@@ -6,6 +6,7 @@ import (
 	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/config"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/errors"
+	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/utils"
 
 	p "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
@@ -20,17 +21,13 @@ type localDbProvider struct {
 	Config config.DatabaseConfig
 }
 
-func (db *localDbProvider) Configure(c *config.AppConfig) {
-	c.Database = &db.Config
-}
-
-func NewLocalDBProvider(p *p.Provider) (DatabaseProvider, error) {
+func NewLocalDBProvider(p *p.Provider) (providers.ClowderProvider, error) {
 	return &localDbProvider{Provider: *p}, nil
 }
 
 // CreateDatabase ensures a database is created for the given app.  The
 // namespaced name passed in must be the actual name of the db resources
-func (db *localDbProvider) CreateDatabase(app *crd.ClowdApp) error {
+func (db *localDbProvider) Provide(app *crd.ClowdApp, c *config.AppConfig) error {
 	nn := types.NamespacedName{
 		Name:      fmt.Sprintf("%v-db", app.Name),
 		Namespace: app.Namespace,
@@ -115,6 +112,7 @@ func (db *localDbProvider) CreateDatabase(app *crd.ClowdApp) error {
 			return err
 		}
 	}
+	c.Database = &db.Config
 	return nil
 }
 

--- a/controllers/cloud.redhat.com/providers/database/provider.go
+++ b/controllers/cloud.redhat.com/providers/database/provider.go
@@ -3,20 +3,11 @@ package database
 import (
 	"fmt"
 
-	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
-	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/config"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/errors"
-	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 	p "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 )
 
-// DatabaseProvider is the interface for apps to use to configure databases
-type DatabaseProvider interface {
-	p.Configurable
-	CreateDatabase(app *crd.ClowdApp) error
-}
-
-func GetDatabase(c *p.Provider) (DatabaseProvider, error) {
+func GetDatabase(c *p.Provider) (p.ClowderProvider, error) {
 	dbMode := c.Env.Spec.Providers.Database.Mode
 	switch dbMode {
 	case "local":
@@ -29,31 +20,6 @@ func GetDatabase(c *p.Provider) (DatabaseProvider, error) {
 	}
 }
 
-func RunAppProvider(provider providers.Provider, c *config.AppConfig, app *crd.ClowdApp) error {
-	dbSpec := app.Spec.Database
-
-	if dbSpec.Name != "" {
-		databaseProvider, err := GetDatabase(&provider)
-
-		if err != nil {
-			return errors.Wrap("Failed to init db provider", err)
-		}
-
-		err = databaseProvider.CreateDatabase(app)
-		if err != nil {
-			return err
-		}
-		databaseProvider.Configure(c)
-	}
-	return nil
-}
-
-func RunEnvProvider(provider providers.Provider) error {
-	_, err := GetDatabase(&provider)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+func init() {
+	p.ProvidersRegistration.Register(GetDatabase, 1, "database", false)
 }

--- a/controllers/cloud.redhat.com/providers/inmemorydb/provider.go
+++ b/controllers/cloud.redhat.com/providers/inmemorydb/provider.go
@@ -3,20 +3,11 @@ package inmemorydb
 import (
 	"fmt"
 
-	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
-	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/config"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/errors"
 	p "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 )
 
-// InMemoryDBProvider is the interface for apps to use to configure in-memory
-// databases
-type InMemoryDBProvider interface {
-	p.Configurable
-	CreateInMemoryDB(app *crd.ClowdApp) error
-}
-
-func GetInMemoryDB(c *p.Provider) (InMemoryDBProvider, error) {
+func GetInMemoryDB(c *p.Provider) (p.ClowderProvider, error) {
 	dbMode := c.Env.Spec.Providers.InMemoryDB.Mode
 	switch dbMode {
 	case "redis":
@@ -27,29 +18,6 @@ func GetInMemoryDB(c *p.Provider) (InMemoryDBProvider, error) {
 	}
 }
 
-func RunAppProvider(provider p.Provider, c *config.AppConfig, app *crd.ClowdApp) error {
-	if app.Spec.InMemoryDB {
-		inMemoryDbProvider, err := GetInMemoryDB(&provider)
-
-		if err != nil {
-			return errors.Wrap("Failed to init in-memory db provider", err)
-		}
-
-		err = inMemoryDbProvider.CreateInMemoryDB(app)
-		if err != nil {
-			return errors.Wrap("Failed to create in-memory db", err)
-		}
-		inMemoryDbProvider.Configure(c)
-	}
-	return nil
-}
-
-func RunEnvProvider(provider p.Provider) error {
-	_, err := GetInMemoryDB(&provider)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+func init() {
+	p.ProvidersRegistration.Register(GetInMemoryDB, 1, "inmemorydb", false)
 }

--- a/controllers/cloud.redhat.com/providers/inmemorydb/redis.go
+++ b/controllers/cloud.redhat.com/providers/inmemorydb/redis.go
@@ -19,11 +19,7 @@ type localRedis struct {
 	Config config.InMemoryDBConfig
 }
 
-func (r *localRedis) Configure(config *config.AppConfig) {
-	config.InMemoryDb = &r.Config
-}
-
-func (r *localRedis) CreateInMemoryDB(app *crd.ClowdApp) error {
+func (r *localRedis) Provide(app *crd.ClowdApp, config *config.AppConfig) error {
 	r.Config.Hostname = fmt.Sprintf("%v-redis.%v.svc", app.Name, app.Namespace)
 	r.Config.Port = 6379
 
@@ -48,10 +44,12 @@ func (r *localRedis) CreateInMemoryDB(app *crd.ClowdApp) error {
 		return err
 	}
 
+	config.InMemoryDb = &r.Config
+
 	return providers.MakeComponent(r.Ctx, r.Client, app, "redis", makeLocalRedis, r.Provider.Env.Spec.Providers.InMemoryDB.PVC)
 }
 
-func NewLocalRedis(p *providers.Provider) (InMemoryDBProvider, error) {
+func NewLocalRedis(p *providers.Provider) (providers.ClowderProvider, error) {
 	config := config.InMemoryDBConfig{}
 
 	redisProvider := localRedis{Provider: *p, Config: config}

--- a/controllers/cloud.redhat.com/providers/kafka/appinterface_test.go
+++ b/controllers/cloud.redhat.com/providers/kafka/appinterface_test.go
@@ -38,10 +38,9 @@ func TestAppInterface(t *testing.T) {
 		t.Error(err)
 	}
 
-	ai.CreateTopics(app)
-
 	c := config.AppConfig{}
-	ai.Configure(&c)
+
+	ai.Provide(app, &c)
 
 	if len(c.Kafka.Brokers) != 1 {
 		t.Errorf("Wrong number of brokers %v; expected 1", len(c.Kafka.Brokers))

--- a/controllers/cloud.redhat.com/providers/kafka/localkafka.go
+++ b/controllers/cloud.redhat.com/providers/kafka/localkafka.go
@@ -27,11 +27,7 @@ type localKafka struct {
 	Config config.KafkaConfig
 }
 
-func (k *localKafka) Configure(config *config.AppConfig) {
-	config.Kafka = &k.Config
-}
-
-func (k *localKafka) CreateTopics(app *crd.ClowdApp) error {
+func (k *localKafka) Provide(app *crd.ClowdApp, c *config.AppConfig) error {
 	host := fmt.Sprintf("%s:29092", k.Config.Brokers[0].Hostname)
 
 	for _, topic := range app.Spec.KafkaTopics {
@@ -53,10 +49,12 @@ func (k *localKafka) CreateTopics(app *crd.ClowdApp) error {
 		}
 		defer conn.Close()
 	}
+
+	c.Kafka = &k.Config
 	return nil
 }
 
-func NewLocalKafka(p *p.Provider) (KafkaProvider, error) {
+func NewLocalKafka(p *p.Provider) (providers.ClowderProvider, error) {
 	config := config.KafkaConfig{
 		Topics: []config.TopicConfig{},
 		Brokers: []config.BrokerConfig{{

--- a/controllers/cloud.redhat.com/providers/kafka/provider.go
+++ b/controllers/cloud.redhat.com/providers/kafka/provider.go
@@ -3,19 +3,11 @@ package kafka
 import (
 	"fmt"
 
-	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
-	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/config"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/errors"
 	p "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 )
 
-// KafkaProvider is the interface for apps to use to configure kafka topics
-type KafkaProvider interface {
-	p.Configurable
-	CreateTopics(app *crd.ClowdApp) error
-}
-
-func GetKafka(c *p.Provider) (KafkaProvider, error) {
+func GetKafka(c *p.Provider) (p.ClowderProvider, error) {
 	kafkaMode := c.Env.Spec.Providers.Kafka.Mode
 	switch kafkaMode {
 	case "operator":
@@ -30,38 +22,10 @@ func GetKafka(c *p.Provider) (KafkaProvider, error) {
 	}
 }
 
-func RunAppProvider(provider p.Provider, c *config.AppConfig, app *crd.ClowdApp) error {
-	if len(app.Spec.KafkaTopics) != 0 {
-
-		kafkaProvider, err := GetKafka(&provider)
-
-		if err != nil {
-			return errors.Wrap("Failed to init kafka provider", err)
-		}
-
-		err = kafkaProvider.CreateTopics(app)
-
-		if err != nil {
-			retErr := errors.Wrap("Failed to init kafka topic", err)
-			retErr.Requeue = true
-			return retErr
-		}
-
-		kafkaProvider.Configure(c)
-	}
-	return nil
-}
-
-func RunEnvProvider(provider p.Provider) error {
-	_, err := GetKafka(&provider)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func intPtr(i int) *int {
 	return &i
+}
+
+func init() {
+	p.ProvidersRegistration.Register(GetKafka, 1, "kafka", true)
 }

--- a/controllers/cloud.redhat.com/providers/logging/appinterface.go
+++ b/controllers/cloud.redhat.com/providers/logging/appinterface.go
@@ -4,6 +4,7 @@ import (
 	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/config"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/errors"
+	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 	p "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -14,19 +15,15 @@ type AppInterfaceLoggingProvider struct {
 	Config config.LoggingConfig
 }
 
-func (a *AppInterfaceLoggingProvider) Configure(c *config.AppConfig) {
-	c.Logging = a.Config
-}
-
-func NewAppInterfaceLogging(p *p.Provider) (LoggingProvider, error) {
+func NewAppInterfaceLogging(p *p.Provider) (providers.ClowderProvider, error) {
 	provider := AppInterfaceLoggingProvider{Provider: *p}
 
 	return &provider, nil
 }
 
-func (a *AppInterfaceLoggingProvider) SetUpLogging(app *crd.ClowdApp) error {
-	a.Config = config.LoggingConfig{}
-	return setCloudwatchSecret(app.Namespace, &a.Provider, &a.Config)
+func (a *AppInterfaceLoggingProvider) Provide(app *crd.ClowdApp, c *config.AppConfig) error {
+	c.Logging = config.LoggingConfig{}
+	return setCloudwatchSecret(app.Namespace, &a.Provider, &c.Logging)
 }
 
 func setCloudwatchSecret(ns string, p *p.Provider, c *config.LoggingConfig) error {

--- a/controllers/cloud.redhat.com/providers/logging/null.go
+++ b/controllers/cloud.redhat.com/providers/logging/null.go
@@ -3,6 +3,7 @@ package logging
 import (
 	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/config"
+	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 	p "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 )
 
@@ -11,18 +12,14 @@ type NullLoggingProvider struct {
 	Config config.LoggingConfig
 }
 
-func (a *NullLoggingProvider) Configure(c *config.AppConfig) {
-	c.Logging = a.Config
-}
-
-func NewNullLogging(p *p.Provider) (LoggingProvider, error) {
+func NewNullLogging(p *p.Provider) (providers.ClowderProvider, error) {
 	provider := NullLoggingProvider{Provider: *p}
 
 	return &provider, nil
 }
 
-func (a *NullLoggingProvider) SetUpLogging(app *crd.ClowdApp) error {
-	a.Config = config.LoggingConfig{
+func (a *NullLoggingProvider) Provide(app *crd.ClowdApp, c *config.AppConfig) error {
+	c.Logging = config.LoggingConfig{
 		Cloudwatch: &config.CloudWatchConfig{
 			AccessKeyId:     "",
 			SecretAccessKey: "",

--- a/controllers/cloud.redhat.com/providers/logging/provider.go
+++ b/controllers/cloud.redhat.com/providers/logging/provider.go
@@ -3,22 +3,11 @@ package logging
 import (
 	"fmt"
 
-	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
-	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/config"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/errors"
-	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 	p "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 )
 
-// LoggingProvider is the interface for apps to use to configure logging.  This
-// may not be needed on a per-app basis; logging is often only configured on a
-// per-environment basis.
-type LoggingProvider interface {
-	providers.Configurable
-	SetUpLogging(app *crd.ClowdApp) error
-}
-
-func GetLogging(c *p.Provider) (LoggingProvider, error) {
+func GetLogging(c *p.Provider) (p.ClowderProvider, error) {
 	logMode := c.Env.Spec.Providers.Logging.Mode
 	switch logMode {
 	case "app-interface":
@@ -31,31 +20,6 @@ func GetLogging(c *p.Provider) (LoggingProvider, error) {
 	}
 }
 
-func RunAppProvider(provider providers.Provider, c *config.AppConfig, app *crd.ClowdApp) error {
-	loggingProvider, err := GetLogging(&provider)
-
-	if err != nil {
-		return errors.Wrap("Failed to init logging provider", err)
-	}
-
-	if loggingProvider != nil {
-		err = loggingProvider.SetUpLogging(app)
-
-		if err != nil {
-			return errors.Wrap("Failed to set up logging", err)
-		}
-
-		loggingProvider.Configure(c)
-	}
-	return nil
-}
-
-func RunEnvProvider(provider providers.Provider) error {
-	_, err := GetLogging(&provider)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
+func init() {
+	p.ProvidersRegistration.Register(GetLogging, 1, "logging", false)
 }

--- a/controllers/cloud.redhat.com/providers/objectstore/appinterface.go
+++ b/controllers/cloud.redhat.com/providers/objectstore/appinterface.go
@@ -7,6 +7,7 @@ import (
 	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/config"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/errors"
+	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 	p "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 	core "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,17 +18,13 @@ type AppInterfaceObjectstoreProvider struct {
 	Config config.ObjectStoreConfig
 }
 
-func (a *AppInterfaceObjectstoreProvider) Configure(c *config.AppConfig) {
-	c.ObjectStore = &a.Config
-}
-
-func NewAppInterfaceObjectstore(p *p.Provider) (ObjectStoreProvider, error) {
+func NewAppInterfaceObjectstore(p *p.Provider) (providers.ClowderProvider, error) {
 	provider := AppInterfaceObjectstoreProvider{Provider: *p}
 
 	return &provider, nil
 }
 
-func (a *AppInterfaceObjectstoreProvider) CreateBuckets(app *crd.ClowdApp) error {
+func (a *AppInterfaceObjectstoreProvider) Provide(app *crd.ClowdApp, c *config.AppConfig) error {
 	if len(app.Spec.ObjectStore) == 0 {
 		return nil
 	}
@@ -52,7 +49,7 @@ func (a *AppInterfaceObjectstoreProvider) CreateBuckets(app *crd.ClowdApp) error
 		return err
 	}
 
-	a.Config = *objStoreConfig
+	c.ObjectStore = objStoreConfig
 	return nil
 }
 

--- a/controllers/cloud.redhat.com/providers/objectstore/minio.go
+++ b/controllers/cloud.redhat.com/providers/objectstore/minio.go
@@ -75,19 +75,8 @@ type minioProvider struct {
 	BucketHandler bucketHandler
 }
 
-func (m *minioProvider) Configure(c *config.AppConfig) {
-	c.ObjectStore = &config.ObjectStoreConfig{
-		Hostname:  m.Config.Hostname,
-		Port:      m.Config.Port,
-		AccessKey: m.Config.AccessKey,
-		SecretKey: m.Config.SecretKey,
-		Buckets:   m.Config.Buckets,
-		Tls:       false,
-	}
-}
-
-// CreateBuckets creates new buckets
-func (m *minioProvider) CreateBuckets(app *crd.ClowdApp) error {
+// Provide creates new buckets
+func (m *minioProvider) Provide(app *crd.ClowdApp, c *config.AppConfig) error {
 	for _, bucket := range app.Spec.ObjectStore {
 		found, err := m.BucketHandler.Exists(m.Ctx, bucket)
 
@@ -110,7 +99,14 @@ func (m *minioProvider) CreateBuckets(app *crd.ClowdApp) error {
 			SecretKey:     m.Config.SecretKey,
 		})
 	}
-
+	c.ObjectStore = &config.ObjectStoreConfig{
+		Hostname:  m.Config.Hostname,
+		Port:      m.Config.Port,
+		AccessKey: m.Config.AccessKey,
+		SecretKey: m.Config.SecretKey,
+		Buckets:   m.Config.Buckets,
+		Tls:       false,
+	}
 	return nil
 }
 
@@ -150,7 +146,7 @@ func createDefaultMinioSecMap(name string, namespace string) map[string]string {
 }
 
 // NewMinIO constructs a new minio for the given config
-func NewMinIO(p *p.Provider) (ObjectStoreProvider, error) {
+func NewMinIO(p *p.Provider) (providers.ClowderProvider, error) {
 	nn := providers.GetNamespacedName(p.Env, "minio")
 
 	dataInit := func() map[string]string {

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,7 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -326,6 +327,7 @@ github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738 h1:VcrIfasaLFkyjk6KNlXQSzO+B0fZcnECiDrKJsfxka0=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.1.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=


### PR DESCRIPTION
Refactor for dynamic-ish providers

* Created a providersRegistration type to deal with the registration and
  ordering of provider resolution, paving the way for resources passing
  between providers.
* Instantiated a singleton called ProvidersRegistration which is called from
  each provider to register its SetupProvider function.
* Controllers now loop through the registered functions in order to create
  resources.
* The Create* functions inside each provider modules have been renamed to
  Provide.
* The Configure function inside each of the provider modules has been removed
  and the configuration step performed as part of the Provide function for each
  provider.
* Individual provider types have been removed as the interface has now been
  standardized and has been replaced with a new type called ClowderProvider.
* The RunAppProvider and RunEnvProvider functions inside each provider module
  have been removed as they are now superfluous.
* The collapsing into a single interface for the providers allowed a singular
  way of invoking the providers action. This further allowed a looping mechanism
  to invoke each provider in order, which is defined by an integer in the
  registration call.