### PR TITLE
Use `minikube kubectl` in kube_setup.sh

### DIFF
--- a/build/kube_setup.sh
+++ b/build/kube_setup.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
+# Configures a local minikube cluster for testing.
 set -e
-
-# Script you can use to set up a local minikube cluster for testing
-# It is assumed you have already run 'minikube start' and your kubectl context is using the minikube cluster
 
 REINSTALL=0
 
@@ -36,6 +34,18 @@ if ! command -v go; then
     exit 1
 fi
 
+# kubectl is required for interactions with the cluster.
+if [ -n "${KUBECTL_CMD}" ]; then
+    :  # already set via env var
+elif command -v kubectl; then
+    KUBECTL_CMD=kubectl
+elif command -v minikube; then
+    KUBECTL_CMD='minikube kubectl --'
+else
+    echo "*** 'kubectl' not found in path. Please install it or minikube, or set KUBECTL_CMD"
+    exit 1
+fi
+
 
 GO_BIN_PATH="$(go env GOPATH)/bin"
 
@@ -62,7 +72,7 @@ function install_strimzi_operator {
     STRIMZI_TARFILE="strimzi-${STRIMZI_VERSION}.tar.gz"
 
     if [ $REINSTALL -ne 1 ]; then
-        STRIMZI_DEPLOYMENT=$(kubectl get deployment strimzi-cluster-operator -n $STRIMZI_OPERATOR_NS --ignore-not-found -o jsonpath='{.metadata.name}')
+        STRIMZI_DEPLOYMENT=$(${KUBECTL_CMD} get deployment strimzi-cluster-operator -n $STRIMZI_OPERATOR_NS --ignore-not-found -o jsonpath='{.metadata.name}')
         if [ ! -z "$STRIMZI_DEPLOYMENT" ]; then
             echo "*** Strimzi operator deployment found, skipping install ..."
             return 0
@@ -92,27 +102,27 @@ function install_strimzi_operator {
 
     echo "*** Creating ns ${STRIMZI_OPERATOR_NS}..."
     # if we hit an error, assumption is the Namespace already exists
-    kubectl create namespace $STRIMZI_OPERATOR_NS || echo " ... ignoring that error"
+    ${KUBECTL_CMD} create namespace $STRIMZI_OPERATOR_NS || echo " ... ignoring that error"
 
     echo "*** Adding cluster-wide RoleBindings for Strimzi ..."
     # if we hit an error, assumption is the ClusterRoleBinding already exists
-    kubectl create clusterrolebinding strimzi-cluster-operator-namespaced \
+    ${KUBECTL_CMD} create clusterrolebinding strimzi-cluster-operator-namespaced \
         --clusterrole=strimzi-cluster-operator-namespaced --serviceaccount ${STRIMZI_OPERATOR_NS}:strimzi-cluster-operator || echo " ... ignoring that error"
-    kubectl create clusterrolebinding strimzi-cluster-operator-entity-operator-delegation \
+    ${KUBECTL_CMD} create clusterrolebinding strimzi-cluster-operator-entity-operator-delegation \
         --clusterrole=strimzi-entity-operator --serviceaccount ${STRIMZI_OPERATOR_NS}:strimzi-cluster-operator || echo " ... ignoring that error"
-    kubectl create clusterrolebinding strimzi-cluster-operator-topic-operator-delegation \
+    ${KUBECTL_CMD} create clusterrolebinding strimzi-cluster-operator-topic-operator-delegation \
         --clusterrole=strimzi-topic-operator --serviceaccount ${STRIMZI_OPERATOR_NS}:strimzi-cluster-operator || echo " ... ignoring that error"
 
     if [ $REINSTALL -ne 1 ]; then
         echo "*** Installing Strimzi resources ..."
-        kubectl create -f . -n $STRIMZI_OPERATOR_NS
+        ${KUBECTL_CMD} create -f . -n $STRIMZI_OPERATOR_NS
     else
         echo "*** Replacing Strimzi resources ..."
-        kubectl replace -f . -n $STRIMZI_OPERATOR_NS
+        ${KUBECTL_CMD} replace -f . -n $STRIMZI_OPERATOR_NS
     fi
 
     echo "*** Will wait for Strimzi operator to come up in background"
-    kubectl rollout status deployment/strimzi-cluster-operator -n $STRIMZI_OPERATOR_NS | sed "s/^/[strimzi] /" &
+    ${KUBECTL_CMD} rollout status deployment/strimzi-cluster-operator -n $STRIMZI_OPERATOR_NS | sed "s/^/[strimzi] /" &
     BG_PIDS+=($!)
 
     cd "$ROOT_DIR"
@@ -128,10 +138,10 @@ function install_cert_manager {
     curl -LsSO https://github.com/jetstack/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
 
     echo "*** Installing Cert Manager resources ..."
-    kubectl apply -f cert-manager.yaml
+    ${KUBECTL_CMD} apply -f cert-manager.yaml
 
     echo "*** Will wait for cert manager to come up in background"
-    kubectl rollout status deployment/cert-manager -n cert-manager | sed "s/^/[cert-manager] /" &
+    ${KUBECTL_CMD} rollout status deployment/cert-manager -n cert-manager | sed "s/^/[cert-manager] /" &
     BG_PIDS+=($!)
 
     cd "$ROOT_DIR"
@@ -143,7 +153,7 @@ function install_prometheus_operator {
     PROM_TARFILE="prometheus-operator-${PROM_VERSION}.tar.gz"
 
     if [ $REINSTALL -ne 1 ]; then
-        PROM_DEPLOYMENT=$(kubectl get deployment prometheus-operator -n $PROM_OPERATOR_NS --ignore-not-found -o jsonpath='{.metadata.name}')
+        PROM_DEPLOYMENT=$(${KUBECTL_CMD} get deployment prometheus-operator -n $PROM_OPERATOR_NS --ignore-not-found -o jsonpath='{.metadata.name}')
         if [ ! -z "$PROM_DEPLOYMENT" ]; then
             echo "*** Prometheus operator deployment found, skipping install ..."
             return 0
@@ -163,10 +173,10 @@ function install_prometheus_operator {
 
     echo "*** Applying prometheus operator manifest ..."
     cd prometheus-operator-${PROM_VERSION}
-    kubectl apply -f bundle.yaml
+    ${KUBECTL_CMD} apply -f bundle.yaml
 
     echo "*** Will wait for Prometheus operator to come up in background"
-    kubectl rollout status deployment/prometheus-operator -n $PROM_OPERATOR_NS | sed "s/^/[prometheus] /" &
+    ${KUBECTL_CMD} rollout status deployment/prometheus-operator -n $PROM_OPERATOR_NS | sed "s/^/[prometheus] /" &
     BG_PIDS+=($!)
 
     cd "$ROOT_DIR"
@@ -178,7 +188,7 @@ function install_cyndi_operator {
     DEPLOYMENT=cyndi-operator-controller-manager
 
     if [ $REINSTALL -ne 1 ]; then
-        OPERATOR_DEPLOYMENT=$(kubectl get deployment $DEPLOYMENT -n $OPERATOR_NS --ignore-not-found -o jsonpath='{.metadata.name}')
+        OPERATOR_DEPLOYMENT=$(${KUBECTL_CMD} get deployment $DEPLOYMENT -n $OPERATOR_NS --ignore-not-found -o jsonpath='{.metadata.name}')
         if [ ! -z "$OPERATOR_DEPLOYMENT" ]; then
             echo "*** cyndi-operator deployment found, skipping install ..."
             return 0
@@ -194,10 +204,10 @@ function install_cyndi_operator {
     curl -LsS $LATEST_MANIFEST -o cyndi-operator-manifest.yaml
 
     echo "*** Applying cyndi-operator manifest ..."
-    kubectl apply -f cyndi-operator-manifest.yaml
+    ${KUBECTL_CMD} apply -f cyndi-operator-manifest.yaml
 
     echo "*** Will wait for cyndi-operator to come up in background"
-    kubectl rollout status deployment/$DEPLOYMENT -n $OPERATOR_NS | sed "s/^/[cyndi-operator] /" &
+    ${KUBECTL_CMD} rollout status deployment/$DEPLOYMENT -n $OPERATOR_NS | sed "s/^/[cyndi-operator] /" &
     BG_PIDS+=($!)
 
     cd "$ROOT_DIR"
@@ -208,7 +218,7 @@ function install_xjoin_operator {
     DEPLOYMENT=xjoin-operator-controller-manager
 
     if [ $REINSTALL -ne 1 ]; then
-        OPERATOR_DEPLOYMENT=$(kubectl get deployment $DEPLOYMENT -n $OPERATOR_NS --ignore-not-found -o jsonpath='{.metadata.name}')
+        OPERATOR_DEPLOYMENT=$(${KUBECTL_CMD} get deployment $DEPLOYMENT -n $OPERATOR_NS --ignore-not-found -o jsonpath='{.metadata.name}')
         if [ ! -z "$OPERATOR_DEPLOYMENT" ]; then
             echo "*** xjoin-operator deployment found, skipping install ..."
             return 0
@@ -224,10 +234,10 @@ function install_xjoin_operator {
     curl -LsS $LATEST_MANIFEST -o xjoin-operator-manifest.yaml
 
     echo "*** Applying xjoin-operator manifest ..."
-    kubectl apply -f xjoin-operator-manifest.yaml
+    ${KUBECTL_CMD} apply -f xjoin-operator-manifest.yaml
 
     echo "*** Will wait for xjoin-operator to come up in background"
-    kubectl rollout status deployment/$DEPLOYMENT -n $OPERATOR_NS | sed "s/^/[xjoin-operator] /" &
+    ${KUBECTL_CMD} rollout status deployment/$DEPLOYMENT -n $OPERATOR_NS | sed "s/^/[xjoin-operator] /" &
     BG_PIDS+=($!)
 
     cd "$ROOT_DIR"
@@ -238,7 +248,7 @@ function install_elasticsearch_operator {
     POD=elastic-operator-0
 
     if [ $REINSTALL -ne 1 ]; then
-        OPERATOR_POD=$(kubectl get pod $POD -n $OPERATOR_NS --ignore-not-found -o jsonpath='{.metadata.name}')
+        OPERATOR_POD=$(${KUBECTL_CMD} get pod $POD -n $OPERATOR_NS --ignore-not-found -o jsonpath='{.metadata.name}')
         if [ ! -z "$OPERATOR_POD" ]; then
             echo "*** elastic-operator-0 pod found, skipping install ..."
             return 0
@@ -246,10 +256,10 @@ function install_elasticsearch_operator {
     fi
 
     echo "*** Applying elastic-operator manifest ..."
-    kubectl apply -f https://download.elastic.co/downloads/eck/1.6.0/all-in-one.yaml
+    ${KUBECTL_CMD} apply -f https://download.elastic.co/downloads/eck/1.6.0/all-in-one.yaml
 
     echo "*** Will wait for elastic-operator to come up in background"
-    kubectl wait pods/$POD --for=condition=Ready --timeout=150s -n "$OPERATOR_NS" &
+    ${KUBECTL_CMD} wait pods/$POD --for=condition=Ready --timeout=150s -n "$OPERATOR_NS" &
     BG_PIDS+=($!)
 
     cd "$ROOT_DIR"


### PR DESCRIPTION
By default, use `minikube kubectl` instead of `kubectl` in
`build/kube_setup.sh`. This removes a dependency, as users no longer
need to install kubectl system-wide in order to use the script. Users
who wish to use the system-wide kubectl may still do so with little
effort.