### PR TITLE
Add new mutating webhook to convert old version to new

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
@@ -419,32 +419,6 @@ func (i *ClowdApp) GetClowdSAName() string {
 	return fmt.Sprintf("%s-app", i.GetClowdName())
 }
 
-// ConvertToNewShim converts an old "pod" based spec into the new "deployment" style.
-func (i *ClowdApp) ConvertToNewShim() {
-	deps := []Deployment{}
-	for _, pod := range i.Spec.Pods {
-		dep := Deployment{
-			Name:        pod.Name,
-			Web:         pod.Web,
-			MinReplicas: pod.MinReplicas,
-			PodSpec: PodSpec{
-				Image:          pod.Image,
-				InitContainers: pod.InitContainers,
-				Command:        pod.Command,
-				Args:           pod.Args,
-				Env:            pod.Env,
-				Resources:      pod.Resources,
-				LivenessProbe:  pod.LivenessProbe,
-				ReadinessProbe: pod.ReadinessProbe,
-				Volumes:        pod.Volumes,
-				VolumeMounts:   pod.VolumeMounts,
-			},
-		}
-		deps = append(deps, dep)
-	}
-	i.Spec.Deployments = deps
-}
-
 // Omfunc is a utility function that performs an operation on a metav1.Object.
 type omfunc func(o metav1.Object)
 

--- a/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
@@ -441,22 +441,3 @@ func (i *ClowdEnvironment) GenerateTargetNamespace() string {
 func (i *ClowdEnvironment) IsReady() bool {
 	return (i.Status.Deployments.ManagedDeployments == i.Status.Deployments.ReadyDeployments)
 }
-
-// ConvertDeprecatedKafkaSpec converts values from the old Kafka provider spec into the new format
-func (i *ClowdEnvironment) ConvertDeprecatedKafkaSpec() {
-	if i.Spec.Providers.Kafka.ClusterName != "" {
-		i.Spec.Providers.Kafka.Cluster.Name = i.Spec.Providers.Kafka.ClusterName
-	}
-
-	if i.Spec.Providers.Kafka.Namespace != "" {
-		i.Spec.Providers.Kafka.Cluster.Namespace = i.Spec.Providers.Kafka.Namespace
-	}
-
-	if i.Spec.Providers.Kafka.ConnectNamespace != "" {
-		i.Spec.Providers.Kafka.Connect.Namespace = i.Spec.Providers.Kafka.ConnectNamespace
-	}
-
-	if i.Spec.Providers.Kafka.ConnectClusterName != "" {
-		i.Spec.Providers.Kafka.Connect.Name = i.Spec.Providers.Kafka.ConnectClusterName
-	}
-}

--- a/build/kube_setup.sh
+++ b/build/kube_setup.sh
@@ -100,6 +100,24 @@ function install_strimzi_operator {
     cd "$ROOT_DIR"
 }
 
+function install_cert_manager {
+    CERT_MANAGER_VERSION=v1.2.0
+
+    echo "*** Installing cert manager ..."
+    cd "$DOWNLOAD_DIR"
+
+    echo "*** Downloading ${CERT_MANAGER_YAML} ..."
+    curl -LsSO https://github.com/jetstack/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
+
+    echo "*** Installing Cert Manager resources ..."
+    kubectl apply -f cert-manager.yaml
+
+    echo "*** Will wait for cert manager to come up in background"
+    kubectl rollout status deployment/cert-manager -n cert-manager | sed "s/^/[cert-manager] /" &
+    BG_PIDS+=($!)
+
+    cd "$ROOT_DIR"
+}
 
 function install_prometheus_operator {
     PROM_VERSION=0.45.0
@@ -139,6 +157,7 @@ function install_prometheus_operator {
 
 install_strimzi_operator
 #install_prometheus_operator
+install_cert_manager
 
 FAILURES=0
 if [ ${#BG_PIDS[@]} -gt 0 ]; then

--- a/bundle/tests/scorecard/kuttl/test-cyndi-strimzi/01-install.yaml
+++ b/bundle/tests/scorecard/kuttl/test-cyndi-strimzi/01-install.yaml
@@ -20,7 +20,6 @@ spec:
         name: my-connect-cluster
       mode: operator
     db:
-      image: "registry.redhat.io/rhel8/postgresql-12:1-36"
       mode: local
     logging:
       mode: none

--- a/bundle/tests/scorecard/kuttl/test-webhook-admission/00-install.yaml
+++ b/bundle/tests/scorecard/kuttl/test-webhook-admission/00-install.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-webhook-admission
+spec:
+  finalizers:
+  - kubernetes

--- a/bundle/tests/scorecard/kuttl/test-webhook-admission/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-webhook-admission/01-assert.yaml
@@ -2,9 +2,9 @@
 apiVersion: cloud.redhat.com/v1alpha1
 kind: ClowdEnvironment
 metadata:
-  name: test-web-services
+  name: test-webhook-admission
 spec:
-  targetNamespace: test-web-services
+  targetNamespace: test-webhook-admission
   providers:
     web:
       port: 8000
@@ -16,6 +16,12 @@ spec:
       path: "/metrics"
     kafka:
       mode: none
+      cluster:
+        namespace: test-webhook-admission
+        name: webhook-admission
+      connect:
+        namespace: test-webhook-admission
+        name: webhook-admission-connect
     db:
       mode: none
     logging:
@@ -27,7 +33,7 @@ spec:
   resourceDefaults:
     limits:
       cpu: 400m
-      memory: 1024Mi
+      memory: 1Gi
     requests:
       cpu: 30m
       memory: 512Mi
@@ -36,10 +42,18 @@ apiVersion: cloud.redhat.com/v1alpha1
 kind: ClowdApp
 metadata:
   name: puptoo
-  namespace: test-web-services
+  namespace: test-webhook-admission
 spec:
-  envName: test-web-services
+  envName: test-webhook-admission
   deployments:
+  - name: processor-2
+    podSpec:
+      image: quay.io/psav/clowder-hello
+      env: 
+        - name: ENV_VAR_1
+          value: env_var_1
+        - name: ENV_VAR_2
+          value: env_var_2
   - name: processor
     podSpec:
       image: quay.io/psav/clowder-hello
@@ -49,7 +63,5 @@ spec:
         - name: ENV_VAR_2
           value: env_var_2
     webServices:
-      private:
-        enabled: True
       public:
         enabled: True

--- a/bundle/tests/scorecard/kuttl/test-webhook-admission/01-errors.yaml
+++ b/bundle/tests/scorecard/kuttl/test-webhook-admission/01-errors.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdEnvironment
+metadata:
+  name: test-webhook-admission
+spec:
+  providers:
+    kafka:
+      namespace: test-webhook-admission
+      clusterName: webhook-admission
+      connectNamespace: test-webhook-admission
+      connectClusterName: webhook-admission-connect
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: puptoo
+  namespace: test-webhook-admission
+spec:
+  pods:
+  - name: processor
+    image: quay.io/psav/clowder-hello
+    env: 
+      - name: ENV_VAR_1
+        value: env_var_1
+      - name: ENV_VAR_2
+        value: env_var_2
+    web: true

--- a/bundle/tests/scorecard/kuttl/test-webhook-admission/01-pods.yaml
+++ b/bundle/tests/scorecard/kuttl/test-webhook-admission/01-pods.yaml
@@ -2,9 +2,9 @@
 apiVersion: cloud.redhat.com/v1alpha1
 kind: ClowdEnvironment
 metadata:
-  name: test-web-services
+  name: test-webhook-admission
 spec:
-  targetNamespace: test-web-services
+  targetNamespace: test-webhook-admission
   providers:
     web:
       port: 8000
@@ -16,6 +16,10 @@ spec:
       path: "/metrics"
     kafka:
       mode: none
+      namespace: test-webhook-admission
+      clusterName: webhook-admission
+      connectNamespace: test-webhook-admission
+      connectClusterName: webhook-admission-connect
     db:
       mode: none
     logging:
@@ -36,11 +40,20 @@ apiVersion: cloud.redhat.com/v1alpha1
 kind: ClowdApp
 metadata:
   name: puptoo
-  namespace: test-web-services
+  namespace: test-webhook-admission
 spec:
-  envName: test-web-services
-  deployments:
+  envName: test-webhook-admission
+  pods:
   - name: processor
+    image: quay.io/psav/clowder-hello
+    env: 
+      - name: ENV_VAR_1
+        value: env_var_1
+      - name: ENV_VAR_2
+        value: env_var_2
+    web: true
+  deployments:
+  - name: processor-2
     podSpec:
       image: quay.io/psav/clowder-hello
       env: 
@@ -48,8 +61,3 @@ spec:
           value: env_var_1
         - name: ENV_VAR_2
           value: env_var_2
-    webServices:
-      private:
-        enabled: True
-      public:
-        enabled: True

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -10,16 +10,16 @@ resources:
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_clowdapps.yaml
-#- patches/webhook_in_clowdenvironments.yaml
+- patches/webhook_in_clowdapps.yaml
+- patches/webhook_in_clowdenvironments.yaml
 #- patches/webhook_in_kafkatopics.yaml
 #- patches/webhook_in_clowdjobinvocations.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_clowdapps.yaml
-#- patches/cainjection_in_clowdenvironments.yaml
+- patches/cainjection_in_clowdapps.yaml
+- patches/cainjection_in_clowdenvironments.yaml
 #- patches/cainjection_in_kafkatopics.yaml
 #- patches/cainjection_in_clowdjobinvocations.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch

--- a/config/crd/patches/cainjection_in_clowdapps.yaml
+++ b/config/crd/patches/cainjection_in_clowdapps.yaml
@@ -5,4 +5,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: clowdapps.cloud.redhat.com.cloud.redhat.com
+  name: clowdapps.cloud.redhat.com

--- a/config/crd/patches/cainjection_in_clowdenvironments.yaml
+++ b/config/crd/patches/cainjection_in_clowdenvironments.yaml
@@ -5,4 +5,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: clowdenvironments.cloud.redhat.com.cloud.redhat.com
+  name: clowdenvironments.cloud.redhat.com

--- a/config/crd/patches/cainjection_in_clowdjobinvocations.yaml
+++ b/config/crd/patches/cainjection_in_clowdjobinvocations.yaml
@@ -5,4 +5,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: clowdjobinvocations.cloud.redhat.com.cloud.redhat.com
+  name: clowdjobinvocations.cloud.redhat.com

--- a/config/crd/patches/webhook_in_clowdapps.yaml
+++ b/config/crd/patches/webhook_in_clowdapps.yaml
@@ -3,8 +3,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: clowdapps.cloud.redhat.com.cloud.redhat.com
+  name: clowdapps.cloud.redhat.com
 spec:
+  preserveUnknownFields: false
   conversion:
     strategy: Webhook
     webhookClientConfig:
@@ -14,4 +15,5 @@ spec:
       service:
         namespace: system
         name: webhook-service
-        path: /convert
+        path: /mutate-app
+        port: 8080

--- a/config/crd/patches/webhook_in_clowdenvironments.yaml
+++ b/config/crd/patches/webhook_in_clowdenvironments.yaml
@@ -3,8 +3,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: clowdenvironments.cloud.redhat.com.cloud.redhat.com
+  name: clowdenvironments.cloud.redhat.com
 spec:
+  preserveUnknownFields: false
   conversion:
     strategy: Webhook
     webhookClientConfig:
@@ -14,4 +15,5 @@ spec:
       service:
         namespace: system
         name: webhook-service
-        path: /convert
+        path: /mutate-env
+        port: 8080

--- a/config/crd/patches/webhook_in_clowdjobinvocations.yaml
+++ b/config/crd/patches/webhook_in_clowdjobinvocations.yaml
@@ -3,7 +3,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: clowdjobinvocations.cloud.redhat.com.cloud.redhat.com
+  name: clowdjobinvocations.cloud.redhat.com
 spec:
   conversion:
     strategy: Webhook

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,9 +18,9 @@ bases:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- ../webhook
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
@@ -32,39 +32,39 @@ patchesStrategicMerge:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- manager_webhook_patch.yaml
+- manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1alpha2
-#    name: serving-cert # this name should match the one in certificate.yaml
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: CERTIFICATE_NAME
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1alpha2
-#    name: serving-cert # this name should match the one in certificate.yaml
-#- name: SERVICE_NAMESPACE # namespace of the service
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: SERVICE_NAME
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
+- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1alpha2
+    name: serving-cert # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
+- name: CERTIFICATE_NAME
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1alpha2
+    name: serving-cert # this name should match the one in certificate.yaml
+- name: SERVICE_NAMESPACE # namespace of the service
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -6,10 +6,10 @@ metadata:
   name: mutating-webhook-configuration
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
----
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: ValidatingWebhookConfiguration
-metadata:
-  name: validating-webhook-configuration
-  annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+# ---
+# apiVersion: admissionregistration.k8s.io/v1beta1
+# kind: ValidatingWebhookConfiguration
+# metadata:
+#   name: validating-webhook-configuration
+#   annotations:
+#     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)

--- a/config/rbac/application_editor_role.yaml
+++ b/config/rbac/application_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: clowdapp-editor-role
 rules:
 - apiGroups:
-  - cloud.redhat.com.cloud.redhat.com
+  - cloud.redhat.com
   resources:
   - clowdapps
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - cloud.redhat.com.cloud.redhat.com
+  - cloud.redhat.com
   resources:
   - clowdapps/status
   verbs:

--- a/config/rbac/application_viewer_role.yaml
+++ b/config/rbac/application_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: clowdapp-viewer-role
 rules:
 - apiGroups:
-  - cloud.redhat.com.cloud.redhat.com
+  - cloud.redhat.com
   resources:
   - clowdapps
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - cloud.redhat.com.cloud.redhat.com
+  - cloud.redhat.com
   resources:
   - clowdapps/status
   verbs:

--- a/config/rbac/clowdjobinvocation_editor_role.yaml
+++ b/config/rbac/clowdjobinvocation_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: clowdjobinvocation-editor-role
 rules:
 - apiGroups:
-  - cloud.redhat.com.cloud.redhat.com
+  - cloud.redhat.com
   resources:
   - clowdjobinvocations
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - cloud.redhat.com.cloud.redhat.com
+  - cloud.redhat.com
   resources:
   - clowdjobinvocations/status
   verbs:

--- a/config/rbac/clowdjobinvocation_viewer_role.yaml
+++ b/config/rbac/clowdjobinvocation_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: clowdjobinvocation-viewer-role
 rules:
 - apiGroups:
-  - cloud.redhat.com.cloud.redhat.com
+  - cloud.redhat.com
   resources:
   - clowdjobinvocations
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - cloud.redhat.com.cloud.redhat.com
+  - cloud.redhat.com
   resources:
   - clowdjobinvocations/status
   verbs:

--- a/config/rbac/environment_editor_role.yaml
+++ b/config/rbac/environment_editor_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: clowdenvironment-editor-role
 rules:
 - apiGroups:
-  - cloud.redhat.com.cloud.redhat.com
+  - cloud.redhat.com
   resources:
   - clowdenvironments
   verbs:
@@ -17,7 +17,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - cloud.redhat.com.cloud.redhat.com
+  - cloud.redhat.com
   resources:
   - clowdenvironments/status
   verbs:

--- a/config/rbac/environment_viewer_role.yaml
+++ b/config/rbac/environment_viewer_role.yaml
@@ -5,7 +5,7 @@ metadata:
   name: clowdenvironment-viewer-role
 rules:
 - apiGroups:
-  - cloud.redhat.com.cloud.redhat.com
+  - cloud.redhat.com
   resources:
   - clowdenvironments
   verbs:
@@ -13,7 +13,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - cloud.redhat.com.cloud.redhat.com
+  - cloud.redhat.com
   resources:
   - clowdenvironments/status
   verbs:

--- a/config/samples/cloud.redhat.com_v1alpha1_clowdapp.yaml
+++ b/config/samples/cloud.redhat.com_v1alpha1_clowdapp.yaml
@@ -1,4 +1,4 @@
-apiVersion: cloud.redhat.com.cloud.redhat.com/v1alpha1
+apiVersion: cloud.redhat.com/v1alpha1
 kind: ClowdApp
 metadata:
   name: clowdapp-sample

--- a/config/samples/cloud.redhat.com_v1alpha1_clowdenvironment.yaml
+++ b/config/samples/cloud.redhat.com_v1alpha1_clowdenvironment.yaml
@@ -1,4 +1,4 @@
-apiVersion: cloud.redhat.com.cloud.redhat.com/v1alpha1
+apiVersion: cloud.redhat.com/v1alpha1
 kind: ClowdEnvironment
 metadata:
   name: clowdenvironment-sample

--- a/config/samples/cloud.redhat.com_v1alpha1_clowdjobinvocation.yaml
+++ b/config/samples/cloud.redhat.com_v1alpha1_clowdjobinvocation.yaml
@@ -1,4 +1,4 @@
-apiVersion: cloud.redhat.com.cloud.redhat.com/v1alpha1
+apiVersion: cloud.redhat.com/v1alpha1
 kind: ClowdJobInvocation
 metadata:
   name: clowdjobinvocation-sample

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
 - manifests.yaml
 - service.yaml
+- network_policy.yaml
 
 configurations:
 - kustomizeconfig.yaml

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,52 @@
+
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: mutating-webhook-configuration
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-app
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - "v1alpha1"
+  - "v1beta1"
+  sideEffects: "None"
+  name: clowdapp.cloud.redhat.com
+  rules:
+  - apiGroups:
+    - cloud.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clowdapps
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-env
+  failurePolicy: Fail
+  admissionReviewVersions:
+  - "v1alpha1"
+  - "v1beta1"
+  sideEffects: "None"
+  name: clowdenv.clowd.redhat.com
+  rules:
+  - apiGroups:
+    - cloud.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clowdenvironments

--- a/config/webhook/network_policy.yaml
+++ b/config/webhook/network_policy.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-to-admission-controller
+spec:
+  ingress:
+  - {}
+  podSelector:
+    matchLabels:
+      name: clowder-controller-manager
+  policyTypes:
+  - Ingress

--- a/controllers/cloud.redhat.com/clowdapp_controller.go
+++ b/controllers/cloud.redhat.com/clowdapp_controller.go
@@ -98,10 +98,6 @@ func (r *ClowdAppReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	app := crd.ClowdApp{}
 	err := r.Client.Get(ctx, req.NamespacedName, &app)
 
-	if app.Spec.Pods != nil {
-		app.ConvertToNewShim()
-	}
-
 	if err != nil {
 		if k8serr.IsNotFound(err) {
 			// Must have been deleted
@@ -372,10 +368,6 @@ func (r *ClowdAppReconciler) appsToEnqueueUponEnvUpdate(a handler.MapObject) []r
 	// Filter based on base attribute
 
 	for _, app := range appList.Items {
-
-		if app.Spec.Pods != nil {
-			app.ConvertToNewShim()
-		}
 
 		if app.Spec.EnvName == env.Name {
 			// Add filtered resources to return result

--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -303,10 +303,6 @@ func (r *ClowdEnvironmentReconciler) setAppInfo(p providers.Provider) error {
 			continue
 		}
 
-		if app.Spec.Pods != nil {
-			app.ConvertToNewShim()
-		}
-
 		appstatus := crd.AppInfo{
 			Name:        app.Name,
 			Deployments: []crd.DeploymentInfo{},
@@ -328,7 +324,7 @@ func (r *ClowdEnvironmentReconciler) setAppInfo(p providers.Provider) error {
 			deploymentStatus := crd.DeploymentInfo{
 				Name: fmt.Sprintf("%s-%s", app.Name, pod.Name),
 			}
-			if bool(pod.Web) || pod.WebServices.Public.Enabled {
+			if pod.WebServices.Public.Enabled {
 				deploymentStatus.Hostname = fmt.Sprintf("%s.%s.svc", deploymentStatus.Name, app.Namespace)
 				deploymentStatus.Port = p.Env.Spec.Providers.Web.Port
 			}

--- a/controllers/cloud.redhat.com/mutator.go
+++ b/controllers/cloud.redhat.com/mutator.go
@@ -1,0 +1,131 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	crd "cloud.redhat.com/clowder/v2/apis/cloud.redhat.com/v1alpha1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type mutantAnnotatorApp struct {
+	Client   client.Client
+	Recorder record.EventRecorder
+	decoder  *admission.Decoder
+}
+
+func (a *mutantAnnotatorApp) Handle(ctx context.Context, req admission.Request) admission.Response {
+	app := &crd.ClowdApp{}
+	err := a.decoder.Decode(req, app)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if app.Spec.Pods != nil {
+		// TODO events don't work here due to object not being "created" yet - could use status to deal with in reconcile
+		// a.Recorder.Eventf(app, "Warning", "ClowdAppOldVersion", "ClowdApp spec [%s] is using deprecated Pods", app.Name)
+
+		deps := []crd.Deployment{}
+		for _, pod := range app.Spec.Pods {
+			dep := crd.Deployment{
+				Name:        pod.Name,
+				Web:         pod.Web,
+				MinReplicas: pod.MinReplicas,
+				PodSpec: crd.PodSpec{
+					Image:          pod.Image,
+					InitContainers: pod.InitContainers,
+					Command:        pod.Command,
+					Args:           pod.Args,
+					Env:            pod.Env,
+					Resources:      pod.Resources,
+					LivenessProbe:  pod.LivenessProbe,
+					ReadinessProbe: pod.ReadinessProbe,
+					Volumes:        pod.Volumes,
+					VolumeMounts:   pod.VolumeMounts,
+				},
+			}
+			deps = append(deps, dep)
+		}
+		if app.Spec.Deployments != nil {
+			app.Spec.Deployments = append(app.Spec.Deployments, deps...)
+		} else {
+			app.Spec.Deployments = deps
+		}
+		app.Spec.Pods = nil
+	}
+
+	for i, deployment := range app.Spec.Deployments {
+		if deployment.Web {
+			// TODO events don't work here due to object not being "created" yet - could use status to deal with in reconcile
+			// a.Recorder.Eventf(app, "Warning", "ClowdAppOldVersion", "ClowdApp spec [%s] is using deprecated Web", app.Name)
+
+			app.Spec.Deployments[i].WebServices = crd.WebServices{
+				Public: crd.PublicWebService{
+					Enabled: true,
+				},
+				Private: crd.PrivateWebService{},
+				Metrics: crd.MetricsWebService{},
+			}
+			app.Spec.Deployments[i].Web = false
+		}
+	}
+
+	marshaledApp, err := json.Marshal(app)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledApp)
+}
+
+func (a *mutantAnnotatorApp) InjectDecoder(d *admission.Decoder) error {
+	a.decoder = d
+	return nil
+}
+
+type mutantAnnotatorEnv struct {
+	Client   client.Client
+	Recorder record.EventRecorder
+	decoder  *admission.Decoder
+}
+
+func (a *mutantAnnotatorEnv) Handle(ctx context.Context, req admission.Request) admission.Response {
+	env := &crd.ClowdEnvironment{}
+	err := a.decoder.Decode(req, env)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	kafkaConfig := env.Spec.Providers.Kafka
+
+	if kafkaConfig.Namespace != "" || kafkaConfig.ClusterName != "" {
+		env.Spec.Providers.Kafka.Cluster = crd.KafkaClusterConfig{
+			Name:      kafkaConfig.ClusterName,
+			Namespace: kafkaConfig.Namespace,
+		}
+		env.Spec.Providers.Kafka.ClusterName = ""
+		env.Spec.Providers.Kafka.Namespace = ""
+	}
+
+	if kafkaConfig.ConnectClusterName != "" || kafkaConfig.ConnectNamespace != "" {
+		env.Spec.Providers.Kafka.Connect = crd.KafkaConnectClusterConfig{
+			Name:      kafkaConfig.ConnectClusterName,
+			Namespace: kafkaConfig.ConnectNamespace,
+		}
+		env.Spec.Providers.Kafka.ConnectClusterName = ""
+		env.Spec.Providers.Kafka.ConnectNamespace = ""
+	}
+
+	marshaledApp, err := json.Marshal(env)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledApp)
+}
+
+func (a *mutantAnnotatorEnv) InjectDecoder(d *admission.Decoder) error {
+	a.decoder = d
+	return nil
+}

--- a/controllers/cloud.redhat.com/providers/dependencies/impl.go
+++ b/controllers/cloud.redhat.com/providers/dependencies/impl.go
@@ -81,11 +81,6 @@ func makeDepConfig(
 	appMap := map[string]crd.ClowdApp{}
 
 	for _, iapp := range apps.Items {
-
-		if iapp.Spec.Pods != nil {
-			iapp.ConvertToNewShim()
-		}
-
 		if iapp.Spec.EnvName == app.Spec.EnvName {
 			appMap[iapp.Name] = iapp
 		}
@@ -118,7 +113,7 @@ func processAppEndpoints(
 		// If app has public endpoint, add it to app config
 
 		for _, deployment := range depApp.Spec.Deployments {
-			if bool(deployment.Web) || deployment.WebServices.Public.Enabled {
+			if deployment.WebServices.Public.Enabled {
 				name := fmt.Sprintf("%s-%s", depApp.Name, deployment.Name)
 				*depConfig = append(*depConfig, config.DependencyEndpoint{
 					Hostname: fmt.Sprintf("%s.%s.svc", name, depApp.Namespace),

--- a/controllers/cloud.redhat.com/providers/dependencies/test.go
+++ b/controllers/cloud.redhat.com/providers/dependencies/test.go
@@ -173,7 +173,11 @@ func TestOptionalDependency(t *testing.T) {
 			ObjectMeta: nobjMeta,
 			Spec: crd.ClowdAppSpec{
 				Deployments: []crd.Deployment{{
-					Web:  true,
+					WebServices: crd.WebServices{
+						Public: crd.PublicWebService{
+							Enabled: true,
+						},
+					},
 					Name: "deep",
 				}}},
 		},
@@ -181,7 +185,11 @@ func TestOptionalDependency(t *testing.T) {
 				ObjectMeta: nobjMeta2,
 				Spec: crd.ClowdAppSpec{
 					Deployments: []crd.Deployment{{
-						Web:  true,
+						WebServices: crd.WebServices{
+							Public: crd.PublicWebService{
+								Enabled: true,
+							},
+						},
 						Name: "beeble",
 					}}},
 			},
@@ -259,7 +267,11 @@ func TestMultiDependency(t *testing.T) {
 					Deployments: []crd.Deployment{
 						{
 							Name: "whopper",
-							Web:  true,
+							WebServices: crd.WebServices{
+								Public: crd.PublicWebService{
+									Enabled: true,
+								},
+							},
 						},
 					},
 				}},
@@ -269,11 +281,19 @@ func TestMultiDependency(t *testing.T) {
 					Deployments: []crd.Deployment{
 						{
 							Name: "chopper",
-							Web:  true,
+							WebServices: crd.WebServices{
+								Public: crd.PublicWebService{
+									Enabled: true,
+								},
+							},
 						},
 						{
 							Name: "bopper",
-							Web:  true,
+							WebServices: crd.WebServices{
+								Public: crd.PublicWebService{
+									Enabled: true,
+								},
+							},
 						},
 					},
 				},

--- a/controllers/cloud.redhat.com/providers/deployment/impl.go
+++ b/controllers/cloud.redhat.com/providers/deployment/impl.go
@@ -86,12 +86,12 @@ func initDeployment(app *crd.ClowdApp, env *crd.ClowdEnvironment, d *apps.Deploy
 	}
 	if pod.LivenessProbe != nil {
 		livenessProbe = *pod.LivenessProbe
-	} else if bool(deployment.Web) || deployment.WebServices.Public.Enabled {
+	} else if deployment.WebServices.Public.Enabled {
 		livenessProbe = baseProbe
 	}
 	if pod.ReadinessProbe != nil {
 		readinessProbe = *pod.ReadinessProbe
-	} else if bool(deployment.Web) || deployment.WebServices.Public.Enabled {
+	} else if deployment.WebServices.Public.Enabled {
 		readinessProbe = baseProbe
 		readinessProbe.InitialDelaySeconds = 45
 	}
@@ -115,7 +115,7 @@ func initDeployment(app *crd.ClowdApp, env *crd.ClowdEnvironment, d *apps.Deploy
 	}
 
 	// TODO: THIS NEEDS TO GO IN SERVICE
-	if deployment.Web {
+	if deployment.WebServices.Public.Enabled {
 		c.Ports = append(c.Ports, core.ContainerPort{
 			Name:          "web",
 			ContainerPort: env.Spec.Providers.Web.Port,

--- a/controllers/cloud.redhat.com/providers/kafka/provider.go
+++ b/controllers/cloud.redhat.com/providers/kafka/provider.go
@@ -25,7 +25,6 @@ var CyndiHostInventoryAppSecret = p.NewSingleResourceIdent(ProvName, "cyndi_host
 
 // GetKafka returns the correct kafka provider based on the environment.
 func GetKafka(c *p.Provider) (p.ClowderProvider, error) {
-	c.Env.ConvertDeprecatedKafkaSpec()
 	kafkaMode := c.Env.Spec.Providers.Kafka.Mode
 	switch kafkaMode {
 	case "operator":

--- a/controllers/cloud.redhat.com/providers/kafka/strimzi.go
+++ b/controllers/cloud.redhat.com/providers/kafka/strimzi.go
@@ -388,10 +388,6 @@ func processTopicValues(
 
 	for _, iapp := range appList.Items {
 
-		if app.Spec.Pods != nil {
-			app.ConvertToNewShim()
-		}
-
 		if iapp.Spec.EnvName != app.Spec.EnvName {
 			// Only consider apps within this ClowdEnvironment
 			continue

--- a/controllers/cloud.redhat.com/providers/web/impl.go
+++ b/controllers/cloud.redhat.com/providers/web/impl.go
@@ -38,7 +38,7 @@ func (web *webProvider) makeService(deployment *crd.Deployment, app *crd.ClowdAp
 	containerPorts := []core.ContainerPort{}
 
 	appProtocol := "http"
-	if bool(deployment.Web) || deployment.WebServices.Public.Enabled {
+	if deployment.WebServices.Public.Enabled {
 		// Create the core service port
 		webPort := core.ServicePort{
 			Name:        "public",

--- a/controllers/cloud.redhat.com/run.go
+++ b/controllers/cloud.redhat.com/run.go
@@ -16,6 +16,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 var (
@@ -51,7 +52,7 @@ func init() {
 }
 
 // Run inits the manager and controllers and then starts the manager
-func Run(metricsAddr string, enableLeaderElection bool, config *rest.Config, signalHandler <-chan struct{}) {
+func Run(metricsAddr string, enableLeaderElection bool, config *rest.Config, signalHandler <-chan struct{}, enableWebHooks bool) {
 	setupLog.Info("Loaded config", "config", clowder_config.LoadedConfig)
 
 	mgr, err := ctrl.NewManager(config, ctrl.Options{
@@ -90,6 +91,29 @@ func Run(metricsAddr string, enableLeaderElection bool, config *rest.Config, sig
 		setupLog.Error(err, "unable to create controller", "controller", "ClowdJobInvocation")
 		os.Exit(1)
 	}
+
+	if enableWebHooks {
+		mgr.GetWebhookServer().Register(
+			"/mutate-app",
+			&webhook.Admission{
+				Handler: &mutantAnnotatorApp{
+					Client:   mgr.GetClient(),
+					Recorder: mgr.GetEventRecorderFor("app"),
+				},
+			},
+		)
+
+		mgr.GetWebhookServer().Register(
+			"/mutate-env",
+			&webhook.Admission{
+				Handler: &mutantAnnotatorEnv{
+					Client:   mgr.GetClient(),
+					Recorder: mgr.GetEventRecorderFor("env"),
+				},
+			},
+		)
+	}
+
 	// +kubebuilder:scaffold:builder
 
 	setupLog.Info("starting manager")

--- a/controllers/cloud.redhat.com/suite_test.go
+++ b/controllers/cloud.redhat.com/suite_test.go
@@ -106,7 +106,7 @@ func TestMain(m *testing.M) {
 	k8sClient.Create(ctx, nsSpec)
 
 	stopManager := make(chan struct{})
-	go Run(":8080", false, testEnv.Config, stopManager)
+	go Run(":8080", false, testEnv.Config, stopManager, false)
 
 	for i := 1; i <= 50; i++ {
 		resp, err := http.Get("http://localhost:8080/metrics")

--- a/main.go
+++ b/main.go
@@ -54,5 +54,5 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(false)))
 
-	controllers.Run(metricsAddr, enableLeaderElection, ctrl.GetConfigOrDie(), ctrl.SetupSignalHandler())
+	controllers.Run(metricsAddr, enableLeaderElection, ctrl.GetConfigOrDie(), ctrl.SetupSignalHandler(), true)
 }


### PR DESCRIPTION
* Currently there are several deprecated features of the spec these are dealt
  with by using certain shims in different places.
* This commit moves all of the 'shim' functionality to a mutating webhook
  so that specs are mutated on creation/edit and Clowder then only deals
  with the latest version of the three specs.
* In time, each shim deprecation will be removed from the webhook, but it is
  less costly to keep it than if it is polluting the codebase.
* kubesetup.sh has been midified to download and install the cert-manager
  required for the creation and security of the webhook endpoint
* Certain YAMLs have been tweaked to provide the mutating webhook endpoint
* All current mutations/shims have been removed from the controller itself.
* Tests have been added to assert the mutation.
* Some tests had a database image removed as it is no longer required.