### PR TITLE
Add support for postgresql 13 in local db provider

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
@@ -48,7 +48,7 @@ type InitContainer struct {
 // DatabaseSpec is a struct defining a database to be exposed to a ClowdApp.
 type DatabaseSpec struct {
 	// Defines the Version of the PostGreSQL database, defaults to 12.
-	// +kubebuilder:validation:Enum:=10;12
+	// +kubebuilder:validation:Enum:=10;12;13
 	Version *int32 `json:"version,omitempty"`
 
 	// Defines the Name of the database to be created. This will be used as the

--- a/config/crd/bases/cloud.redhat.com_clowdapps.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdapps.yaml
@@ -91,6 +91,7 @@ spec:
                   enum:
                   - 10
                   - 12
+                  - 13
                   format: int32
                   type: integer
               type: object

--- a/controllers/cloud.redhat.com/providers/database/provider.go
+++ b/controllers/cloud.redhat.com/providers/database/provider.go
@@ -32,6 +32,7 @@ func GetDatabase(c *p.Provider) (p.ClowderProvider, error) {
 func init() {
 	p.ProvidersRegistration.Register(GetDatabase, 5, ProvName)
 	imageList = map[int32]string{
+		13: "quay.io/cloudservices/postgresql-rds:13-1",
 		12: "quay.io/cloudservices/postgresql-rds:12-1",
 		10: "quay.io/cloudservices/postgresql-rds:10-1",
 	}


### PR DESCRIPTION
* Configures Clowder to use the Postgresql 13 database image if requested
* Closes [RHCLOUD-13938](https://issues.redhat.com/browse/RHCLOUD-13938)