### PR TITLE
Add endpoints to standard app

### DIFF
--- a/bundle/tests/scorecard/kuttl/test-multiple-app-endpoints/02-json-asserts.yaml
+++ b/bundle/tests/scorecard/kuttl/test-multiple-app-endpoints/02-json-asserts.yaml
@@ -10,13 +10,15 @@ commands:
 - script: jq -r '.data["cdappconfig.json"]' < /tmp/test-multiple-app-endpoints-b | base64 -d > /tmp/test-multiple-app-endpoints-json-b
 
 # Positive searches
+- script: jq -r '.endpoints[] | select(.app == "puptoo") | .name == "processor"' -e < /tmp/test-multiple-app-endpoints-json
 - script: jq -r '.endpoints[] | select(.app == "puptoo-2") | .name == "processor-2"' -e < /tmp/test-multiple-app-endpoints-json
 
 # Negative searches
-- script: jq -r '.endpoints | length == 1' -e < /tmp/test-multiple-app-endpoints-json
+- script: jq -r '.endpoints | length == 2' -e < /tmp/test-multiple-app-endpoints-json
 
 # Positive searches
+- script: jq -r '.endpoints[] | select(.app == "puptoo-b") | .name == "processor-b"' -e < /tmp/test-multiple-app-endpoints-json-b
 - script: jq -r '.endpoints[] | select(.app == "puptoo-b-2") | .name == "processor-b-2"' -e < /tmp/test-multiple-app-endpoints-json-b
 
 # Negative searches
-- script: jq -r '.endpoints | length == 1' -e < /tmp/test-multiple-app-endpoints-json-b
+- script: jq -r '.endpoints | length == 2' -e < /tmp/test-multiple-app-endpoints-json-b

--- a/controllers/cloud.redhat.com/makers/maker.go
+++ b/controllers/cloud.redhat.com/makers/maker.go
@@ -39,12 +39,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-//DependencyMaker makes the DependencyConfig object
-type DependencyMaker struct {
-	*Maker
-	config []config.DependencyEndpoint
-}
-
 //Maker struct for passing variables into SubMakers
 type Maker struct {
 	App     *crd.ClowdApp
@@ -672,6 +666,15 @@ func makeDepConfig(
 
 	missingDeps = processAppEndpoints(appMap, app.Spec.Dependencies, &depConfig, &privDepConfig, webPort, privatePort)
 	_ = processAppEndpoints(appMap, app.Spec.OptionalDependencies, &depConfig, &privDepConfig, webPort, privatePort)
+
+	processAppEndpoints(
+		map[string]crd.ClowdApp{app.Name: *app},
+		[]string{app.Name},
+		&(depConfig),
+		&(privDepConfig),
+		webPort,
+		privatePort,
+	)
 
 	return depConfig, privDepConfig, missingDeps
 }


### PR DESCRIPTION
* App currently does not know about itself so if it has multiple
  deployments, then it has no way to discover these.
* At the end of the Make phase, we now add in the app endpoints
  for the app itself.