### PR TITLE
adds macos docs for minikube

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ initiated with the following options:
   minikube start --cpus 4 --disk-size 36GB --memory 8000MB --driver=kvm2
   ```
 
+Mac OS is also supported with the `virtualbox` and `hyperkit` drivers. A full
+guide [can be found here](docs/macos.md)
+
   To persist these changes for every minikube invocation, run the following:
   ```shell
   minikube config set cpus 4

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,0 +1,22 @@
+# Using Clowder on MacOS
+
+### Install Minikube
+
+`brew install minikube`
+
+If you do not use `brew`, you can follow [this guide](https://v1-18.docs.kubernetes.io/docs/tasks/tools/install-minikube/)
+
+
+### Install HyperKit or VirtualBox
+
+Virtualbox will work, but we recommend HyperKit. It is much faster and more 
+light weight than VirtualBox, but it will also work just fine. 
+
+`brew install hyperkit`
+
+
+### Running
+
+Minikube can now be run the same way as the rest of the documentation suggests. 
+Setting the config will also make the minikube experience less verbose.
+`minikube config set vm-driver hyperkit` or  `minikube config set vm-driver virtualbox`.

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -10,9 +10,13 @@ If you do not use `brew`, you can follow [this guide](https://v1-18.docs.kuberne
 ### Install HyperKit or VirtualBox
 
 Virtualbox will work, but we recommend HyperKit. It is much faster and more 
-light weight than VirtualBox, but it will also work just fine. 
+light weight than VirtualBox, but VirtualBox will also work just fine. 
 
 `brew install hyperkit`
+
+or 
+
+Install VirtualBox from [the VirtualBox site](https://www.virtualbox.org/wiki/Downloads)
 
 
 ### Running


### PR DESCRIPTION
I was able to get Clowder's getting started guide running on my 2015 Macbook last night. Documented the steps here.