### PR TITLE
Fix api-docs formatting

### DIFF
--- a/build/build_config_docs.sh
+++ b/build/build_config_docs.sh
@@ -9,7 +9,7 @@ if [ ! -f docs/build/node_modules/.bin/jsonschema2md ]; then
 	if [ ! -d node_modules ]; then
 		mkdir node_modules
 	fi
-	npm install @adobe/jsonschema2md
+	npm install @adobe/jsonschema2md@4.2.2
 	cd -
 fi
 


### PR DESCRIPTION
* enforces install of version 4.2.2 of jsonschema2md to preserve formatting and fix list item errors