### PR TITLE
Convert IQE CJI to use iqe-core image's entrypoint command

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdjobinvocation_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdjobinvocation_types.go
@@ -43,6 +43,8 @@ type IqeJobSpec struct {
 	DynaconfEnvName string `json:"dynaconfEnvName"`
 	// sets pytest -k args
 	Filter string `json:"filter,omitempty"`
+	// used when desiring to run `oc debug`on the Job to cause pod to immediately & gracefully exit
+	Debug bool `json:"debug,omitempty"`
 }
 
 type UiSpec struct {

--- a/bundle/tests/scorecard/kuttl/test-iqe-jobs/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-iqe-jobs/01-assert.yaml
@@ -42,6 +42,8 @@ spec:
               value: "smoke"
             - name: IQE_FILTER_EXPRESSION
               value: "test_plugin_accessible"
+            - name: CLOWDER_ENABLED
+              value: "true"
           resources:
             limits:
               cpu: "2"

--- a/bundle/tests/scorecard/kuttl/test-iqe-jobs/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-iqe-jobs/01-assert.yaml
@@ -29,15 +29,19 @@ spec:
       containers:
         - name: host-inventory-smoke-iqe
           image: quay.io/psav/clowder-hello:latest
-          command:
-          - "iqe"
-          - "tests"
-          - "plugin"
-          - "host_inventory"
-          - "-m"
-          - "smoke"
-          - "-k"
-          - "test_plugin_accessible"
+          env:
+            - name: "ENV_FOR_DYNACONF"
+              value: clowder_smoke
+            - name: "NAMESPACE"
+              value: test-iqe-jobs
+            - name: IQE_DEBUG_POD
+              value: "false"
+            - name: IQE_PLUGINS
+              value: "host-inventory"
+            - name: IQE_MARKER_EXPRESSION
+              value: "smoke"
+            - name: IQE_FILTER_EXPRESSION
+              value: "test_plugin_accessible"
           resources:
             limits:
               cpu: "2"

--- a/bundle/tests/scorecard/kuttl/test-iqe-jobs/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-iqe-jobs/01-assert.yaml
@@ -34,6 +34,8 @@ spec:
               value: clowder_smoke
             - name: "NAMESPACE"
               value: test-iqe-jobs
+            - name: CLOWDER_ENABLED
+              value: "true"
             - name: IQE_DEBUG_POD
               value: "false"
             - name: IQE_PLUGINS
@@ -42,8 +44,6 @@ spec:
               value: "smoke"
             - name: IQE_FILTER_EXPRESSION
               value: "test_plugin_accessible"
-            - name: CLOWDER_ENABLED
-              value: "true"
           resources:
             limits:
               cpu: "2"

--- a/controllers/cloud.redhat.com/providers/iqe/impl.go
+++ b/controllers/cloud.redhat.com/providers/iqe/impl.go
@@ -42,6 +42,7 @@ func CreateIqeJobResource(cache *providers.ObjectCache, cji *crd.ClowdJobInvocat
 	envvar := []core.EnvVar{
 		{Name: "ENV_FOR_DYNACONF", Value: cji.Spec.Testing.Iqe.DynaconfEnvName},
 		{Name: "NAMESPACE", Value: nn.Namespace},
+		{Name: "CLOWDER_ENABLED", Value: "true"},
 		{Name: "IQE_DEBUG_POD", Value: strconv.FormatBool(cji.Spec.Testing.Iqe.Debug)},
 		{Name: "IQE_PLUGINS", Value: app.Spec.Testing.IqePlugin},
 		{Name: "IQE_MARKER_EXPRESSION", Value: cji.Spec.Testing.Iqe.Marker},


### PR DESCRIPTION
* Don't set a command on the pod, use the iqe-tests image's entrypoint
* Pass marker/filter/etc. as env vars to the container
* Add 'debug: true' to the IqeSpec which will tell the iqe runner to sleep infinitely (so that tests do not run and you can run `oc rsh` to get into the IQE pod and debug/troubleshoot)

Goes along with https://gitlab.cee.redhat.com/insights-qe/iqe-dockerfiles/-/merge_requests/59 and https://gitlab.cee.redhat.com/insights-qe/iqe-dockerfiles/-/merge_requests/61