### PR TITLE
Also wait for cert-manager-webhook deployment

### DIFF
--- a/build/kube_setup.sh
+++ b/build/kube_setup.sh
@@ -143,6 +143,7 @@ function install_cert_manager {
 
     echo "*** Will wait for cert manager to come up in background"
     ${KUBECTL_CMD} rollout status deployment/cert-manager -n cert-manager | sed "s/^/[cert-manager] /" &
+    ${KUBECTL_CMD} rollout status deployment/cert-manager-webhook -n cert-manager-webhook | sed "s/^/[cert-manager] /" &
     BG_PIDS+=($!)
 
     cd "$ROOT_DIR"


### PR DESCRIPTION
Applying the clowder manifest hits an error if cert-manager-webhook is not up and running.