### PR TITLE
Add Postgress port to Istio exclude rule

### DIFF
--- a/bundle/tests/scorecard/kuttl/test-service-mesh/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-service-mesh/01-assert.yaml
@@ -9,4 +9,4 @@ spec:
     metadata:
       annotations: 
         sidecar.istio.io/inject: "true"
-        traffic.sidecar.istio.io/excludeOutboundPorts: "443,9093"
+        traffic.sidecar.istio.io/excludeOutboundPorts: "443,9093,5432"

--- a/controllers/cloud.redhat.com/providers/servicemesh/default.go
+++ b/controllers/cloud.redhat.com/providers/servicemesh/default.go
@@ -33,7 +33,7 @@ func (ch *servicemeshProvider) Provide(app *crd.ClowdApp, c *config.AppConfig) e
 			annotations = make(map[string]string)
 		}
 		annotations["sidecar.istio.io/inject"] = "true"
-		annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = "443,9093"
+		annotations["traffic.sidecar.istio.io/excludeOutboundPorts"] = "443,9093,5432"
 
 		deployment.Spec.Template.SetAnnotations(annotations)
 


### PR DESCRIPTION
Add postgress port to exclude rule. Applications already encrypt database communications.
This allows applications to make database calls in init containers and also avoid double encryption.