### PR TITLE
Change 25 to 25% for rollouts

### DIFF
--- a/controllers/cloud.redhat.com/makers/maker.go
+++ b/controllers/cloud.redhat.com/makers/maker.go
@@ -486,8 +486,8 @@ func initDeployment(app *crd.ClowdApp, env *crd.ClowdEnvironment, d *apps.Deploy
 	d.Spec.Strategy = apps.DeploymentStrategy{
 		Type: apps.RollingUpdateDeploymentStrategyType,
 		RollingUpdate: &apps.RollingUpdateDeployment{
-			MaxSurge:       &intstr.IntOrString{Type: intstr.Int, IntVal: int32(25)},
-			MaxUnavailable: &intstr.IntOrString{Type: intstr.Int, IntVal: int32(25)},
+			MaxSurge:       &intstr.IntOrString{Type: intstr.String, StrVal: string("25%")},
+			MaxUnavailable: &intstr.IntOrString{Type: intstr.String, StrVal: string("25%")},
 		},
 	}
 	d.Spec.ProgressDeadlineSeconds = utils.Int32Ptr(600)


### PR DESCRIPTION
Having int 25 instead of string 25% caused rollouts to not wait for the new pods to fully init before killing the old pods.  Changing it to a string 25% will give us the desired behavior.