### PR TITLE
Add detailed dev environment setup steps to README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.redhat.io/ubi8/go-toolset:1.13.15 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.13.15 as builder
 
 USER 0
 WORKDIR /workspace

--- a/bundle/tests/scorecard/kuttl/test-kafka-strimzi/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-kafka-strimzi/01-assert.yaml
@@ -26,7 +26,6 @@ metadata:
     strimzi.io/cluster: my-cluster
   name: topicone-test-kafka-strimzi-test-kafka-strimzi
   namespace: test-kafka-strimzi-kafka
-  selfLink: /apis/kafka.strimzi.io/v1beta1/namespaces/test-kafka-strimzi-kafka/kafkatopics/topicone-test-kafka-strimzi-test-kafka-strimzi
 spec:
   partitions: 96
   replicas: 7
@@ -40,7 +39,6 @@ metadata:
     strimzi.io/cluster: my-cluster
   name: topictwo-test-kafka-strimzi-test-kafka-strimzi
   namespace: test-kafka-strimzi-kafka
-  selfLink: /apis/kafka.strimzi.io/v1beta1/namespaces/test-kafka-strimzi-kafka/kafkatopics/topictwo-test-kafka-strimzi-test-kafka-strimzi
 spec:
   partitions: 128
   replicas: 5
@@ -54,7 +52,6 @@ metadata:
     strimzi.io/cluster: my-cluster
   name: topicthree-test-kafka-strimzi-test-kafka-strimzi
   namespace: test-kafka-strimzi-kafka
-  selfLink: /apis/kafka.strimzi.io/v1beta1/namespaces/test-kafka-strimzi-kafka/kafkatopics/topicthree-test-kafka-strimzi-test-kafka-strimzi
 spec:
   partitions: 12
   replicas: 5

--- a/bundle/tests/scorecard/kuttl/test-minio-app/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-minio-app/01-assert.yaml
@@ -30,7 +30,6 @@ metadata:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdEnvironment
     name: test-minio-app
-  selfLink: /apis/apps/v1/namespaces/test-minio-app/deployments/test-minio-app-minio
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
@@ -118,7 +117,6 @@ metadata:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdEnvironment
     name: test-minio-app
-  selfLink: /api/v1/namespaces/test-minio-app/services/test-minio-app-minio
 spec:
   ports:
   - name: minio

--- a/e2e-test-local.sh
+++ b/e2e-test-local.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 kubectl apply -f skuttl-namespace.yaml
 kubectl apply -f skuttl-perms.yaml

--- a/e2e-test.sh
+++ b/e2e-test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 export IMAGE_TAG=`git rev-parse --short HEAD`
 


### PR DESCRIPTION
Also to make the build/testing process a little more efficient: use the unauthenticated RH registry in the Dockerfile, and use `set -e` in e2e-test shell scripts.

Also removed `selfLink` from minio/strimzi kuttl tests -- I don't think our test needs to care about the presence of this attribute -- on my local k8s v1.20.2 env the tests were failing with:
```
    case.go:233: resource KafkaTopic:test-kafka-strimzi-kafka/topicthree-test-kafka-strimzi-test-kafka-strimzi: .metadata.selfLink: key is missing from map
```