### PR TITLE
Update getting started docs to include latest bonfire commands

### DIFF
--- a/docs/antora/modules/usage/pages/app-workflow.adoc
+++ b/docs/antora/modules/usage/pages/app-workflow.adoc
@@ -18,43 +18,33 @@ Step 1 is pretty case by case basis. Maybe your config is reading the wrong
 variable. Perhaps your ClowdApp is missing a Kafka topic. Whatever your changes
 may be, update the code and go on to step 2. 
 
-
 == 2. Deploy locally with Bonfire
 
-https://internal.cloud.redhat.com/docs/devprod/ephemeral/[Bonfire] is a cli tool used to deploy apps with Clowder. Bonfire comes with
+Bonfire is a cli tool used to deploy apps with Clowder. Bonfire comes with
 a local config option that we'll use to drop our ClowdApp into our minikube
-cluster. 
+cluster. Read about getting started with bonfire on ephemeral environments https://clouddot.pages.redhat.com/docs/dev/getting-started/ephemeral/index.html[here]
 
-First, https://github.com/RedHatInsights/bonfire#installation[install Bonfire] if you don't already have it on your local machine. 
+We'll use our examples from https://github.com/RedHatInsights/clowder/blob/master/docs/usage/getting-started.rst[Getting Started] again. First, let's make a custom config for our ClowdApp so that bonfire can deploy it without
+us needing to push any configuration into app-interface.
 
-We'll use our examples from the https://github.com/RedHatInsights/clowder/blob/master/docs/usage/getting-started.rst[Getting Started] again. First, let's make a
-`config.yaml`. This file will be used to inform Bonfire about our ClowdApp. 
+Type `bonfire config edit` and add the following to the 'apps' section:
 
-Update ``$(PWD)`` to the place where your app will be stored ``/home/src/app``
-for example.  Save as ``config.yaml```
-
-=== config.yaml
 [source,yaml]
-envName: env-jumpstart
 apps:
 - name: jumpstart
   host: local
-  repo: $(PWD)
+  repo: /path/to/your/git/repo
   path: clowdapp.yml
   parameters:
     IMAGE: quay.io/psav/clowder-hello
 
-Our config.yaml defines an app name, a local host (this machine), a repo to
-read, and a path to a ClowdApp in that repo. Bonfire will use this information
-to deploy our ClowdApp into the namespace declared in our ClowdApp. 
+This config instructs bonfire to fetch the template for your application from a git repo located on local disk.
 
-Let's refer back to our example app from earlier. Now, instead of using a base
-App, we will use a Template. 
+Let's refer back to our example app from earlier. Now, instead of using a base ClowdApp, we will use a Template. 
 
-Note: if your previous ClowdApp is still running, use ``oc delete app
-jumpstart`` to remove it. 
+Note: if your previous ClowdApp is still running in the `jumpstart` namespace, use ``oc delete app jumpstart`` to remove it. 
 
-Save as ``clowdapp.yml```
+Save ``clowdapp.yml`` in your git repo's folder:
 [source,yaml]
 ----
 ---
@@ -80,10 +70,10 @@ objects:
         metrics: true
       # Give details about your running pod
       podSpec:
-        image: ${IMAGE}
+        image: ${IMAGE}:${IMAGE_TAG}
 
     # The name of the ClowdEnvironment providing the services
-    envName: env-jumpstart
+    envName: ${ENV_NAME}
     
     # Request kafka topics for your application here
     kafkaTopics:
@@ -98,16 +88,24 @@ objects:
       version: 12
 
 parameters:
-  IMAGE: ''
+  - name: IMAGE
+    value: quay.io/psav/clowder-hello
+  - name: IMAGE_TAG
+    value: latest
+  - name: ENV_NAME
+    required: true
 ----
 
-``bonfire config get -l -a jumpstart | oc apply -f -``
+
+Now run:
+
+[source,shell]
+bonfire deploy jumpstart -n jumpstart
 
 == 3. Observe the changes
-Run ``oc get app`` to verify the jumpstart app has been deployed.
+Run ``kubectl get app -n jumpstart`` to verify the jumpstart app has been deployed.
 
-You can do all the standard ``oc logs`` debugging to figure out if your changes
-are successful.
+If the deployment fails to reach a 'ready' state or pods fail to come up, use ``kubectl get events -n jumpstart`` and look for any errors related to your ClowdApp. You can also use ``kubectl logs <pod name> -n jumpstart --previous=true`` if your pods are crash looping.
 
 == 4. Repeat
 Repeat until you're happy with the results. When satisfied, checkout the

--- a/docs/antora/modules/usage/pages/getting-started.adoc
+++ b/docs/antora/modules/usage/pages/getting-started.adoc
@@ -17,54 +17,63 @@ developer environment, https://github.com/RedHatInsights/clowder/blob/master/doc
 Let's make a namespace to hold all the resources we'll be creating :
 
 [source,shell]
-oc new-project jumpstart
-oc project jumpstart
+kubectl create ns jumpstart
 
 That's the example namespace we'll be using for the rest of the guide.
 
 Now we can drop in our first resource, a ClowdEnvironment. A ClowdEnvironment,
 or ClowdEnv, is a custom resource that defines the environment our ClowdApp will
 utilize. The ClowdEnv defines what types of services our app may require and
-what source is providing those services. For our purposes, these services are
-set to ``local`` mode and will spin up pods in the ``jumpstart`` namespace.
+what source is providing those services. For our purposes, these services are configured to operate with ephemeral environments.
 
-The https://redhatinsights.github.io/clowder/api_reference.html#k8s-api-cloud-redhat-com-clowder-v2-apis-cloud-redhat-com-v1alpha1-clowdenvironment[API docs for ClowdEnvironments] can be found on redhatinsights.github.io.
+The easiest way to install a ClowdEnvironment that is fit for working with ephemeral environments is by using Bonfire.
 
-A https://github.com/RedHatInsights/clowder/blob/master/docs/examples/clowdenv.yml[fully annotated ClowdEnv] file can be found in the Clowder examples
-directory.
+Bonfire is a cli tool used to deploy apps into ephemeral environments. Read about getting started with bonfire on ephemeral environments https://clouddot.pages.redhat.com/docs/dev/getting-started/ephemeral/index.html[here]
+
+If you're curious to see what is going to be deployed (without actually applying the config), run:
+
+[source,shell]
+bonfire process-env -n jumpstart
+
+You can apply the environment's config and wait for it to become "ready" using:
+
+[source,shell]
+bonfire deploy-env -n jumpstart
+
+This will cause bonfire to apply the https://github.com/RedHatInsights/bonfire/blob/master/bonfire/resources/ephemeral-clowdenvironment.yaml[default ephemeral template] and set the ``targetNamespace`` to ``jumpstart```
 
 NOTE: You will only create a ClowdEnvironment in your local minikube. Stage
 and Production will have one ClowdEnv, respectively, shared by all apps in
-that environment.
+that environment. The ephemeral cluster has a ClowdEnvironment created for you ahead of time when you reserve a namespace.
+
+Let's see what the ClowdEnv does.
 
 [source,shell]
-oc apply -f https://raw.githubusercontent.com/RedHatInsights/clowder/master/docs/examples/clowdenv.yml
+kubectl get env env-jumpstart -o yaml
 
-Clowder will pick up and apply that env resource. You may notice there are no
-pods running -- and that's correct. Let's see what the ClowdEnv does.
+As you can see in the output, we have ``providers``_ for the different services. Some of these providers have caused certain deployments to appear in the environment's ``targetNamespace`` such as kafka, minio, featureflags service, etc.
+These will be used by ClowdApps associated with this environment.
+
+=== Accessing services running inside your namespace
+
+Pods running within your kubernetes cluster can access the services set up by the ClowdEnvironment. However, if you are wanting to access a ClowdEnv-provided service (Kafka, Minio, etc) directly from your host we need edit to your ``/etc/hosts`` mappings. Our example uses
+Kafka, so we are going to look up the bootstrap service address in our environment:
 
 [source,shell]
-oc get env env-jumpstart -o yaml
+kubectl get kafka -n jumpstart -o jsonpath='{.items[0].status.listeners[0].bootstrapServers}' | cut -f1 -d':'
 
-As you can see in the output, we have `providers`_ for the different services,
-but they won't do anything until a ClowdApp asks for them specifically.
+This is your kafka cluster's boostrap FQDN. It will look similar to:
 
-=== Handling local ports
-
-If you are going to use a ClowdEnv service in your ClowdApp (Kafka, Minio, etc),
-we need edit to your ``/etc/hosts`` localhost (127.0.0.1). Our example uses
-Kafka, so we are using the ``env-jumpstart-kafka.jumpstart.svc`` service because
-it matches our environment's name. Follow the Kubernetes service pattern for
-whatever your entry may need to be; just be sure it matches your specific
-environment name.
+[source,text]
+env-jumpstart-cadf501e-kafka-bootstrap.jumpstart.svc
 
 Your ``/etc/hosts`` should now look like ::
 
 [source,text]
-127.0.0.1   localhost ...  env-jumpstart-kafka.jumpstart.svc.
+127.0.0.1   localhost ...  env-jumpstart-cadf501e-kafka-bootstrap.jumpstart.svc.
 
-If you are not using the name ``jumpstart``, change it to the appropriate
-service.
+
+You can then use ``kubectl port-forward svc/env-jumpstart-cadf501e-kafka-bootstrap -n jumpstart 9092:9092`` and access the kafka broker using ``env-jumpstart-cadf501e-kafka-bootstrap.jumpstart.svc:9092``
 
 == Create your first ClowdApp
 
@@ -79,37 +88,24 @@ The https://redhatinsights.github.io/clowder/api_reference.html#k8s-api-cloud-re
 
 A https://github.com/RedHatInsights/clowder/blob/master/docs/examples/clowdapp.yml[fully annotated ClowdApp] file can be found in the Clowder examples directory.
 
-=== Port forwarding a localhost service
-
-In order for the local minikube to reach your Kafka service, we'll need to
-port-forward it on your local machine using the ``/etc/hosts`` entry from
-earlier:
-
-[source,shell]
-oc port-forward svc/env-jumpstart-kafka 29092
-
-You can background that with ``&`` if you'd like, or run it in a different
-terminal window. You only need to do this for local deployments.
-
 Now let's add our ClowdApp:
 
 [source,shell]
-oc apply -f https://raw.githubusercontent.com/RedHatInsights/clowder/master/docs/examples/clowdapp.yml
+kubectl apply -f https://raw.githubusercontent.com/RedHatInsights/clowder/master/docs/examples/clowdapp.yml -n jumpstart
 
 Let's verify that ClowdApp was created:
 
 [source,shell]
-oc get app
+kubectl get app -n jumpstart
 
 Now you should see pods!:
 
 [source,shell]
-oc get pods -w
+kubectl get pods -n jumpstart -w
 
 This should show you several running pods. Some of them we defined in our
 ClowdApp, some we did not. Pods like Kafka are defined in the ClowdEnv and spun
-up when requested by your app, then added to your namespace. As a note, your app
-will not come up until the all ClowdEnv supplied pods are marked as ready (1/1).
+up when the environment was created, while others are related to your ClowdApp. As a note, your app will not come up until the all ClowdEnv's managed deployments are marked as ready.
 
 That's it! You have a running ClowdApp deployed with Clowder. In the next few
 documents, we'll cover creating a more powerful dev environment, building a more

--- a/docs/antora/modules/usage/pages/jobs.adoc
+++ b/docs/antora/modules/usage/pages/jobs.adoc
@@ -99,40 +99,11 @@ A CJI can then be checked by ``oc get cji``
 == Running IQE Tests with ClowdJobs
 
 Part of the mission for jobs was to empower developers to run the full suite
-of testing on their local machine. Using ClowdJobsInvocations, developers can
+of testing on their local machine. Using ClowdJobInvocations, developers can
 now run smoke tests locally and on a remote cluster. In order to get everything
 setup correctly for the full smoke tests, we need to do the following:
 
 1. Ensure your app's iqe plugin is configured to read from cdappconfig. Please feel 
   free to use this https://gitlab.cee.redhat.com/insights-qe/iqe-host-inventory-plugin/-/merge_requests/514/diffs[inventory MR as a reference]. 
-2. Run ``bonfire`` with the ``--get-dependencies`` flag enabled. This will
-  install the ClowdApp along with any apps listed as dependencies; optional or
-  otherwise.
-3. Define the ``iqe`` pod parameters in the ClowdJobInvocation. Note: The
-  example below specifies overrides for the already set App and Env definitions
-  of an IQE job.
-
-[source,yaml]
-----
---- 
-apiVersion: cloud.redhat.com/v1alpha1
-kind: ClowdJobInvocation
-metadata:
-  name: my-job-invocation
-  namespace: ${NAMESPACE}
-spec:
-  appName: host-inventory
-  testing:
-    iqe:
-      # by default, Clowder will set the image on the ClowdJob to be
-      # "baseImage:<name of the iqe plugin set on ClowdApp>", but you
-      # can override the image tag here:
-      imageTag: "my-custom-image-tag"
-
-      # override the environment's default test run options
-      ui: 
-        enabled: true  # indicates whether a selenium container should be included in the pod
-      marker: "smoke AND (something) AND (my other marker)"  # sets pytest -m argument
-      dynaconfEnvName: "my_env_override"  # sets value for ENV_FOR_DYNACONF
-      filter: "some_test"  # sets pytest -k argument
-----
+2. Use `bonfire` to deploy your app into an ephemeral namespace.
+3. Use `bonfire deploy-iqe-cji` to deploy a CJI into the namespace.


### PR DESCRIPTION
We had a few engineers try to run through these last week and of course they weren't too successful -- these docs are pretty out of date and needed a refresh.