### PR TITLE
Adds sorting to the db secret search in app-interface mode

### DIFF
--- a/bundle/tests/scorecard/kuttl/test-multi-app-interface-db/01-pods.yaml
+++ b/bundle/tests/scorecard/kuttl/test-multi-app-interface-db/01-pods.yaml
@@ -75,3 +75,16 @@ data:
   db.port: NTQzMg==  # 5432
   db.user: dXNlcg==  # user
   db.password:  cGFzc3dvcmQxMjM=  # password123
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-c-readonly-db
+  namespace: test-multi-app-interface-db
+type: Opaque
+data:
+  db.host: YXBwLWItc3RhZ2UucmRzLmV4YW1wbGUuY29t  # app-b-stage.rds.example.com
+  db.name: ZGJuYW1l  # dbname
+  db.port: NTQzMg==  # 5432
+  db.user: dXNlcmJhZAo=  # userbad
+  db.password:  cGFzc3dvcmQxMjM=  # password123

--- a/bundle/tests/scorecard/kuttl/test-multi-app-interface-db/02-json-asserts.yaml
+++ b/bundle/tests/scorecard/kuttl/test-multi-app-interface-db/02-json-asserts.yaml
@@ -8,6 +8,7 @@ commands:
 
 - script: jq -r '.database.hostname == "app-b-stage.rds.example.com"' -e < /tmp/test-multi-app-interface-db-json-c
 - script: jq -r '.database.sslMode == "verify-full"' -e < /tmp/test-multi-app-interface-db-json-c
+- script: jq -r '.database.username == "user"' -e < /tmp/test-multi-app-interface-db-json-c
 
 
 - script: kubectl get secret --namespace=test-multi-app-interface-db app-b -o json > /tmp/test-multi-app-interface-db-b
@@ -15,3 +16,4 @@ commands:
 
 - script: jq -r '.database.hostname == "app-b-stage.rds.example.com"' -e < /tmp/test-multi-app-interface-db-json-b
 - script: jq -r '.database.sslMode == "verify-full"' -e < /tmp/test-multi-app-interface-db-json-b
+- script: jq -r '.database.username == "user"' -e < /tmp/test-multi-app-interface-db-json-b

--- a/controllers/cloud.redhat.com/providers/database/appinterface.go
+++ b/controllers/cloud.redhat.com/providers/database/appinterface.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -108,6 +109,10 @@ func (a *appInterface) Provide(app *crd.ClowdApp, c *config.AppConfig) error {
 		msg := fmt.Sprintf("Failed to list secrets in %s", namespace)
 		return errors.Wrap(msg, err)
 	}
+
+	sort.Slice(secrets.Items, func(i, j int) bool {
+		return secrets.Items[i].Name < secrets.Items[j].Name
+	})
 
 	dbConfigs, err := genDbConfigs(secrets.Items)
 


### PR DESCRIPTION
* Owing to the fact that the order of the result from the search is not
  deterministic, we now sort these to prevent the issue of two different
  secrets causing a pod to flap due to config changes.