### PR TITLE
New local fast builder

### DIFF
--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -1,0 +1,8 @@
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY bin/manager-cgo ./manager
+USER nonroot:nonroot
+
+ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,11 @@ docker-build: test
 	$(RUNTIME) build . -t ${IMG}
 
 # Build the docker image
+docker-build-no-test-quick:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o bin/manager-cgo main.go
+	$(RUNTIME) build -f Dockerfile-local . -t ${IMG}
+
+# Build the docker image
 docker-build-no-test:
 	$(RUNTIME) build . -t ${IMG}
 
@@ -110,6 +115,8 @@ docker-push-minikube:
 	$(RUNTIME) push ${IMG} $(shell minikube ip):5000/clowder:$(shell git rev-parse --short=7 HEAD) --tls-verify=false
 
 deploy-minikube: bundle-verify docker-build-no-test docker-push-minikube deploy
+
+deploy-minikube-quick: bundle-verify docker-build-no-test-quick docker-push-minikube deploy
 
 
 # find or download controller-gen


### PR DESCRIPTION
The current build system takes around 1m37s to build the necessary image and deploy it into minikube, even using a local registry.
To speed up the process, instead of building inside a NEW container, which means obtaining all the dependencies all over again, it is quicker to build the binary locally, and just copy it into a bare container. This yields an **85%** reduction in build/deploy time for local testing. It now takes only 15s in a benchmark to build and deploy a new version of clowder locally to minikube.