### PR TITLE
Added trigger debug

### DIFF
--- a/bundle/olm-bundle.yml
+++ b/bundle/olm-bundle.yml
@@ -9,6 +9,14 @@ parameters:
   value: quay.io/cloudservices/clowder-index
 - name: TARGET_NAMESPACE
   value: clowder
+- name: DEBUG_TRIGGERS
+  value: "false"
+- name: DEBUG_CACHE_CREATE
+  value: "false"
+- name: DEBUG_CACHE_UPDATE
+  value: "false"
+- name: DEBUG_CACHE_APPLY
+  value: "false"
 objects:
 - apiVersion: operators.coreos.com/v1alpha1
   kind: CatalogSource
@@ -46,3 +54,21 @@ objects:
       control-plane: controller-manager
       operator-name: clowder
     type: ClusterIP
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: clowder-config
+  data:
+    test_config.json: |
+      {
+          "debugOptions": {
+              "trigger": {
+                  "diff": ${DEBUG_TRIGGERS}
+              },
+              "cache": {
+                  "create": ${DEBUG_CACHE_CREATE},
+                  "update": ${DEBUG_CACHE_UPDATE},
+                  "apply": ${DEBUG_CACHE_APPLY}
+              }
+          }
+      }

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -39,4 +39,12 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+        volumeMounts:
+          - mountPath: "/config/"
+            name: "config"
+      volumes:
+        - name: "config"
+          configMap:
+            optional: True
+            name: clowder-config
       terminationGracePeriodSeconds: 10

--- a/controllers/cloud.redhat.com/clowdapp_controller.go
+++ b/controllers/cloud.redhat.com/clowdapp_controller.go
@@ -16,6 +16,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 
@@ -24,9 +25,12 @@ import (
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -37,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	// Import the providers to initialize them
+	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/clowder_config"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/config"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 
@@ -59,6 +64,8 @@ import (
 	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/errors"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/utils"
+
+	"github.com/RedHatInsights/go-difflib/difflib"
 )
 
 const appFinalizer = "finalizer.app.cloud.redhat.com"
@@ -211,9 +218,58 @@ func (r *ClowdAppReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{Requeue: requeue}, nil
 }
 
-func ignoreStatusUpdatePredicate() predicate.Predicate {
+func isOurs(meta metav1.Object, gvk schema.GroupVersionKind) bool {
+	if gvk.Kind == "ClowdEnvironment" {
+		return true
+	} else if gvk.Kind == "ClowdApp" {
+		return true
+	} else if len(meta.GetOwnerReferences()) == 0 {
+		return false
+	} else if meta.GetOwnerReferences()[0].Kind == "ClowdApp" {
+		return true
+	} else if meta.GetOwnerReferences()[0].Kind == "ClowdEnvironment" {
+		return true
+	}
+	return false
+}
+
+func ignoreStatusUpdatePredicate(logr logr.Logger, ctrlName string) predicate.Predicate {
 	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			gvk, _ := getKindFromObj(scheme, e.Object)
+			if !isOurs(e.Meta, gvk) {
+				return false
+			}
+			logr.Info("Reconciliation trigger", "ctrl", ctrlName, "type", "create", "resType", gvk.Kind, "name", e.Meta.GetName(), "namespace", e.Meta.GetNamespace())
+			return true
+		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
+			gvk, _ := getKindFromObj(scheme, e.ObjectNew)
+			if !isOurs(e.MetaNew, gvk) {
+				return false
+			}
+
+			logr.Info("Reconciliation trigger", "ctrl", ctrlName, "type", "update", "resType", gvk.Kind, "name", e.MetaOld.GetName(), "namespace", e.MetaOld.GetNamespace())
+
+			if clowder_config.LoadedConfig.DebugOptions.Trigger.Diff {
+				if e.ObjectNew.GetObjectKind().GroupVersionKind() == secretCompare {
+					logr.Info("Trigger diff", "diff", "hidden", "ctrl", ctrlName, "type", "update", "resType", gvk.Kind, "name", e.MetaOld.GetName(), "namespace", e.MetaOld.GetNamespace())
+				} else {
+					oldObjJSON, _ := json.MarshalIndent(e.ObjectOld, "", "  ")
+					newObjJSON, _ := json.MarshalIndent(e.ObjectNew, "", "  ")
+
+					diff := difflib.UnifiedDiff{
+						A:        difflib.SplitLines(string(oldObjJSON)),
+						B:        difflib.SplitLines(string(newObjJSON)),
+						FromFile: "old",
+						ToFile:   "new",
+						Context:  3,
+					}
+					text, _ := difflib.GetUnifiedDiffString(diff)
+					logr.Info("Trigger diff", "diff", text, "ctrl", ctrlName, "type", "update", "resType", gvk.Kind, "name", e.MetaOld.GetName(), "namespace", e.MetaOld.GetNamespace())
+				}
+			}
+
 			// Always update if a deployment being watched changes - this allows
 			// status rollups to occur
 			if reflect.TypeOf(e.ObjectNew).String() == "*v1.Deployment" {
@@ -239,6 +295,22 @@ func ignoreStatusUpdatePredicate() predicate.Predicate {
 
 			// Ignore updates to CR status in which case metadata.Generation does not change
 			return e.MetaOld.GetGeneration() != e.MetaNew.GetGeneration()
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			gvk, _ := getKindFromObj(scheme, e.Object)
+			if !isOurs(e.Meta, gvk) {
+				return false
+			}
+			logr.Info("Reconciliation trigger", "ctrl", ctrlName, "type", "delete", "resType", gvk, "name", e.Meta.GetName(), "namespace", e.Meta.GetNamespace())
+			return true
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			gvk, _ := getKindFromObj(scheme, e.Object)
+			if !isOurs(e.Meta, gvk) {
+				return false
+			}
+			logr.Info("Reconciliation trigger", "ctrl", ctrlName, "type", "generic", "resType", gvk, "name", e.Meta.GetName(), "namespace", e.Meta.GetNamespace())
+			return true
 		},
 	}
 }
@@ -266,7 +338,7 @@ func (r *ClowdAppReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&apps.Deployment{}).
 		Owns(&core.Service{}).
 		Owns(&core.ConfigMap{}).
-		WithEventFilter(ignoreStatusUpdatePredicate()).
+		WithEventFilter(ignoreStatusUpdatePredicate(r.Log, "app")).
 		Complete(r)
 }
 

--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -238,7 +238,7 @@ func (r *ClowdEnvironmentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			},
 		).
 		For(&crd.ClowdEnvironment{}).
-		WithEventFilter(ignoreStatusUpdatePredicate()).
+		WithEventFilter(ignoreStatusUpdatePredicate(r.Log, "env")).
 		Complete(r)
 }
 

--- a/controllers/cloud.redhat.com/clowder_config/config.go
+++ b/controllers/cloud.redhat.com/clowder_config/config.go
@@ -1,0 +1,45 @@
+package clowder_config
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+)
+
+type ClowderConfig struct {
+	DebugOptions struct {
+		Trigger struct {
+			Diff bool `json:"diff"`
+		} `json:"trigger"`
+		Cache struct {
+			Create bool `json:"create"`
+			Update bool `json:"update"`
+			Apply  bool `json:"apply"`
+		} `json:"cache"`
+	} `json:"debugOptions"`
+}
+
+func getConfig() ClowderConfig {
+	jsonData, err := ioutil.ReadFile("/config/test")
+
+	if err != nil {
+		fmt.Printf("Config file not found")
+		return ClowderConfig{}
+	}
+
+	clowderConfig := ClowderConfig{}
+	err = json.Unmarshal(jsonData, &clowderConfig)
+
+	if err != nil {
+		fmt.Printf("Couldn't parse json")
+		return ClowderConfig{}
+	}
+
+	return clowderConfig
+}
+
+var LoadedConfig ClowderConfig
+
+func init() {
+	LoadedConfig = getConfig()
+}

--- a/controllers/cloud.redhat.com/clowder_config/config_test.go
+++ b/controllers/cloud.redhat.com/clowder_config/config_test.go
@@ -1,0 +1,29 @@
+package clowder_config
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig(t *testing.T) {
+	configFile, err := os.Open("test_config.json")
+
+	assert.NoError(t, err)
+
+	jsonParser := json.NewDecoder(configFile)
+
+	config := ClowderConfig{}
+	err = jsonParser.Decode(&config)
+
+	assert.NoError(t, err)
+
+	debug := config.DebugOptions
+
+	assert.Equal(t, debug.Trigger.Diff, true)
+	assert.Equal(t, debug.Cache.Create, true)
+	assert.Equal(t, debug.Cache.Update, false)
+	assert.Equal(t, debug.Cache.Apply, true)
+}

--- a/controllers/cloud.redhat.com/clowder_config/test_config.json
+++ b/controllers/cloud.redhat.com/clowder_config/test_config.json
@@ -1,0 +1,12 @@
+{
+    "debugOptions": {
+        "trigger": {
+            "diff": true
+        },
+        "cache": {
+            "create": true,
+            "update": false,
+            "apply": true
+        }
+    }
+}

--- a/controllers/cloud.redhat.com/providers/resource_cache.go
+++ b/controllers/cloud.redhat.com/providers/resource_cache.go
@@ -216,11 +216,20 @@ func (o *ObjectCache) Create(resourceIdent ResourceIdent, nn types.NamespacedNam
 	}
 
 	if clowder_config.LoadedConfig.DebugOptions.Cache.Create {
-		if object.GetObjectKind().GroupVersionKind() == secretCompare {
-			o.log.Info("CREATE resource ", "namespace", nn.Namespace, "name", nn.Name, "provider", resourceIdent.GetProvider(), "purpose", resourceIdent.GetPurpose(), "kind", object.GetObjectKind().GroupVersionKind().Kind, "diff", "hidden")
-		} else {
-			o.log.Info("CREATE resource ", "namespace", nn.Namespace, "name", nn.Name, "provider", resourceIdent.GetProvider(), "purpose", resourceIdent.GetPurpose(), "kind", object.GetObjectKind().GroupVersionKind().Kind, "diff", string(jsonData))
+		diffVal := "hidden"
+
+		if object.GetObjectKind().GroupVersionKind() != secretCompare {
+			diffVal = string(jsonData)
 		}
+
+		o.log.Info("CREATE resource ",
+			"namespace", nn.Namespace,
+			"name", nn.Name,
+			"provider", resourceIdent.GetProvider(),
+			"purpose", resourceIdent.GetPurpose(),
+			"kind", object.GetObjectKind().GroupVersionKind().Kind,
+			"diff", diffVal,
+		)
 	}
 
 	return nil

--- a/controllers/cloud.redhat.com/run.go
+++ b/controllers/cloud.redhat.com/run.go
@@ -1,12 +1,17 @@
 package controllers
 
 import (
+	"fmt"
 	"os"
+
+	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/clowder_config"
 
 	cloudredhatcomv1alpha1 "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
 	cyndi "cloud.redhat.com/clowder/v2/apis/cyndi-operator/v1alpha1"
 	strimzi "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta1"
+	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -18,6 +23,22 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 )
 
+var secretCompare schema.GroupVersionKind
+
+func getKindFromObj(scheme *runtime.Scheme, object runtime.Object) (schema.GroupVersionKind, error) {
+	gvks, nok, err := scheme.ObjectKinds(object)
+
+	if err != nil {
+		return schema.EmptyObjectKind.GroupVersionKind(), err
+	}
+
+	if nok {
+		return schema.EmptyObjectKind.GroupVersionKind(), fmt.Errorf("object type is unknown")
+	}
+
+	return gvks[0], nil
+}
+
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
@@ -25,10 +46,14 @@ func init() {
 	utilruntime.Must(strimzi.AddToScheme(scheme))
 	utilruntime.Must(cyndi.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
+
+	secretCompare, _ = getKindFromObj(scheme, &core.Secret{})
 }
 
 // Run inits the manager and controllers and then starts the manager
 func Run(metricsAddr string, enableLeaderElection bool, config *rest.Config, signalHandler <-chan struct{}) {
+	setupLog.Info("Loaded config", "config", clowder_config.LoadedConfig)
+
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: metricsAddr,

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module cloud.redhat.com/clowder/v2
 go 1.13
 
 require (
+	github.com/RedHatInsights/go-difflib v1.0.0
 	github.com/RedHatInsights/strimzi-client-go v0.21.1-3
 	github.com/go-logr/logr v0.2.1
 	github.com/go-logr/zapr v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/RedHatInsights/go-difflib v1.0.0 h1:BoruyjZfxO81sEynhkG6c4SMAQOjuBWezcJxtGK8dyw=
+github.com/RedHatInsights/go-difflib v1.0.0/go.mod h1:UMKOFdypYfrKT1B1nbGodM09nhOiAmcjes8qWP7Myrs=
 github.com/RedHatInsights/strimzi-client-go v0.21.1-3 h1:9McbENXUSe+r1bfFxjdsyAaJghwHvoZMYn1vn7HHm3g=
 github.com/RedHatInsights/strimzi-client-go v0.21.1-3/go.mod h1:DQ0Lv64xIvOwDNd+WQF7jWiF7G4pci2pKZsgDFk0k78=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=


### PR DESCRIPTION
* Currently there is log message to determine which resource triggered a reconciliation.
* A log message is now emitted detailing which resource in k8s triggered the reconciliation.
* This commit also adds several new debugging tools to Clowder which are controlled by
  environment variables.
* A new struct was added and a configmap can be created called clowder-config in the same
  namespace as clowder.

```
    debugOptions:
      cache:
        create: true
        update: true
        apply: true
      trigger:
        diff: true
```

* For "update" reconciliations, where a resource was modified, a diff can be logged by setting
  debugOptions->trigger->diff to true
* When the resource cache CREATEs an item, a message containing the content of this resource can be
  shown by setting debugoptions->cache->create to true
* When the resource cache UPDATEs an item, a message containing a diff of the change can be
  shown by setting debugOptions->cache->update to true
* When the resource cache APPLYs an item, a message containing the content of this resource can be
  shown by setting debugOptions->cache->apply to true
* In all cases, if the resource is a kind Secret, the output will be hidden to protect sensitive
  information.