### PR TITLE
Add 'deployment metadata' to cdappconfig

### DIFF
--- a/controllers/cloud.redhat.com/clowdapp_controller.go
+++ b/controllers/cloud.redhat.com/clowdapp_controller.go
@@ -458,6 +458,7 @@ func contains(list []string, s string) bool {
 func (r *ClowdAppReconciler) runProviders(log logr.Logger, provider *providers.Provider, a *crd.ClowdApp) error {
 
 	c := config.AppConfig{}
+	c.Self = a.Spec
 
 	for _, provAcc := range providers.ProvidersRegistration.Registry {
 		log.Info("running provider:", "name", provAcc.Name, "order", provAcc.Order)

--- a/controllers/cloud.redhat.com/clowdapp_controller.go
+++ b/controllers/cloud.redhat.com/clowdapp_controller.go
@@ -455,10 +455,26 @@ func contains(list []string, s string) bool {
 	return false
 }
 
+func updateMetadata(app *crd.ClowdApp, appConfig *config.AppConfig) {
+	metadata := config.AppMetadata{}
+
+	for _, deployment := range app.Spec.Deployments {
+		deploymentMetadata := config.DeploymentMetadata{
+			Name:  deployment.Name,
+			Image: deployment.PodSpec.Image,
+		}
+		metadata.Deployments = append(metadata.Deployments, deploymentMetadata)
+	}
+
+	appConfig.Metadata = metadata
+}
+
 func (r *ClowdAppReconciler) runProviders(log logr.Logger, provider *providers.Provider, a *crd.ClowdApp) error {
 
 	c := config.AppConfig{}
-	c.Self = a.Spec
+
+	// Update app metadata
+	updateMetadata(a, &c)
 
 	for _, provAcc := range providers.ProvidersRegistration.Registry {
 		log.Info("running provider:", "name", provAcc.Name, "order", provAcc.Order)

--- a/controllers/cloud.redhat.com/config/types.go
+++ b/controllers/cloud.redhat.com/config/types.go
@@ -2,12 +2,19 @@
 
 package config
 
-import "fmt"
-import "encoding/json"
-import "reflect"
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	crd "github.com/RedHatInsights/clowder/apis/cloud.redhat.com/v1alpha1"
+)
 
 // ClowdApp deployment configuration for Clowder enabled apps.
 type AppConfig struct {
+	// Self corresponds to the full ClowdApp spec of this app as seen by the operator
+	Self crd.ClowdAppSpec `json:"self"`
+
 	// Database corresponds to the JSON schema field "database".
 	Database *DatabaseConfig `json:"database,omitempty"`
 

--- a/controllers/cloud.redhat.com/config/types.go
+++ b/controllers/cloud.redhat.com/config/types.go
@@ -6,14 +6,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-
-	crd "github.com/RedHatInsights/clowder/apis/cloud.redhat.com/v1alpha1"
 )
 
 // ClowdApp deployment configuration for Clowder enabled apps.
 type AppConfig struct {
-	// Self corresponds to the full ClowdApp spec of this app as seen by the operator
-	Self crd.ClowdAppSpec `json:"self"`
+	// Arbitrary metadata pertaining to the application application
+	Metadata AppMetadata `json:"metadata,omitempty"`
 
 	// Database corresponds to the JSON schema field "database".
 	Database *DatabaseConfig `json:"database,omitempty"`
@@ -57,6 +55,21 @@ type AppConfig struct {
 
 	// Deprecated: Use 'publicPort' instead.
 	WebPort *int `json:"webPort,omitempty"`
+}
+
+// Application Metadata
+type AppMetadata struct {
+	// Metadata pertaining to an application's deployments
+	Deployments []DeploymentMetadata `json:"deployments,omitempty"`
+}
+
+// Deployment Metadata
+type DeploymentMetadata struct {
+	// Name of deployment
+	Name string `json:"name"`
+
+	// Image used by deployment
+	Image string `json:"image"`
 }
 
 // Broker Configuration

--- a/controllers/cloud.redhat.com/suite_test.go
+++ b/controllers/cloud.redhat.com/suite_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/RedHatInsights/clowder/apis/cloud.redhat.com/v1alpha1/common"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
@@ -626,9 +627,22 @@ func TestCreateClowdApp(t *testing.T) {
 		return
 	}
 
+	metadataValidation(t, app, jsonContent)
+
 	kafkaValidation(t, env, app, jsonContent, clowdAppNN)
 
 	clowdWatchValidation(t, jsonContent, cwData)
+}
+
+func metadataValidation(t *testing.T, app *crd.ClowdApp, jsonContent *config.AppConfig) {
+	for _, deployment := range app.Spec.Deployments {
+		expected := config.DeploymentMetadata{
+			Name:  deployment.Name,
+			Image: deployment.PodSpec.Image,
+		}
+		assert.Contains(t, jsonContent.Metadata.Deployments, expected)
+	}
+	assert.Len(t, jsonContent.Metadata.Deployments, len(app.Spec.Deployments))
 }
 
 func kafkaValidation(t *testing.T, env *crd.ClowdEnvironment, app *crd.ClowdApp, jsonContent *config.AppConfig, clowdAppNN types.NamespacedName) {


### PR DESCRIPTION
So that the ClowdApp is able to know version info about its deployments via cdappconfig.json

This will also allow us to share the configs of all cdapps within the "/cdenv/cdenvconfig.json" on the IQE ClowdJobInvocation -- which will allow IQE to fetch deployment information about each ClowdApp (such as image/image tag being used by the deployments) without having to query the k8s API itself.