### PR TITLE
Fix error when trying to get a deleted Job

### DIFF
--- a/controllers/cloud.redhat.com/clowdjobinvocation_controller.go
+++ b/controllers/cloud.redhat.com/clowdjobinvocation_controller.go
@@ -312,7 +312,12 @@ func (r *ClowdJobInvocationReconciler) cjiToEnqueueUponJobUpdate(a handler.MapOb
 
 	job := batchv1.Job{}
 	if err := r.Client.Get(ctx, obj, &job); err != nil {
+		if k8serr.IsNotFound(err) {
+			// Must have been deleted
+			return reqs
+		}
 		r.Log.Error(err, "Failed to fetch Job")
+		return nil
 	}
 
 	cjiList := crd.ClowdJobInvocationList{}


### PR DESCRIPTION
* Fixes a bug where CronJobs are causing reconciliations because the ClowdJob controller is watching them. It expects the job name to be there and will error if it does not.
* `{"level":"error","ts":1618516894.2577295,"logger":"controllers.ClowdJobInvocation","msg":"Failed to fetch Job","error":"Job.batch \"crd-pruner-1618506000\" not found"`
* The above entry no longer exists and is causing errors