### PR TITLE
Add appProtocol to service port definitions

### DIFF
--- a/bundle/tests/scorecard/kuttl/test-basic-app/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-basic-app/01-assert.yaml
@@ -52,3 +52,4 @@ spec:
   - port: 8000
     targetPort: 8000
     name: public
+    appProtocol: http

--- a/controllers/cloud.redhat.com/makers/maker.go
+++ b/controllers/cloud.redhat.com/makers/maker.go
@@ -116,13 +116,24 @@ func (m *Maker) makeService(deployment crd.Deployment, app *crd.ClowdApp) error 
 		{Name: "metrics", Port: m.Env.Spec.Providers.Metrics.Port, Protocol: "TCP"},
 	}
 
+	appProtocol := "http"
 	if bool(deployment.Web) || deployment.WebServices.Public.Enabled {
-		webPort := core.ServicePort{Name: "http-public", Port: m.Env.Spec.Providers.Web.Port, Protocol: "TCP"}
+		webPort := core.ServicePort{
+			Name:        "public",
+			Port:        m.Env.Spec.Providers.Web.Port,
+			Protocol:    "TCP",
+			AppProtocol: &appProtocol,
+		}
 		ports = append(ports, webPort)
 	}
 
 	if deployment.WebServices.Private.Enabled {
-		webPort := core.ServicePort{Name: "http-private", Port: m.Env.Spec.Providers.Web.PrivatePort, Protocol: "TCP"}
+		webPort := core.ServicePort{
+			Name:        "private",
+			Port:        m.Env.Spec.Providers.Web.PrivatePort,
+			Protocol:    "TCP",
+			AppProtocol: &appProtocol,
+		}
 		ports = append(ports, webPort)
 	}
 

--- a/controllers/cloud.redhat.com/makers/maker.go
+++ b/controllers/cloud.redhat.com/makers/maker.go
@@ -117,12 +117,12 @@ func (m *Maker) makeService(deployment crd.Deployment, app *crd.ClowdApp) error 
 	}
 
 	if bool(deployment.Web) || deployment.WebServices.Public.Enabled {
-		webPort := core.ServicePort{Name: "public", Port: m.Env.Spec.Providers.Web.Port, Protocol: "TCP"}
+		webPort := core.ServicePort{Name: "http-public", Port: m.Env.Spec.Providers.Web.Port, Protocol: "TCP"}
 		ports = append(ports, webPort)
 	}
 
 	if deployment.WebServices.Private.Enabled {
-		webPort := core.ServicePort{Name: "private", Port: m.Env.Spec.Providers.Web.PrivatePort, Protocol: "TCP"}
+		webPort := core.ServicePort{Name: "http-private", Port: m.Env.Spec.Providers.Web.PrivatePort, Protocol: "TCP"}
 		ports = append(ports, webPort)
 	}
 


### PR DESCRIPTION
kiali/istioctl can report traffic as http as long as a port is named
"http" or starts with "http-".