### PR TITLE
Allow empty featureFlags mode in ClowdEnvironment

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
@@ -180,6 +180,7 @@ type ObjectStoreConfig struct {
 // FeatureFlagsMode details the mode of operation of the Clowder FeatureFlags
 // Provider
 // +kubebuilder:validation:Enum=local;app-interface;none
+// +kubebuilder:validation:Optional
 type FeatureFlagsMode string
 
 // FeatureFlagsConfig configures the Clowder provider controlling the creation of
@@ -189,7 +190,7 @@ type FeatureFlagsConfig struct {
 	// (*_app-interface_*) where the provider will pass through credentials
 	// to the app configuration, and (*_local_*) where a local Unleash instance will
 	// be created.
-	Mode FeatureFlagsMode `json:"mode"`
+	Mode FeatureFlagsMode `json:"mode,omitempty"`
 
 	// If using the (*_local_*) mode and PVC is set to true, this instructs the local
 	// Database instance to use a PVC instead of emptyDir for its volumes.

--- a/bundle/tests/scorecard/kuttl/test-basic-app/01-pods.yaml
+++ b/bundle/tests/scorecard/kuttl/test-basic-app/01-pods.yaml
@@ -26,8 +26,6 @@ spec:
       mode: none
     inMemoryDb:
       mode: none
-    featureFlags:
-      mode: none
   resourceDefaults:
     limits:
       cpu: 400m

--- a/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
@@ -119,8 +119,6 @@ spec:
                         true, this instructs the local Database instance to use a
                         PVC instead of emptyDir for its volumes.
                       type: boolean
-                  required:
-                  - mode
                   type: object
                 inMemoryDb:
                   description: Defines the Configuration for the Clowder InMemoryDB


### PR DESCRIPTION
We have some ClowdEnvironments without a featureFlags mode set that cannot be deleted, the finalizer hits this error:

```
Failed to update ClowdEnvironment with finalizer","env":"env-ephemeral-01","error":"ClowdEnvironment.cloud.redhat.com \"env-ephemeral-01\" is invalid: spec.providers.featureFlags.mode: Unsupported value: \"\": supported values: \"local\", \"app-interface\", \"none\""
```

Since we check for empty state on the feature flags mode [here](https://github.com/RedHatInsights/clowder/blob/master/controllers/cloud.redhat.com/providers/featureflags/provider.go#L19-L20) we should be ok to `omitempty` on it in the CR spec.