### PR TITLE
Added role binding and per app service accounts

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
@@ -117,6 +117,10 @@ type WebServices struct {
 	Metrics MetricsWebService `json:"metrics,omitempty"`
 }
 
+// K8sAccessLevel defines the access level for the deployment, one of 'default', 'view' or 'edit'
+// +kubebuilder:validation:Enum=default;view;edit
+type K8sAccessLevel string
+
 // Deployment defines a service running inside a ClowdApp and will output a deployment resource.
 // Only one container per pod is allowed and this is defined in the PodSpec attribute.
 type Deployment struct {
@@ -138,6 +142,9 @@ type Deployment struct {
 
 	// PodSpec defines a container running inside a ClowdApp.
 	PodSpec PodSpec `json:"podSpec"`
+
+	// K8sAccessLevel defines the level of access for this deployment
+	K8sAccessLevel K8sAccessLevel `json:"k8sAccessLevel,omitempty"`
 }
 
 // PodSpec defines a container running inside a ClowdApp.
@@ -407,6 +414,14 @@ func (i *ClowdApp) GetUID() types.UID {
 // GetDeploymentStatus returns the Status.Deployments member
 func (i *ClowdApp) GetDeploymentStatus() *common.DeploymentStatus {
 	return &i.Status.Deployments
+}
+
+// GetDeploymentStatus returns the Status.Deployments member
+func (i *ClowdApp) GetDeploymentNamespacedName(d *Deployment) types.NamespacedName {
+	return types.NamespacedName{
+		Name:      fmt.Sprintf("%s-%s", i.Name, d.Name),
+		Namespace: i.Namespace,
+	}
 }
 
 // IsReady returns true when all the ManagedDeployments are Ready

--- a/bundle/tests/scorecard/kuttl/test-basic-app/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-basic-app/01-assert.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   template:
     spec:
-      serviceAccountName: puptoo-app
+      serviceAccountName: puptoo-processor
       containers:
       - env:
         - name: ENV_VAR_1
@@ -71,7 +71,7 @@ status:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: puptoo-app
+  name: puptoo-processor
   namespace: test-basic-app
 imagePullSecrets:
   - name: test

--- a/bundle/tests/scorecard/kuttl/test-k8s-access/00-install.yaml
+++ b/bundle/tests/scorecard/kuttl/test-k8s-access/00-install.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-k8s-access
+spec:
+  finalizers:
+  - kubernetes

--- a/bundle/tests/scorecard/kuttl/test-k8s-access/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-k8s-access/01-assert.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: puptoo-default
+  namespace: test-k8s-access
+spec:
+  template:
+    spec:
+      serviceAccountName: puptoo-default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: puptoo-default
+  namespace: test-k8s-access
+imagePullSecrets:
+  - name: test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: puptoo-view
+  namespace: test-k8s-access
+spec:
+  template:
+    spec:
+      serviceAccountName: puptoo-view
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: puptoo-view
+  namespace: test-k8s-access
+imagePullSecrets:
+  - name: test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: puptoo-edit
+  namespace: test-k8s-access
+spec:
+  template:
+    spec:
+      serviceAccountName: puptoo-edit
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: puptoo-edit
+  namespace: test-k8s-access
+imagePullSecrets:
+  - name: test

--- a/bundle/tests/scorecard/kuttl/test-k8s-access/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-k8s-access/01-assert.yaml
@@ -35,6 +35,20 @@ metadata:
 imagePullSecrets:
   - name: test
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: puptoo-view
+  namespace: test-k8s-access
+subjects:
+- kind: ServiceAccount
+  name: puptoo-view
+  namespace: test-k8s-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -52,3 +66,17 @@ metadata:
   namespace: test-k8s-access
 imagePullSecrets:
   - name: test
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: puptoo-edit
+  namespace: test-k8s-access
+subjects:
+- kind: ServiceAccount
+  name: puptoo-edit
+  namespace: test-k8s-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit

--- a/bundle/tests/scorecard/kuttl/test-k8s-access/01-pods.yaml
+++ b/bundle/tests/scorecard/kuttl/test-k8s-access/01-pods.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdEnvironment
+metadata:
+  name: test-k8s-access
+spec:
+  targetNamespace: test-k8s-access
+  providers:
+    web:
+      port: 8000
+      mode: operator
+    metrics:
+      port: 9000
+      mode: operator
+      path: "/metrics"
+    kafka:
+      mode: none
+    db:
+      mode: none
+    logging:
+      mode: none
+    objectStore:
+      mode: none
+    inMemoryDb:
+      mode: none
+    pullSecrets:
+    - test
+  resourceDefaults:
+    limits:
+      cpu: 400m
+      memory: 1024Mi
+    requests:
+      cpu: 30m
+      memory: 512Mi
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: puptoo
+  namespace: test-k8s-access
+spec:
+  envName: test-k8s-access
+  deployments:
+  - name: default
+    podSpec:
+      image: quay.io/psav/clowder-hello
+  - name: edit
+    podSpec:
+      image: quay.io/psav/clowder-hello
+    k8sAccessLevel: edit
+  - name: view
+    podSpec:
+      image: quay.io/psav/clowder-hello
+    k8sAccessLevel: view

--- a/bundle/tests/scorecard/kuttl/test-k8s-access/02-delete.yaml
+++ b/bundle/tests/scorecard/kuttl/test-k8s-access/02-delete.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: v1
+  kind: Namespace
+  name: test-k8s-access
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdEnvironment
+  name: test-k8s-access

--- a/config/crd/bases/cloud.redhat.com_clowdapps.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdapps.yaml
@@ -107,6 +107,14 @@ spec:
                   and will output a deployment resource. Only one container per pod
                   is allowed and this is defined in the PodSpec attribute.
                 properties:
+                  k8sAccessLevel:
+                    description: K8sAccessLevel defines the level of access for this
+                      deployment
+                    enum:
+                    - default
+                    - view
+                    - edit
+                    type: string
                   minReplicas:
                     description: Defines the minimum replica count for the pod.
                     format: int32

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
 - role.yaml
 - role_binding.yaml
+- role_binding_admin.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -178,3 +178,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/config/rbac/role_binding_admin.yaml
+++ b/config/rbac/role_binding_admin.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system

--- a/controllers/cloud.redhat.com/clowdapp_controller.go
+++ b/controllers/cloud.redhat.com/clowdapp_controller.go
@@ -88,6 +88,7 @@ type ClowdAppReconciler struct {
 // +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkaconnects,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kafka.strimzi.io,resources=kafkaconnectors,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cyndi.cloud.redhat.com,resources=cyndipipelines,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile fn
 func (r *ClowdAppReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/cloud.redhat.com/providers/dependencies/impl.go
+++ b/controllers/cloud.redhat.com/providers/dependencies/impl.go
@@ -8,10 +8,6 @@ import (
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/errors"
 )
 
-func GetDeploymentName(app *crd.ClowdApp, deployment *crd.Deployment) string {
-	return fmt.Sprintf("%s-%s", app.Name, deployment.Name)
-}
-
 func (dep *dependenciesProvider) makeDependencies(app *crd.ClowdApp, c *config.AppConfig) error {
 
 	if dep.Provider.Env.Spec.Providers.Web.PrivatePort == 0 {
@@ -119,7 +115,7 @@ func processAppEndpoints(
 
 		for _, deployment := range depApp.Spec.Deployments {
 			if bool(deployment.Web) || deployment.WebServices.Public.Enabled {
-				name := fmt.Sprintf("%s-%s", depApp.Name, deployment.Name)
+				name := depApp.GetDeploymentNamespacedName(&deployment).Name
 				*depConfig = append(*depConfig, config.DependencyEndpoint{
 					Hostname: fmt.Sprintf("%s.%s.svc", name, depApp.Namespace),
 					Port:     int(webPort),
@@ -128,7 +124,7 @@ func processAppEndpoints(
 				})
 			}
 			if deployment.WebServices.Private.Enabled {
-				name := fmt.Sprintf("%s-%s", depApp.Name, deployment.Name)
+				name := depApp.GetDeploymentNamespacedName(&deployment).Name
 				*privDepConfig = append(*privDepConfig, config.PrivateDependencyEndpoint{
 					Hostname: fmt.Sprintf("%s.%s.svc", name, depApp.Namespace),
 					Port:     int(privatePort),

--- a/controllers/cloud.redhat.com/providers/deployment/impl.go
+++ b/controllers/cloud.redhat.com/providers/deployment/impl.go
@@ -1,8 +1,6 @@
 package deployment
 
 import (
-	"fmt"
-
 	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/utils"
 	apps "k8s.io/api/apps/v1"
@@ -13,17 +11,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func GetDeploymentName(app *crd.ClowdApp, deployment *crd.Deployment) string {
-	return fmt.Sprintf("%s-%s", app.Name, deployment.Name)
-}
-
 func (dp *deploymentProvider) makeDeployment(deployment crd.Deployment, app *crd.ClowdApp) error {
 
 	d := &apps.Deployment{}
-	nn := types.NamespacedName{
-		Name:      GetDeploymentName(app, &deployment),
-		Namespace: app.Namespace,
-	}
+	nn := app.GetDeploymentNamespacedName(&deployment)
 
 	if err := dp.Cache.Create(CoreDeployment, nn, d); err != nil {
 		return err

--- a/controllers/cloud.redhat.com/providers/metrics/impl.go
+++ b/controllers/cloud.redhat.com/providers/metrics/impl.go
@@ -6,26 +6,19 @@ import (
 	webProvider "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers/web"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 func (m *metricsProvider) makeMetrics(deployment *crd.Deployment, app *crd.ClowdApp) error {
 
 	s := &core.Service{}
 
-	if err := m.Cache.Get(webProvider.CoreService, s, types.NamespacedName{
-		Name:      webProvider.GetServiceName(app, deployment),
-		Namespace: app.GetNamespace(),
-	}); err != nil {
+	if err := m.Cache.Get(webProvider.CoreService, s, app.GetDeploymentNamespacedName(deployment)); err != nil {
 		return err
 	}
 
 	d := &apps.Deployment{}
 
-	if err := m.Cache.Get(deployProvider.CoreDeployment, d, types.NamespacedName{
-		Name:      deployProvider.GetDeploymentName(app, deployment),
-		Namespace: app.GetNamespace(),
-	}); err != nil {
+	if err := m.Cache.Get(deployProvider.CoreDeployment, d, app.GetDeploymentNamespacedName(deployment)); err != nil {
 		return err
 	}
 

--- a/controllers/cloud.redhat.com/providers/serviceaccount/default.go
+++ b/controllers/cloud.redhat.com/providers/serviceaccount/default.go
@@ -80,11 +80,11 @@ func (sa *serviceaccountProvider) Provide(app *crd.ClowdApp, c *config.AppConfig
 
 	for _, dep := range app.Spec.Deployments {
 		d := &apps.Deployment{}
-		if err := sa.Cache.Get(deployment.CoreDeployment, d, app.GetDeploymentNamespacedName(&dep)); err != nil {
+		nn := app.GetDeploymentNamespacedName(&dep)
+
+		if err := sa.Cache.Get(deployment.CoreDeployment, d, nn); err != nil {
 			return err
 		}
-
-		nn := app.GetDeploymentNamespacedName(&dep)
 
 		labeler := utils.GetCustomLabeler(nil, nn, app)
 
@@ -111,8 +111,8 @@ func (sa *serviceaccountProvider) Provide(app *crd.ClowdApp, c *config.AppConfig
 
 		rb.Subjects = []rbac.Subject{{
 			Kind:      "ServiceAccount",
-			Name:      app.GetDeploymentNamespacedName(&dep).Name,
-			Namespace: app.GetDeploymentNamespacedName(&dep).Namespace,
+			Name:      nn.Name,
+			Namespace: nn.Namespace,
 		}}
 		rb.RoleRef = rbac.RoleRef{
 			Kind: "ClusterRole",

--- a/controllers/cloud.redhat.com/providers/serviceaccount/impl.go
+++ b/controllers/cloud.redhat.com/providers/serviceaccount/impl.go
@@ -7,20 +7,29 @@ import (
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/utils"
 	core "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func createServiceAccount(cache *providers.ObjectCache, ident providers.ResourceIdent, obj object.ClowdObject, pullSecretNames crd.PullSecrets) error {
-	nn := types.NamespacedName{
-		Name:      obj.GetClowdSAName(),
-		Namespace: obj.GetClowdNamespace(),
-	}
+func createServiceAccountForClowdObj(cache *providers.ObjectCache, ident providers.ResourceIdent, obj object.ClowdObject, pullSecretNames crd.PullSecrets) error {
 
 	if obj.GetClowdNamespace() == "" {
 		err := errors.New("targetNamespace not yet populated")
 		err.Requeue = true
 		return err
 	}
+
+	nn := types.NamespacedName{
+		Name:      obj.GetClowdSAName(),
+		Namespace: obj.GetClowdNamespace(),
+	}
+
+	labeler := utils.GetCustomLabeler(nil, nn, obj)
+
+	return CreateServiceAccount(cache, ident, pullSecretNames, nn, labeler)
+}
+
+func CreateServiceAccount(cache *providers.ObjectCache, ident providers.ResourceIdent, pullSecretNames crd.PullSecrets, nn types.NamespacedName, labeler func(v1.Object)) error {
 
 	sa := &core.ServiceAccount{}
 	if err := cache.Create(ident, nn, sa); err != nil {
@@ -35,7 +44,6 @@ func createServiceAccount(cache *providers.ObjectCache, ident providers.Resource
 		})
 	}
 
-	labeler := utils.GetCustomLabeler(nil, nn, obj)
 	labeler(sa)
 
 	if err := cache.Update(ident, sa); err != nil {

--- a/controllers/cloud.redhat.com/providers/serviceaccount/provider.go
+++ b/controllers/cloud.redhat.com/providers/serviceaccount/provider.go
@@ -3,10 +3,17 @@ package serviceaccount
 import (
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers"
 	core "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
 )
 
 // ProvName sets the provider name identifier
 var ProvName = "serviceaccount"
+
+// CoreAppServiceAccount is the serviceaccount for the apps.
+var CoreDeploymentRoleBinding = providers.NewMultiResourceIdent(ProvName, "core_deployment_role_binding", &rbac.RoleBinding{})
+
+// CoreAppServiceAccount is the serviceaccount for the apps.
+var CoreDeploymentServiceAccount = providers.NewMultiResourceIdent(ProvName, "core_deployment_service_account", &core.ServiceAccount{})
 
 // CoreAppServiceAccount is the serviceaccount for the apps.
 var CoreAppServiceAccount = providers.NewSingleResourceIdent(ProvName, "core_app_service_account", &core.ServiceAccount{})

--- a/controllers/cloud.redhat.com/providers/web/impl.go
+++ b/controllers/cloud.redhat.com/providers/web/impl.go
@@ -1,27 +1,17 @@
 package web
 
 import (
-	"fmt"
-
 	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
 	deployProvider "cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/providers/deployment"
 	"cloud.redhat.com/clowder/v2/controllers/cloud.redhat.com/utils"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
-
-func GetServiceName(app *crd.ClowdApp, deployment *crd.Deployment) string {
-	return fmt.Sprintf("%s-%s", app.Name, deployment.Name)
-}
 
 func (web *webProvider) makeService(deployment *crd.Deployment, app *crd.ClowdApp) error {
 
 	s := &core.Service{}
-	nn := types.NamespacedName{
-		Name:      GetServiceName(app, deployment),
-		Namespace: app.Namespace,
-	}
+	nn := app.GetDeploymentNamespacedName(deployment)
 
 	if err := web.Cache.Create(CoreService, nn, s); err != nil {
 		return err
@@ -29,10 +19,7 @@ func (web *webProvider) makeService(deployment *crd.Deployment, app *crd.ClowdAp
 
 	d := &apps.Deployment{}
 
-	web.Cache.Get(deployProvider.CoreDeployment, d, types.NamespacedName{
-		Name:      deployProvider.GetDeploymentName(app, deployment),
-		Namespace: app.GetNamespace(),
-	})
+	web.Cache.Get(deployProvider.CoreDeployment, d, app.GetDeploymentNamespacedName(deployment))
 
 	servicePorts := []core.ServicePort{}
 	containerPorts := []core.ContainerPort{}

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -328,6 +328,7 @@ Appears In:
    "``web`` (WebDeprecated)", "If set to true, creates a service on the webPort defined in the ClowdEnvironment resource, along with the relevant liveness and readiness probes."
    "``webServices`` (:ref:`WebServices`)", ""
    "``podSpec`` (:ref:`PodSpec`)", "PodSpec defines a container running inside a ClowdApp."
+   "``k8sAccessLevel`` (K8sAccessLevel)", "K8sAccessLevel defines the level of access for this deployment"
 
 
 .. _DeploymentInfo :

--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -163,10 +163,7 @@ cache.
 .. code-block:: go
 
     d := &apps.Deployment{}
-    nn := types.NamespacedName{
-        Name:      GetDeploymentName(app, &deployment),
-        Namespace: app.Namespace,
-    }
+    nn := app.GetDeploymentNamespacedName(&deployment)
 
     if err := dp.Cache.Create(CoreDeployment, nn, d); err != nil {
         return err


### PR DESCRIPTION
* Added K8sAccessLevel to Deployment Spec.
* Added GetDeploymentNamespacedName() to ClowdApp.
* Deleted GetDeploymentName() from various places and replaced with the
  ClowdApp.GetDeploymentNamespacedName.
* Upgraded access rights for controller to deal with RoleBindings
* Now create a service account per deployment to allow for more granular
  access levels.