### PR TITLE
Add preStop lifecycle to local DB containers

### DIFF
--- a/controllers/cloud.redhat.com/providers/database/localdb_test.go
+++ b/controllers/cloud.redhat.com/providers/database/localdb_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	apps "k8s.io/api/apps/v1"
 	core "k8s.io/api/core/v1"
 
@@ -134,6 +136,11 @@ func TestLocalDBDeployment(t *testing.T) {
 	if !compareEnvs(&envVars, &d.Spec.Template.Spec.Containers[0].Env) {
 		t.Fatal("Envvars didn't match")
 	}
+	assert.Equal(
+		t,
+		d.Spec.Template.Spec.Containers[0].Lifecycle.PreStop.Exec.Command,
+		[]string{"/bin/bash", "-c", "pg_ctl stop -D /var/lib/pgsql/data"},
+	)
 }
 
 func compareEnvs(a, b *([]core.EnvVar)) bool {


### PR DESCRIPTION
I witnessed this error in a test environment when a postgresql DB was starting up:
```
❯ oc logs -f advisor-backend-db-c6547fb86-tnxwh
pg_ctl: another server might be running; trying to start server anyway
waiting for server to start....2021-09-10 15:29:22.748 UTC [25] LOG:  starting PostgreSQL 12.7 on x86_64-redhat-linux-gnu, compiled by gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-44), 64-bit
2021-09-10 15:29:22.750 UTC [25] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2021-09-10 15:29:22.753 UTC [25] LOG:  listening on Unix socket "/tmp/.s.PGSQL.5432"
2021-09-10 15:29:22.763 UTC [25] LOG:  redirecting log output to logging collector process
2021-09-10 15:29:22.763 UTC [25] HINT:  Future log output will appear in directory "log".
 done
server started
/var/run/postgresql:5432 - accepting connections
=> sourcing /opt/app-root/src/postgresql-start/grant_createdb.sh ...
ERROR:  tuple concurrently updated
11:32
```

I am thinking that the move to persistent volumes may have been related. The DB pod may have been uncleanly restarted (why or how? I'm not sure), causing something to get messed up on the volume. `pg_ctl: another server might be running; trying to start server anyway` is especially suspicious because this would indicate the presence of a `.pid` file on the volume somewhere.