### PR TITLE
Generation check added to ClowdApp reconciliation 

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
@@ -337,6 +337,7 @@ type ClowdEnvironmentStatus struct {
 	Ready           bool                    `json:"ready"`
 	Deployments     common.DeploymentStatus `json:"deployments"`
 	Apps            []AppInfo               `json:"apps,omitempty"`
+	Generation      int64                   `json:"generation,omitempty"`
 }
 
 // AppInfo details information about a specific app.

--- a/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
@@ -427,6 +427,9 @@ spec:
               - managedDeployments
               - readyDeployments
               type: object
+            generation:
+              format: int64
+              type: integer
             ready:
               type: boolean
             targetNamespace:

--- a/controllers/cloud.redhat.com/clowdapp_controller.go
+++ b/controllers/cloud.redhat.com/clowdapp_controller.go
@@ -140,6 +140,10 @@ func (r *ClowdAppReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return ctrl.Result{Requeue: true}, err
 	}
 
+	if env.Generation != env.Status.Generation {
+		return ctrl.Result{Requeue: true}, errors.New(fmt.Sprintf("Clowd Environment not yet reconciled: %s", env.Name))
+	}
+
 	if !env.IsReady() {
 		r.Recorder.Eventf(&app, "Warning", "ClowdEnvNotReady", "Clowder Environment [%s] is not ready", app.Spec.EnvName)
 		log.Info("Env not yet ready", "app", app.Name, "namespace", app.Namespace)
@@ -190,7 +194,7 @@ func (r *ClowdAppReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	// Delete all resources that are not used anymore
 	if !requeue {
-		r.Recorder.Eventf(&app, "Normal", "SuccessfulCreate", "created", app.GetClowdName())
+		r.Recorder.Eventf(&app, "Normal", "SuccessfulReconciliation", "Clowdapp reconciled [%s%]", app.GetClowdName())
 		log.Info("Reconciliation successful", "app", fmt.Sprintf("%s:%s", app.Namespace, app.Name))
 		err := cache.Reconcile(&app)
 		if err != nil {
@@ -198,7 +202,7 @@ func (r *ClowdAppReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		}
 	} else {
 		log.Info("Reconciliation partially successful", "app", fmt.Sprintf("%s:%s", app.Namespace, app.Name))
-		r.Recorder.Eventf(&app, "Normal", "SuccessfulPartialCreate", "requeued", app.GetClowdName())
+		r.Recorder.Eventf(&app, "Warning", "SuccessfulPartialReconciliation", "Clowdapp requeued [%s%]", app.GetClowdName())
 	}
 
 	if err == nil {

--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -195,22 +195,24 @@ func (r *ClowdEnvironmentReconciler) Reconcile(req ctrl.Request) (ctrl.Result, e
 	}
 
 	env.Status.Ready = env.IsReady()
+	env.Status.Generation = env.Generation
 
 	if err := r.Client.Status().Update(ctx, &env); err != nil {
 		return ctrl.Result{}, err
 	}
 
 	if !requeue {
-		// Delete all resources that are not used anymore
-		r.Recorder.Eventf(&env, "Normal", "SuccessfulCreate", "created", env.GetClowdName())
+		r.Recorder.Eventf(&env, "Normal", "SuccessfulReconciliation", "Environment reconciled [%s]", env.GetClowdName())
 		log.Info("Reconciliation successful", "env", env.Name)
+
+		// Delete all resources that are not used anymore
 		err := cache.Reconcile(&env)
 		if err != nil {
 			return ctrl.Result{Requeue: requeue}, nil
 		}
 	} else {
 		log.Info("Reconciliation partially successful", "env", fmt.Sprintf("%s:%s", env.Namespace, env.Name))
-		r.Recorder.Eventf(&env, "Normal", "SuccessfulPartialCreate", "requeued", env.GetClowdName())
+		r.Recorder.Eventf(&env, "Warning", "SuccessfulPartialReconciliation", "Environment requeued [%s]", env.GetClowdName())
 	}
 
 	return ctrl.Result{Requeue: requeue}, nil


### PR DESCRIPTION
* Currently app + env reconciliations can often get kicked off together
  and result in one reconciliation failing as it tries to modify a resource
  that either already exists now, or has been modified by another
  reconciliation. This is unnecessary.
* The generation check ensures that a ClowdEnv has been reconcilied before
  the ClowdApp is allowed to reconcile. This ensures that the ClowdApp
  always has the latest, up to date, reconciled env to work with.