### PR TITLE
Decrease concurrent kuttl tests for stability increase

### DIFF
--- a/bundle/tests/scorecard/kuttl/kuttl-test.yaml
+++ b/bundle/tests/scorecard/kuttl/kuttl-test.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 startControlPlane: false
 timeout: 300
-parallel: 12
+parallel: 8

--- a/bundle/tests/scorecard/kuttl/kuttl-test.yaml
+++ b/bundle/tests/scorecard/kuttl/kuttl-test.yaml
@@ -2,4 +2,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestSuite
 startControlPlane: false
 timeout: 300
-parallel: 8
+parallel: 6


### PR DESCRIPTION
* Rollback from 12 to 6