### PR TITLE
[RHCLOUD-16216] Update k8s batch/v1beta1 to batch/v1

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/RedHatInsights/clowder/apis/cloud.redhat.com/v1alpha1/common"
 	keda "github.com/kedacore/keda/v2/api/v1alpha1"
-	batch "k8s.io/api/batch/v1beta1"
+	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/bundle/tests/scorecard/kuttl/test-clowder-jobs/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-clowder-jobs/01-assert.yaml
@@ -18,7 +18,7 @@ metadata:
   name: puptoo-processor
   namespace: test-clowder-jobs
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: puptoo-standard-cron
@@ -40,7 +40,7 @@ spec:
               image: quay.io/psav/clowder-hello
           restartPolicy: Never
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: puptoo-suspend-cron
@@ -61,7 +61,7 @@ spec:
               image: quay.io/psav/clowder-hello
           restartPolicy: Never
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: puptoo-restart-on-failure

--- a/controllers/cloud.redhat.com/providers/confighash/default.go
+++ b/controllers/cloud.redhat.com/providers/confighash/default.go
@@ -7,7 +7,7 @@ import (
 	cronjobProvider "github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/providers/cronjob"
 	deployProvider "github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/providers/deployment"
 	apps "k8s.io/api/apps/v1"
-	batch "k8s.io/api/batch/v1beta1"
+	batch "k8s.io/api/batch/v1"
 	core "k8s.io/api/core/v1"
 
 	rc "github.com/RedHatInsights/rhc-osdk-utils/resource_cache"

--- a/controllers/cloud.redhat.com/providers/cronjob/impl.go
+++ b/controllers/cloud.redhat.com/providers/cronjob/impl.go
@@ -6,7 +6,7 @@ import (
 	crd "github.com/RedHatInsights/clowder/apis/cloud.redhat.com/v1alpha1"
 	deployProvider "github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/providers/deployment"
 
-	batch "k8s.io/api/batch/v1beta1"
+	batch "k8s.io/api/batch/v1"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )

--- a/controllers/cloud.redhat.com/providers/cronjob/provider.go
+++ b/controllers/cloud.redhat.com/providers/cronjob/provider.go
@@ -2,9 +2,8 @@ package cronjob
 
 import (
 	p "github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/providers"
-	batch "k8s.io/api/batch/v1beta1"
-
 	rc "github.com/RedHatInsights/rhc-osdk-utils/resource_cache"
+	batch "k8s.io/api/batch/v1"
 )
 
 // ProvName sets the provider name identifier

--- a/controllers/cloud.redhat.com/providers/sidecar/default.go
+++ b/controllers/cloud.redhat.com/providers/sidecar/default.go
@@ -10,7 +10,7 @@ import (
 	deployProvider "github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/providers/deployment"
 
 	apps "k8s.io/api/apps/v1"
-	batch "k8s.io/api/batch/v1beta1"
+	batch "k8s.io/api/batch/v1"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )

--- a/docs/antora/modules/ROOT/pages/api_reference.adoc
+++ b/docs/antora/modules/ROOT/pages/api_reference.adoc
@@ -529,7 +529,7 @@ Job defines a ClowdJob A Job struct will deploy as a CronJob if `schedule` is se
 | *`schedule`* __string__ | Defines the schedule for the job to run
 | *`podSpec`* __xref:{anchor_prefix}-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-podspec[$$PodSpec$$]__ | PodSpec defines a container running inside the CronJob.
 | *`restartPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#restartpolicy-v1-core[$$RestartPolicy$$]__ | Defines the restart policy for the CronJob, defaults to never
-| *`concurrencyPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#concurrencypolicy-v1beta1-batch[$$ConcurrencyPolicy$$]__ | Defines the concurrency policy for the CronJob, defaults to Allow Only applies to Cronjobs
+| *`concurrencyPolicy`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#concurrencypolicy-v1-batch[$$ConcurrencyPolicy$$]__ | Defines the concurrency policy for the CronJob, defaults to Allow Only applies to Cronjobs
 | *`suspend`* __boolean__ | This flag tells the controller to suspend subsequent executions, it does not apply to already started executions.  Defaults to false. Only applies to Cronjobs
 | *`successfulJobsHistoryLimit`* __integer__ | The number of successful finished jobs to retain. Value must be non-negative integer. Defaults to 3. Only applies to Cronjobs
 | *`failedJobsHistoryLimit`* __integer__ | The number of failed finished jobs to retain. Value must be non-negative integer. Defaults to 1. Only applies to Cronjobs


### PR DESCRIPTION
A good bit going on here, so I'll summarize:

- `CronJob` was promoted to `batch/v1` in `k8s.io/api v0.21.0`.
-  `batch/v1beta1` is being removed in `v0.25.0`. So an API package update was needed. I went ahead and jumped to the latest on `v0.22.0`
- Because of this update, `go1.15` is no longer sufficient and at least `go1.16` is needed. 
- `github.com/go-logr/logr` had to be downgraded from `1.1.0 => 0.4.0` [because of this controller-runtime issue](https://github.com/kubernetes-sigs/controller-runtime/issues/1607), but this is a small upgrade from our current version. Latest won't work yet.