### PR TITLE
Setup iqe jobs to only use a single service account

### DIFF
--- a/bundle/tests/scorecard/kuttl/test-iqe-jobs/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-iqe-jobs/01-assert.yaml
@@ -56,13 +56,13 @@ type: Opaque
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: host-inventory-smoke-iqe
+  name: iqe-test-iqe-jobs
   namespace: test-iqe-jobs
 ---
 apiVersion: rbac.authorization.k8s.io/v1 
 kind: RoleBinding 
 metadata:
-  name: host-inventory-smoke-iqe
+  name: iqe-test-iqe-jobs
   namespace: test-iqe-jobs
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -70,5 +70,5 @@ roleRef:
   name: edit
 subjects:
 - kind: ServiceAccount
-  name: host-inventory-smoke-iqe
+  name: iqe-test-iqe-jobs
   namespace: test-iqe-jobs

--- a/controllers/cloud.redhat.com/providers/serviceaccount/provider.go
+++ b/controllers/cloud.redhat.com/providers/serviceaccount/provider.go
@@ -21,6 +21,12 @@ var CoreAppServiceAccount = providers.NewSingleResourceIdent(ProvName, "core_app
 // CoreEnvServiceAccount is the serviceaccount for the env.
 var CoreEnvServiceAccount = providers.NewSingleResourceIdent(ProvName, "core_env_service_account", &core.ServiceAccount{})
 
+// CoreEnvServiceAccount is the serviceaccount for the env.
+var IQEServiceAccount = providers.NewMultiResourceIdent(ProvName, "iqe_service_account", &core.ServiceAccount{})
+
+// CoreEnvServiceAccount is the serviceaccount for the env.
+var IQERoleBinding = providers.NewMultiResourceIdent(ProvName, "iqe_role_binding", &core.ServiceAccount{})
+
 // GetEnd returns the correct end provider.
 func GetServiceAccount(c *providers.Provider) (providers.ClowderProvider, error) {
 	return NewServiceAccountProvider(c)


### PR DESCRIPTION
* Uses https://github.com/RedHatInsights/clowder/pull/304/commits/bd75295a07bb68ad1d950bb336c0fb266304ae18 from Pete's NamespacedName PR #304 
* Reuses the ClowdEnv defined ServiceAccount for IQE.
* Fixes test names that were mapped to outdated Rolebindings and ServiceAccounts 