### PR TITLE
README format fix

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -102,14 +102,16 @@ minikube config set vm-driver kvm2
 If you encounter any kvm issues, please take a look 
 xref:docs/antora/modules/ROOT/pages/developer-guide.adoc[at the troubleshooting guide]
 
-The ``kube_setup.sh``` script then need to be run by invoking
+The ``kube_setup.sh`` script then needs to be run by invoking
 
 [source,shell]
+....
 ./build/kube_setup.sh
+....
 
 Clowder can then be installed by visiting the 
 https://github.com/RedHatInsights/clowder/releases/latest[latest release]
-page copying the link to the manifest and running something similar to that
+page, copying the link to the manifest, and running something similar to that
 shown below:
 
 [source,shell]


### PR DESCRIPTION
Small formatting fix. In the code block containing the shell command `./build/kube_setup.sh`, the leading period caused it to be interpreted as a title, and the paragraph following the block was incorrectly formatted as shell output. This PR adds Literal Block delimiters around the command to resolve this.