### PR TITLE
Default kafka cluster name to env name

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
@@ -83,7 +83,7 @@ type KafkaMode string
 // KafkaClusterConfig defines options related to the Kafka cluster managed/monitored by Clowder
 type KafkaClusterConfig struct {
 	// Defines the kafka cluster name
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// The namespace the kafka cluster is expected to reside in (default: the environment's targetNamespace)
 	Namespace string `json:"namespace,omitempty"`

--- a/bundle/tests/scorecard/kuttl/test-kafka-strimzi-topic-auth/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-kafka-strimzi-topic-auth/01-assert.yaml
@@ -23,7 +23,7 @@ kind: KafkaTopic
 metadata:
   labels:
     env: test-kafka-strimzi-topic-auth
-    strimzi.io/cluster: my-cluster
+    strimzi.io/cluster: test-kafka-strimzi-topic-auth
   name: topicone-test-kafka-strimzi-topic-auth-test-kafka-strimzi-topic-auth
   namespace: test-kafka-strimzi-topic-auth-kafka
   ownerReferences:
@@ -39,7 +39,7 @@ kind: KafkaTopic
 metadata:
   labels:
     env: test-kafka-strimzi-topic-auth
-    strimzi.io/cluster: my-cluster
+    strimzi.io/cluster: test-kafka-strimzi-topic-auth
   name: topictwo-test-kafka-strimzi-topic-auth-test-kafka-strimzi-topic-auth
   namespace: test-kafka-strimzi-topic-auth-kafka
   ownerReferences:
@@ -55,7 +55,7 @@ kind: KafkaTopic
 metadata:
   labels:
     env: test-kafka-strimzi-topic-auth
-    strimzi.io/cluster: my-cluster
+    strimzi.io/cluster: test-kafka-strimzi-topic-auth
   name: topicthree-test-kafka-strimzi-topic-auth-test-kafka-strimzi-topic-auth
   namespace: test-kafka-strimzi-topic-auth-kafka
   ownerReferences:
@@ -71,7 +71,7 @@ kind: KafkaUser
 metadata:
   labels:
     app: test-kafka-strimzi-topic-auth
-    strimzi.io/cluster: my-cluster
+    strimzi.io/cluster: test-kafka-strimzi-topic-auth
   name: test-kafka-strimzi-topic-auth-puptoo
   namespace: test-kafka-strimzi-topic-auth-kafka
   ownerReferences:
@@ -108,7 +108,7 @@ kind: KafkaUser
 metadata:
   labels:
     app: test-kafka-strimzi-topic-auth
-    strimzi.io/cluster: my-cluster
+    strimzi.io/cluster: test-kafka-strimzi-topic-auth
   name: test-kafka-strimzi-topic-auth-puptoo-two
   namespace: test-kafka-strimzi-topic-auth-kafka
   ownerReferences:

--- a/bundle/tests/scorecard/kuttl/test-kafka-strimzi-topic-auth/01-pods.yaml
+++ b/bundle/tests/scorecard/kuttl/test-kafka-strimzi-topic-auth/01-pods.yaml
@@ -15,7 +15,6 @@ spec:
       path: "/metrics"
     kafka:
       cluster:
-        name: my-cluster
         namespace: test-kafka-strimzi-topic-auth-kafka
       mode: operator
     db:

--- a/bundle/tests/scorecard/kuttl/test-kafka-strimzi-topic-auth/02-json-asserts.yaml
+++ b/bundle/tests/scorecard/kuttl/test-kafka-strimzi-topic-auth/02-json-asserts.yaml
@@ -6,6 +6,6 @@ commands:
 - script: kubectl get secret --namespace=test-kafka-strimzi-topic-auth puptoo -o json > /tmp/test-kafka-strimzi-topic-auth
 - script: jq -r '.data["cdappconfig.json"]' < /tmp/test-kafka-strimzi-topic-auth | base64 -d > /tmp/test-kafka-strimzi-topic-auth-json
 
-- script: jq -r '.kafka.brokers[0].hostname == "my-cluster-kafka-bootstrap.test-kafka-strimzi-topic-auth-kafka.svc"' -e < /tmp/test-kafka-strimzi-topic-auth-json
+- script: jq -r '.kafka.brokers[0].hostname == "test-kafka-strimzi-topic-auth-kafka-bootstrap.test-kafka-strimzi-topic-auth-kafka.svc"' -e < /tmp/test-kafka-strimzi-topic-auth-json
 - script: jq -r '.kafka.brokers[0].port == 9093' -e < /tmp/test-kafka-strimzi-topic-auth-json
 - script: jq -r '.kafka.brokers[0].sasl.username == "test-kafka-strimzi-topic-auth-puptoo"' -e < /tmp/test-kafka-strimzi-topic-auth-json

--- a/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
@@ -206,8 +206,6 @@ spec:
                         version:
                           description: Version. If unset, default is '2.5.0'
                           type: string
-                      required:
-                      - name
                       type: object
                     clusterName:
                       description: (Deprecated) Defines the cluster name to be used

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: 127.0.0.1:5000/clowder
-  newTag: 7af0d5f6
+  newTag: d778ee9

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: 127.0.0.1:5000/clowder
-  newTag: d778ee9
+  newTag: 7af0d5f6

--- a/controllers/cloud.redhat.com/providers/kafka/provider.go
+++ b/controllers/cloud.redhat.com/providers/kafka/provider.go
@@ -71,7 +71,7 @@ func getConnectNamespace(env *crd.ClowdEnvironment) string {
 
 func getConnectClusterName(env *crd.ClowdEnvironment) string {
 	if env.Spec.Providers.Kafka.Connect.Name == "" {
-		return fmt.Sprintf("%s-connect", env.Spec.Providers.Kafka.Cluster.Name)
+		return fmt.Sprintf("%s-connect", getKafkaName(env))
 	}
 	return env.Spec.Providers.Kafka.Connect.Name
 }

--- a/controllers/cloud.redhat.com/providers/kafka/provider.go
+++ b/controllers/cloud.redhat.com/providers/kafka/provider.go
@@ -48,6 +48,13 @@ func getKafkaUsername(env *crd.ClowdEnvironment, app *crd.ClowdApp) string {
 	return fmt.Sprintf("%s-%s", env.Name, app.Name)
 }
 
+func getKafkaName(e *crd.ClowdEnvironment) string {
+	if e.Spec.Providers.Kafka.Cluster.Name == "" {
+		return e.Name
+	}
+	return e.Spec.Providers.Kafka.Cluster.Name
+}
+
 func getKafkaNamespace(e *crd.ClowdEnvironment) string {
 	if e.Spec.Providers.Kafka.Cluster.Namespace == "" {
 		return e.Status.TargetNamespace

--- a/controllers/cloud.redhat.com/providers/kafka/strimzi.go
+++ b/controllers/cloud.redhat.com/providers/kafka/strimzi.go
@@ -658,7 +658,7 @@ func (s *strimziProvider) processTopics(app *crd.ClowdApp) error {
 
 		topicName := fmt.Sprintf("%s-%s-%s", topic.TopicName, s.Env.Name, nn.Namespace)
 		knn := types.NamespacedName{
-			Namespace: getKafkaName(s.Env),
+			Namespace: getKafkaNamespace(s.Env),
 			Name:      topicName,
 		}
 


### PR DESCRIPTION
If the kafka cluster name is not specified in the env spec, then name
the cluster the same as the environment.