### PR TITLE
remove all instances of quay-cloudservices-pull

### DIFF
--- a/controllers/cloud.redhat.com/providers/cronjob/impl.go
+++ b/controllers/cloud.redhat.com/providers/cronjob/impl.go
@@ -46,10 +46,6 @@ func buildPodTemplate(app *crd.ClowdApp, env *crd.ClowdEnvironment, pt *core.Pod
 
 	pt.ObjectMeta.Labels = labels
 
-	pt.Spec.ImagePullSecrets = []core.LocalObjectReference{
-		{Name: "quay-cloudservices-pull"},
-	}
-
 	envvar := pod.Env
 	envvar = append(envvar, core.EnvVar{Name: "ACG_CONFIG", Value: "/cdapp/cdappconfig.json"})
 

--- a/controllers/cloud.redhat.com/providers/deployment/impl.go
+++ b/controllers/cloud.redhat.com/providers/deployment/impl.go
@@ -48,10 +48,6 @@ func initDeployment(app *crd.ClowdApp, env *crd.ClowdEnvironment, d *apps.Deploy
 	}
 	d.Spec.ProgressDeadlineSeconds = common.Int32Ptr(600)
 
-	d.Spec.Template.Spec.ImagePullSecrets = []core.LocalObjectReference{
-		{Name: "quay-cloudservices-pull"},
-	}
-
 	envvar := pod.Env
 	envvar = append(envvar, core.EnvVar{Name: "ACG_CONFIG", Value: "/cdapp/cdappconfig.json"})
 

--- a/controllers/cloud.redhat.com/providers/featureflags/localfeatureflags.go
+++ b/controllers/cloud.redhat.com/providers/featureflags/localfeatureflags.go
@@ -157,12 +157,6 @@ func makeLocalFeatureFlags(o obj.ClowdObject, objMap providers.ObjectMap, usePVC
 
 	dd.Spec.Template.ObjectMeta.Labels = labels
 
-	dd.Spec.Template.Spec.ImagePullSecrets = []core.LocalObjectReference{{
-		Name: "quay-cloudservices-pull",
-	}}
-
-	// get the secret
-
 	port := int32(4242)
 
 	envVars := []core.EnvVar{{

--- a/controllers/cloud.redhat.com/providers/iqe/impl.go
+++ b/controllers/cloud.redhat.com/providers/iqe/impl.go
@@ -33,10 +33,6 @@ func CreateIqeJobResource(cache *providers.ObjectCache, cji *crd.ClowdJobInvocat
 	j.Spec.Template.Spec.RestartPolicy = core.RestartPolicyNever
 	j.Spec.BackoffLimit = common.Int32Ptr(0)
 
-	j.Spec.Template.Spec.ImagePullSecrets = []core.LocalObjectReference{
-		{Name: "quay-cloudservices-pull"},
-	}
-
 	pod := crd.PodSpec{
 		Resources: env.Spec.Providers.Testing.Iqe.Resources,
 	}

--- a/controllers/cloud.redhat.com/providers/job/impl.go
+++ b/controllers/cloud.redhat.com/providers/job/impl.go
@@ -27,10 +27,6 @@ func CreateJobResource(cji *crd.ClowdJobInvocation, env *crd.ClowdEnvironment, n
 		j.Spec.Template.Spec.RestartPolicy = job.RestartPolicy
 	}
 
-	j.Spec.Template.Spec.ImagePullSecrets = []core.LocalObjectReference{
-		{Name: "quay-cloudservices-pull"},
-	}
-
 	envvar := pod.Env
 	envvar = append(envvar, core.EnvVar{Name: "ACG_CONFIG", Value: "/cdapp/cdappconfig.json"})
 

--- a/controllers/cloud.redhat.com/providers/objectstore/minio.go
+++ b/controllers/cloud.redhat.com/providers/objectstore/minio.go
@@ -286,12 +286,6 @@ func makeLocalMinIO(o obj.ClowdObject, objMap providers.ObjectMap, usePVC bool, 
 	}
 	dd.Spec.Template.ObjectMeta.Labels = labels
 
-	dd.Spec.Template.Spec.ImagePullSecrets = []core.LocalObjectReference{{
-		Name: "quay-cloudservices-pull",
-	}}
-
-	// get the secret
-
 	port := int32(9000)
 
 	envVars := []core.EnvVar{{

--- a/controllers/cloud.redhat.com/providers/utils/utils.go
+++ b/controllers/cloud.redhat.com/providers/utils/utils.go
@@ -43,10 +43,6 @@ func MakeLocalDB(dd *apps.Deployment, nn types.NamespacedName, baseResource obj.
 	}
 	dd.Spec.Template.ObjectMeta.Labels = labels
 
-	dd.Spec.Template.Spec.ImagePullSecrets = []core.LocalObjectReference{{
-		Name: "quay-cloudservices-pull",
-	}}
-
 	envVars := []core.EnvVar{
 		{Name: "POSTGRESQL_USER", Value: cfg.Username},
 		{Name: "POSTGRESQL_PASSWORD", Value: cfg.Password},


### PR DESCRIPTION
Closes: https://issues.redhat.com/browse/RHCLOUD-14787

Removes the hardcoded `quay-cloudservices-pull`  in favor of using the pullSecret provider in the ClowdEnvironment.

MR for setting up the provider was merged here: https://gitlab.cee.redhat.com/insights-platform/clowd-environments/-/merge_requests/2/diffs 

`on hold` until new Bonfire changes make it easier to deploy a pullSecret provider in the environment.