### PR TITLE
WIP: Add 'debug' flag for ClowdJobInvocation

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdjobinvocation_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdjobinvocation_types.go
@@ -60,6 +60,12 @@ type ClowdJobInvocationSpec struct {
 
 	// Testing is the struct for building out test jobs (iqe, etc) in a CJI
 	Testing JobTestingSpec `json:"testing,omitempty"`
+
+	// invokes the job pods in "debug" mode -- i.e., command is swapped to the debugCommand
+	Debug bool `json:"debug,omitempty"`
+
+	// indicates pod command to run when in debug mode (default: "/bin/sh -c 'while true; do sleep 1; done'")
+	DebugCommand []string `json:"debugCommand,omitempty"`
 }
 
 // ClowdJobInvocationStatus defines the observed state of ClowdJobInvocation

--- a/bundle/tests/scorecard/kuttl/test-clowder-debug-job/00-install.yaml
+++ b/bundle/tests/scorecard/kuttl/test-clowder-debug-job/00-install.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-clowder-debug-job
+spec:
+  finalizers:
+  - kubernetes

--- a/bundle/tests/scorecard/kuttl/test-clowder-debug-job/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-clowder-debug-job/01-assert.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: puptoo
+  namespace: test-clowder-debug-job
+  labels:
+    app: puptoo
+  ownerReferences:
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdApp
+    name: puptoo
+type: Opaque
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: puptoo-processor
+  namespace: test-clowder-debug-job
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: puptoo-standard-cron
+  namespace: test-clowder-debug-job
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: puptoo-standard-cron
+              image: quay.io/psav/clowder-hello
+          restartPolicy: Never
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: puptoo-restart-on-failure
+  namespace: test-clowder-debug-job
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: puptoo-restart-on-failure
+              image: quay.io/psav/clowder-hello
+          restartPolicy: OnFailure
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: puptoo-hello-cji-runner
+  namespace: test-clowder-debug-job
+spec:
+  restartPolicy: Never
+  template:
+    spec:
+      containers:
+        - name: puptoo-hello-cji-runner-debug
+          image: busybox
+          command:
+          - "/bin/sh"
+          - "-c"
+          - "while true; do sleep 1; done"
+      initContainers: []

--- a/bundle/tests/scorecard/kuttl/test-clowder-debug-job/01-pods.yaml
+++ b/bundle/tests/scorecard/kuttl/test-clowder-debug-job/01-pods.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdEnvironment
+metadata:
+  name: ttest-clowder-debug-job
+spec:
+  targetNamespace: ttest-clowder-debug-job
+  providers:
+    web:
+      port: 8000
+      mode: operator
+    metrics:
+      port: 9000
+      mode: operator
+      path: "/metrics"
+    kafka:
+      mode: none
+    db:
+      mode: none
+    logging:
+      mode: none
+    objectStore:
+      mode: none
+    inMemoryDb:
+      mode: none
+    featureFlags:
+      mode: none
+  resourceDefaults:
+    limits:
+      cpu: 400m
+      memory: 1024Mi
+    requests:
+      cpu: 30m
+      memory: 512Mi
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: puptoo
+  namespace: ttest-clowder-debug-job
+spec:
+  envName: ttest-clowder-debug-job
+  deployments:
+    - name: processor
+      podSpec:
+        image: quay.io/psav/clowder-hello
+  jobs:
+    - name: standard-cron
+      schedule: "*/1 * * * *"
+      podSpec:
+        image: quay.io/psav/clowder-hello
+        args:
+          - ./clowder-hello
+          - boo
+    - name: restart-on-failure 
+      schedule: "*/1 * * * *"
+      restartPolicy: OnFailure
+      podSpec:
+        image: quay.io/psav/clowder-hello
+        args:
+          - ./clowder-hello
+          - boo
+    - name: hello-cji
+      podSpec:
+        initContainers:
+        - name: foo
+          command: "i shouldn't be here in debug mode"
+        image: busybox
+        args:
+        - /bin/sh
+        - -c
+        - echo "Hello!"
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdJobInvocation
+metadata:
+  name: runner
+  namespace: ttest-clowder-debug-job
+spec:
+  debug: true
+  appName: puptoo
+  jobs:
+    - hello-cji

--- a/bundle/tests/scorecard/kuttl/test-clowder-debug-job/03-delete.yaml
+++ b/bundle/tests/scorecard/kuttl/test-clowder-debug-job/03-delete.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: v1
+  kind: Namespace
+  name: ttest-clowder-debug-job
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdEnvironment
+  name: ttest-clowder-debug-job

--- a/bundle/tests/scorecard/kuttl/test-iqe-debug-job/00-install.yaml
+++ b/bundle/tests/scorecard/kuttl/test-iqe-debug-job/00-install.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-iqe-debug-job
+spec:
+  finalizers:
+  - kubernetes

--- a/bundle/tests/scorecard/kuttl/test-iqe-debug-job/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-iqe-debug-job/01-assert.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: host-inventory 
+  namespace: test-iqe-debug-job 
+  labels:
+    app: host-inventory
+  ownerReferences:
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdApp
+    name: host-inventory
+type: Opaque
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: host-inventory-service
+  namespace: test-iqe-debug-job 
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: host-inventory-smoke-iqe
+  namespace: test-iqe-debug-job 
+spec:
+  restartPolicy: Never
+  template:
+    spec:
+      containers:
+        - name: host-inventory-smoke-iqe-debug
+          image: quay.io/psav/clowder-hello:latest
+          command:
+          - "/bin/foo"
+          - "bar"
+          resources:
+            limits:
+              cpu: "2"
+              memory: 600Mi
+            requests:
+              cpu: 200m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: host-inventory-smoke-iqe
+  namespace: test-iqe-debug-job 
+type: Opaque
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: iqe-test-iqe-debug-job
+  namespace: test-iqe-debug-job
+---
+apiVersion: rbac.authorization.k8s.io/v1 
+kind: RoleBinding 
+metadata:
+  name: iqe-test-iqe-debug-job
+  namespace: test-iqe-debug-job
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: edit
+subjects:
+- kind: ServiceAccount
+  name: iqe-test-iqe-debug-job
+  namespace: test-iqe-debug-job

--- a/bundle/tests/scorecard/kuttl/test-iqe-debug-job/01-pods.yaml
+++ b/bundle/tests/scorecard/kuttl/test-iqe-debug-job/01-pods.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdEnvironment
+metadata:
+  name: test-iqe-debug-job
+spec:
+  targetNamespace: test-iqe-debug-job
+  providers:
+    testing:
+      # Level of access this pod has in the namespace
+      k8sAccessLevel: edit
+      # gather configuraiton for the specified environment
+      configAccess: environment
+      iqe:
+        # Base image for iqe-tests
+        imageBase: "quay.io/psav/clowder-hello"
+        resources:
+          limits:
+            cpu: 2
+            memory: 600Mi
+          requests:
+            cpu: 200m
+            memory: 256Mi
+    web:
+      port: 8000
+      mode: operator
+    metrics:
+      port: 9000
+      mode: operator
+      path: "/metrics"
+    kafka:
+      mode: none
+    db:
+      mode: none
+    logging:
+      mode: none
+    objectStore:
+      mode: none
+    inMemoryDb:
+      mode: none
+    featureFlags:
+      mode: none
+  resourceDefaults:
+    limits:
+      cpu: 400m
+      memory: 1024Mi
+    requests:
+      cpu: 30m
+      memory: 512Mi
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: host-inventory
+  namespace: test-iqe-debug-job
+spec:
+  testing:
+    iqePlugin: host-inventory 
+  envName: test-iqe-debug-job
+  deployments:
+    - name: service
+      podSpec:
+        image: quay.io/psav/clowder-hello
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdJobInvocation
+metadata:
+  name: host-inventory-smoke 
+  namespace: test-iqe-debug-job
+spec:
+  debug: true
+  debugCommand:
+  - "/bin/foo"
+  - "bar"
+  appName: host-inventory
+  testing:
+    iqe:
+      imageTag: latest
+      ui:
+        enabled: false
+      marker: "smoke"
+      dynaconfEnvName: "clowder_smoke"
+      filter: "test_plugin_accessible"

--- a/bundle/tests/scorecard/kuttl/test-iqe-debug-job/02-delete.yaml
+++ b/bundle/tests/scorecard/kuttl/test-iqe-debug-job/02-delete.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: v1
+  kind: Namespace
+  name: test-iqe-debug-job
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdEnvironment
+  name: test-iqe-debug-job

--- a/controllers/cloud.redhat.com/providers/iqe/impl.go
+++ b/controllers/cloud.redhat.com/providers/iqe/impl.go
@@ -75,6 +75,15 @@ func CreateIqeJobResource(cache *providers.ObjectCache, cji *crd.ClowdJobInvocat
 		ImagePullPolicy: core.PullAlways,
 	}
 
+	if cji.Spec.Debug {
+		c.Name = fmt.Sprintf("%s-debug", nn.Name)
+		c.Command = []string{"/bin/sh", "-c", "while true; do sleep 1; done"}
+		if len(cji.Spec.DebugCommand) > 0 {
+			c.Command = cji.Spec.DebugCommand
+		}
+		c.Args = []string{}
+	}
+
 	j.Spec.Template.Spec.Volumes = []core.Volume{}
 	configAccess := env.Spec.Providers.Testing.ConfigAccess
 
@@ -130,6 +139,7 @@ func ConstructIqeCommand(cji *crd.ClowdJobInvocation, plugin string) ([]string, 
 	if plugin == "" {
 		return []string{}, errors.New("iqe-plugin is missing from ClowdApp")
 	}
+
 	command := []string{
 		"iqe", "tests", "plugin",
 		fmt.Sprintf("%v", strings.ReplaceAll(plugin, "-", "_")),


### PR DESCRIPTION
The goal here is to get a pod spun up in the namespace that uses the config of a ClowdJob -- but does not actually run the ClowdJob (so that you can rsh into it and debug)

* Adds 'debug' and 'debugCommand' to ClowdJobInvocation spec
* If CJI is applied with 'debug'=true, a few things happen:
** command of the pod is swapped to debugCommand (by default this is `/bin/sh -c 'while true; do sleep 1; done'`)
** initContainers will not be applied in the podSpec
** pod restart policy is set to `Never`
** name of the container in the job's podSpec will have `-debug` appended to the end