### PR TITLE
Add "how to use" guide

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,12 +1,3 @@
-## CRD documentation
-
-- [ClowdApp](https://redhatinsights.github.io/clowder/api_reference.html#k8s-api-cloud-redhat-com-clowder-v2-apis-cloud-redhat-com-v1alpha1-clowdapp)
-- [ClowdEnvironment](https://redhatinsights.github.io/clowder/api_reference.html#k8s-api-cloud-redhat-com-clowder-v2-apis-cloud-redhat-com-v1alpha1-clowdenvironment)
-
-## AppConfig documentation
-
-- [AppConfig](https://github.com/RedHatInsights/clowder/blob/master/docs/appconfig/schema.md)
-
 ## Design
 
 [Design docs](https://github.com/RedHatInsights/clowder/tree/master/docs/)

--- a/docs/examples/clowdapp.yml
+++ b/docs/examples/clowdapp.yml
@@ -1,0 +1,33 @@
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: hello
+  namespace: jumpstart
+spec:
+  # The name of the ClowdEnvironment providing the services
+  envName: env-jumpstart
+
+  # The bulk of your App. This is where your running apps will live
+  deployments:
+  - name: app
+    # Give details about your running pod
+    podSpec:
+      image: quay.io/psav/clowder-hello
+
+  # Request kafka topics for your application here
+  kafkaTopics:
+    - replicas: 3
+      partitions: 64
+      topicName: topicOne
+
+  # Creates a Service on port 8000
+  webServices:
+    public: true
+    private: false
+    metrics: true
+
+  # Creates a database if local mode, or uses RDS in production
+  database:
+    # Must specify both a name and a major postgres version
+    name: jumpstart-db
+    version: 12

--- a/docs/examples/clowdenv.yml
+++ b/docs/examples/clowdenv.yml
@@ -1,0 +1,55 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+# Custom Resource defined as part of the Clowder API
+kind: ClowdEnvironment
+metadata:
+  name: env-jumpstart
+spec:
+  targetNamespace: jumpstart
+
+  # Providers all your app to consume configuration 
+  # data automatically based on your request
+  providers:
+
+    # provides a k8s service on port 8000
+    web:
+      port: 8000
+      privatePort: 8080
+      mode: operator
+
+    # provides a prometheus metrics port on 9000
+    metrics:
+      port: 9000
+      mode: operator
+      path: "/metrics"
+
+    # Creates a kafka pod in the targetNamespace
+    kafka:
+      namespace: default
+      clusterName: crc-cluster
+      mode: local 
+
+    # Clowder supports postgres 10 and 12. Specify the name
+    # and other details in the clowdapp
+    db:
+      mode: local
+
+    logging:
+      mode: none
+
+    # Deploys a local minio pod for object storage
+    objectStore:
+      mode: minio
+      port: 9000
+
+    # Deploys a local redis pod
+    inMemoryDb:
+      mode: redis
+
+  resourceDefaults:
+    limits: 
+      cpu: "500m"
+      memory: "8192Mi"
+    requests:
+      cpu: "300m"
+      memory: "1024Mi"

--- a/docs/usage/app-workflow.rst
+++ b/docs/usage/app-workflow.rst
@@ -1,0 +1,128 @@
+ClowdApp Workflow
+=================
+
+Deploying a ClowdApp with new changes should be easy, repeatable, and timely. In order to make the
+Clowder experience smoother, there are a few tools to know and a suggested workflow to follow.
+
+In our general experience, you'll need to make edits to a Clowdapp and your source code as you work
+through your Clowder migration. The workflow will generally follow this pattern: 
+
+  1. Make a change in the source code or Clowdapp
+  2. Deploy the new changes locally
+  3. Observe the change 
+  4. Repeat
+
+1. Making local changes
+-----------------------
+Step 1 is pretty case by case basis. Maybe your config is reading the wrong variable. Perhaps your
+ClowdApp is missing a Kafka topic. Whatever your changes may be, update the code and go on to step 2. 
+
+
+2. Deploy locally with Bonfire
+------------------------------
+
+Bonfire [1]_ is a cli tool used to deploy apps with Clowder. Bonfire comes with a local config
+option that we'll use to drop our ClowdApp into our minikube cluster. 
+
+First, `install Bonfire`_ if you don't already have it on your local machine. 
+
+We'll use our examples from the `Getting Started`_ again. First, let's make a `config.yaml`. This
+file will be used to inform Bonfire about our ClowdApp. 
+
+  Update ``$(PWD)`` to the place where your app will be stored ``/home/src/app`` for example. 
+  Save as "config.yaml"
+
+.. code-block:: yaml
+
+  envName: env-jumpstart
+  apps:
+  - name: jumpstart
+    host: local
+    repo: $(PWD)
+    path: clowdapp.yml
+    parameters:
+      IMAGE: quay.io/psav/clowder-hello
+
+Our config.yaml defines an app name, a local host (this machine), a repo to read, and a path to a
+ClowdApp in that repo. Bonfire will use this information to deploy our ClowdApp into the namespace
+declared in our ClowdApp. 
+
+Let's refer back to our example app from earlier. Now, instead of using a base App, we will use a
+Template. 
+
+Note: if your previous ClowdApp is still running, use ``oc delete app jumpstart`` to remove it. 
+
+  Save as "clowdapp.yml"
+
+.. code-block:: yaml 
+
+  ---
+  apiVersion: v1
+  kind: Template
+  metadata:
+    name: jumpstart
+  objects:
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdApp
+    metadata:
+      name: hello
+      namespace: jumpstart
+    spec:
+
+      # The bulk of your App. This is where your running apps will live
+      deployments:
+      - name: app
+        # Creates services based on the ports set in ClowdEnv
+        webServices:
+          public: true
+          private: false
+          metrics: true
+        # Give details about your running pod
+        podSpec:
+          image: ${IMAGE}
+
+      # The name of the ClowdEnvironment providing the services
+      envName: env-jumpstart
+      
+      # Request kafka topics for your application here
+      kafkaTopics:
+        - replicas: 3
+          partitions: 64
+          topicName: topicOne
+
+      # Creates a database if local mode, or uses RDS in production
+      database:
+        # Must specify both a name and a major postgres version
+        name: jumpstart-db
+        version: 12
+
+  parameters:
+    IMAGE: ''
+
+
+``bonfire config get -l -a jumpstart | oc apply -f -``
+
+3. Observe the changes
+----------------------
+
+Run ``oc get app`` to verify the jumpstart app has been deployed.
+
+You can do all the standard ``oc logs`` debugging to figure out if your changes are successful.
+
+4. Repeat
+---------
+Repeat until you're happy with the results. When satisfied, checkout the migration guide [2]_ to start
+your app on the jouney to ephemeral and beyond.   
+
+
+Next Steps
+==========
+
+- `Migrating a service from v3 to Clowder`_
+
+.. _install Bonfire: https://github.com/RedHatInsights/bonfire#installation
+.. _Getting Started: https://github.com/RedHatInsights/clowder/blob/master/docs/usage/getting-started.rst
+.. _Migrating a service from v3 to Clowder: https://github.com/RedHatInsights/clowder/blob/master/docs/migration
+
+.. [1] https://internal.cloud.redhat.com/docs/devprod/ephemeral/ 
+.. [2] https://github.com/RedHatInsights/clowder/blob/master/docs/migration

--- a/docs/usage/getting-started.rst
+++ b/docs/usage/getting-started.rst
@@ -1,0 +1,103 @@
+Getting Started
+===============
+
+Install Clowder
+---------------
+
+As covered in the main README section [1]_ , the installation process for Clowder is a breeze. 
+
+Using the above method will install clowder locally through your minikube instance. It will also 
+create two new Custom Resource types that are easy to query. ``env`` for ClowdEnvs and ``app`` for ClowdApps
+
+If you would like to install Clowder manually and setup a contributing developer environment,
+`follow the developer guide`_. 
+
+
+Create your first ClowdEnvironment
+----------------------------------
+
+Let's make a namespace to hold all the resources we'll be creating 
+
+``kubectl create ns jumpstart``
+
+``oc project jumpstart``
+
+That's the example namespace we'll be using for the rest of the guide. 
+
+Now we can drop in our first resource, a ClowdEnvironment. A ClowdEnvironment, or ClowdEnv, is a
+CustomResource that defines the environment our ClowdApp will utilize. The ClowdEnv defines what
+types of services our app may require and what source is providing those services. For our purposes,
+these services are set to 'local' mode and will spin up pods in the ``jumpstart`` namespace. 
+
+The API docs for ClowdEnvironments can be found on redhatinsights.github.io [2]_
+
+A fully annotated ClowdEnv file can be found in the Clowder examples directory [3]_
+
+  Note: You will only create a ClowdEnvironment in your local minikube. Stage and Production will
+  have stable, shared ClowdEnvs. Your ClowdApp will use the provided Envs.
+
+``oc apply -f https://raw.githubusercontent.com/RedHatInsights/clowder/master/docs/examples/clowdenv.yml``
+
+Clowder will pickup and apply that env resource. You may notice there are no pods running -- and
+that's correct. Let's see what the ClowdEnv does. 
+
+``oc get env env-jumpstart -o yaml``
+
+As you can see in the output, we have providers [4]_ for the different services, but they won't
+do anything until a ClowdApp asks for them specifically. 
+
+Create your first ClowdApp
+---------------------------
+
+Now that we have a ClowdEnv up and running, let's use those providers and get some pods going. We
+can do that using a ClowdApp. You can think of a ClowdApp much like a Deployment resource, but more
+powerful. In your ClowdApp, you define everything your app needs to run. Database names, Object
+storage, environment variables, container images, and CronJobs; the whole party. We'll start small
+and use the example. 
+
+The API docs for ClowdApps can be found on redhatinsights.github.io [5]_
+
+A fully annotated ClowdApp file can be found in the Clowder examples directory [6]_
+
+``oc apply -f https://raw.githubusercontent.com/RedHatInsights/clowder/master/docs/examples/clowdapp.yml``
+
+Let's verify that ClowdApp was created 
+
+``oc get app`` 
+
+Now you should see pods!
+
+``oc get pods -w`` 
+
+Will show you several running pods. Some of them we defined in our ClowdApp, some we did not. Pods
+like Kafka are defined in the ClowdEnv, and spun up when requested by your app, then added to your
+namespace. As a note, your app will not come up until the all ClowdEnv
+supplied pods are marked as ready (1/1). 
+
+  Note: Your ClowdApp must specify services your app will need. Kafka will not spin up if it is
+  listed in your ClowdEnv, but missing in your ClowdApp  
+
+That's it! You have a running ClowdApp deployed with Clowder. In the next few documents, we'll cover
+creating a more powerful dev environment, building a more complex ClowdApp, and migrating existing
+services over to Clowder. 
+
+Next Steps
+==========
+
+- `Testing ClowdApp with Bonfire and Ephemeral Environments`_
+- `Migrating a service from v3 to Clowder`_
+
+
+.. _Bonfire: https://github.com/RedHatInsights/bonfire/
+   
+.. [1] https://github.com/RedHatInsights/clowder#getting-clowder
+.. [2] https://redhatinsights.github.io/clowder/api_reference.html#k8s-api-cloud-redhat-com-clowder-v2-apis-cloud-redhat-com-v1alpha1-clowdenvironment
+.. [3] https://github.com/RedHatInsights/clowder/blob/master/docs/examples/clowdenv.yml
+.. [4] https://github.com/RedHatInsights/clowder/blob/master/docs/providers.rst
+.. [5] https://redhatinsights.github.io/clowder/api_reference.html#k8s-api-cloud-redhat-com-clowder-v2-apis-cloud-redhat-com-v1alpha1-clowdapp
+.. [6] https://github.com/RedHatInsights/clowder/blob/master/docs/examples/clowdapp.yml
+
+.. _Testing ClowdApp with Bonfire and Ephemeral Environments: https://github.com/RedHatInsights/clowder/blob/master/docs/customizing-clowdapps.rst
+.. _Migrating a service from v3 to Clowder: https://github.com/RedHatInsights/clowder/blob/master/docs/migration
+.. _follow the developer guide: https://github.com/RedHatInsights/clowder/blob/master/docs/developer-guide.md
+


### PR DESCRIPTION
For [11580](https://issues.redhat.com/browse/RHCLOUD-11580)

I opted to make two new directories
```
--- docs
|----- examples
|----- usage
```
`usage` will be the dir where the how to use guide are stored. Right now it's a `getting started` page and an `app workflow` page. 

`examples` has a sample Env and App