### PR TITLE
update KREW install to include OS and ARCH

### DIFF
--- a/build/pr_check_inner.sh
+++ b/build/pr_check_inner.sh
@@ -10,12 +10,15 @@ cd /container_workspace
 export KUBEBUILDER_ASSETS=/container_workspace/testbin/bin
 
 (
-  cd "$(mktemp -d)" &&
-  curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/krew.tar.gz" &&
-  tar zxvf krew.tar.gz &&
-  KREW=./krew-"$(uname | tr '[:upper:]' '[:lower:]')_$(uname -m | sed -e 's/x86_64/amd64/' -e 's/arm.*$/arm/')" &&
-  "$KREW" install krew
+  set -x; cd "$(mktemp -d)" &&
+  OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
+  ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
+  KREW="krew-${OS}_${ARCH}" &&
+  curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
+  tar zxvf "${KREW}.tar.gz" &&
+  ./"${KREW}" install krew
 )
+
 
 export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
 


### PR DESCRIPTION
Krew 4.2 changed the [install path for its tarball](https://github.com/kubernetes-sigs/krew/pull/700) 

We just need to update the URL based on OS and ARCH of the system.

Pulled from user guide: https://krew.sigs.k8s.io/docs/user-guide/setup/install/ 