### PR TITLE
Apps only reconcile when env is ready

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
@@ -251,6 +251,7 @@ type ClowdEnvironmentStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 	TargetNamespace string                  `json:"targetNamespace"`
+	Ready           bool                    `json:"ready"`
 	Deployments     common.DeploymentStatus `json:"deployments"`
 	Apps            []AppInfo               `json:"apps,omitempty"`
 }

--- a/bundle/tests/scorecard/kuttl/test-multiple-app-endpoints/01-pods.yaml
+++ b/bundle/tests/scorecard/kuttl/test-multiple-app-endpoints/01-pods.yaml
@@ -51,17 +51,16 @@ spec:
     kafka:
       namespace: kafka
       clusterName: my-cluster
-      mode: local
+      mode: none
     db:
       image: "registry.redhat.io/rhel8/postgresql-12:1-36"
-      mode: local
+      mode: none
     logging:
       mode: none
     objectStore:
-      mode: minio
-      #Possibly need to specify a port here
+      mode: none
     inMemoryDb:
-      mode: redis
+      mode: none
   resourceDefaults:
     limits:
       cpu: 400m

--- a/bundle/tests/scorecard/kuttl/test-multiple-app-endpoints/02-json-asserts.yaml
+++ b/bundle/tests/scorecard/kuttl/test-multiple-app-endpoints/02-json-asserts.yaml
@@ -2,7 +2,7 @@
 apiVersion: kudo.dev/v1alpha1
 kind: TestStep
 commands:
-- script: sleep 10
+- script: sleep 20
 - script: kubectl get secret puptoo -o json -n test-multiple-app-endpoints > /tmp/test-multiple-app-endpoints
 - script: jq -r '.data["cdappconfig.json"]' < /tmp/test-multiple-app-endpoints | base64 -d > /tmp/test-multiple-app-endpoints-json
 

--- a/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
@@ -328,6 +328,8 @@ spec:
               - managedDeployments
               - readyDeployments
               type: object
+            ready:
+              type: boolean
             targetNamespace:
               description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
                 of cluster Important: Run "make" to regenerate code after modifying
@@ -335,6 +337,7 @@ spec:
               type: string
           required:
           - deployments
+          - ready
           - targetNamespace
           type: object
       type: object

--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -164,6 +164,12 @@ func (r *ClowdEnvironmentReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 		return ctrl.Result{Requeue: true}, err
 	}
 	SetDeploymentStatus(ctx, &proxyClient, &env)
+
+	env.Status.Ready = false
+	if env.Status.Deployments.ManagedDeployments == env.Status.Deployments.ReadyDeployments {
+		env.Status.Ready = true
+	}
+
 	err = proxyClient.Status().Update(ctx, &env)
 
 	if err != nil {

--- a/controllers/cloud.redhat.com/proxy_client.go
+++ b/controllers/cloud.redhat.com/proxy_client.go
@@ -52,6 +52,7 @@ func (p *ProxyClient) AddResource(obj runtime.Object) {
 	}
 
 	var name string
+	var namespace string
 	var rKind string
 
 	switch kind {
@@ -59,26 +60,32 @@ func (p *ProxyClient) AddResource(obj runtime.Object) {
 		rKind = "ConfigMap"
 		dobj := obj.(*core.ConfigMap)
 		name = dobj.Name
+		namespace = dobj.Namespace
 	case "Deployment", "*v1.Deployment":
 		rKind = "Deployment"
 		dobj := obj.(*apps.Deployment)
 		name = dobj.Name
+		namespace = dobj.Namespace
 	case "Service", "*v1.Service":
 		rKind = "Service"
 		dobj := obj.(*core.Service)
 		name = dobj.Name
+		namespace = dobj.Namespace
 	case "PersistentVolumeClaim", "*v1.PersistentVolumeClaim":
 		rKind = "PersistentVolumeClaim"
 		dobj := obj.(*core.PersistentVolumeClaim)
 		name = dobj.Name
+		namespace = dobj.Namespace
 	case "Secret", "*v1.Secret":
 		rKind = "Secret"
 		dobj := obj.(*core.Secret)
 		name = dobj.Name
+		namespace = dobj.Namespace
 	case "CronJob", "*v1beta1.CronJob":
 		rKind = "CronJob"
 		dobj := obj.(*batch.CronJob)
 		name = dobj.Name
+		namespace = dobj.Namespace
 	default:
 		return
 	}
@@ -87,7 +94,7 @@ func (p *ProxyClient) AddResource(obj runtime.Object) {
 		p.ResourceTracker[rKind] = map[string]bool{}
 	}
 
-	log.Info("Tracking resource", "kind", rKind, "name", name)
+	log.Info("Tracking resource", "kind", rKind, "namespace", namespace, "name", name)
 	p.ResourceTracker[rKind][name] = true
 }
 

--- a/controllers/cloud.redhat.com/utils/utils.go
+++ b/controllers/cloud.redhat.com/utils/utils.go
@@ -54,7 +54,7 @@ func (u *Updater) Apply(ctx context.Context, cl client.Client, obj runtime.Objec
 	meta := obj.(metav1.Object)
 
 	if *u {
-		Log.Info("Updating resource", "kind", kind, "object_name", meta.GetName())
+		Log.Info("Updating resource", "namespace", meta.GetNamespace(), "name", meta.GetName(), "kind", kind)
 		err = cl.Update(ctx, obj)
 	} else {
 		if meta.GetName() == "" {
@@ -62,7 +62,7 @@ func (u *Updater) Apply(ctx context.Context, cl client.Client, obj runtime.Objec
 			return nil
 		}
 
-		Log.Info("Creating resource", "kind", kind, "object_name", meta.GetName())
+		Log.Info("Creating resource", "namespace", meta.GetNamespace(), "name", meta.GetName(), "kind", kind)
 		err = cl.Create(ctx, obj)
 	}
 


### PR DESCRIPTION
* Previously an app would try to reconcile when an env was not ready
* As apps and envs can be deployed together, there would be a protracted
  period of time where an app would continually requeue its requests.
  This made the start up time far longer than it should since the backoff
  time would have already progresed to minutes by the time the env was
  finally ready.
* This PR introduces a new Status.Ready flag which is set inside the env
  reconciler. Currently this is set if the ready deployments match
  the number of managed deployments.
* The app reconciler has been modified to requeue in the event that
  an env is deemed not ready.