### PR TITLE
Defer clowdapp reconciliation until env ready

### DIFF
--- a/controllers/cloud.redhat.com/clowdapp_controller.go
+++ b/controllers/cloud.redhat.com/clowdapp_controller.go
@@ -165,7 +165,15 @@ func (r *ClowdAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{Requeue: true}, err
 	}
 
-	if env.Generation != env.Status.Generation {
+	successfulReconciliation := false
+
+	for _, cond := range env.Status.Conditions {
+		if cond.Type == crd.ReconciliationSuccessful && cond.Status == core.ConditionTrue {
+			successfulReconciliation = true
+		}
+	}
+
+	if env.Generation != env.Status.Generation || !successfulReconciliation {
 		err := errors.New(fmt.Sprintf("Clowd Environment not yet reconciled: %s", env.Name))
 		SetClowdAppConditions(ctx, r.Client, &app, crd.ReconciliationFailed, err)
 		return ctrl.Result{Requeue: true}, errors.New(fmt.Sprintf("Clowd Environment not yet reconciled: %s", env.Name))


### PR DESCRIPTION
* Currently the ClowdApp can start to reconcile even when the env
  is not yet ready. This can lead to crashes and problems.
* This PR inspects the status of the ClowdEnv and prevents the
  ClowdApp from being reconciled until the Env is complete.