### PR TITLE
Add image field/override to initContainer

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
@@ -29,6 +29,10 @@ import (
 // deployed along with the parent pod and is used to carry out one time
 // initialization procedures.
 type InitContainer struct {
+	// Image refers to the container image used to create the init container
+	// (if different from the primary pod image).
+	Image string `json:"image,omitempty"`
+
 	// A list of commands to run inside the parent Pod.
 	Command []string `json:"command,omitempty"`
 

--- a/bundle/tests/scorecard/kuttl/test-init-container-image/00-install.yaml
+++ b/bundle/tests/scorecard/kuttl/test-init-container-image/00-install.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-init-container-image
+spec:
+  finalizers:
+  - kubernetes

--- a/bundle/tests/scorecard/kuttl/test-init-container-image/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-init-container-image/01-assert.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-init-container-image-overridden
+  namespace: test-init-container-image
+spec:
+  template:
+    spec:
+      containers:
+      - image: k8s.gcr.io/pause:3.2
+      initContainers:
+      - image: k8s.gcr.io/pause:3.1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-init-container-image-app
+  namespace: test-init-container-image
+spec:
+  template:
+    spec:
+      containers:
+      - image: k8s.gcr.io/pause:3.2
+      initContainers:
+      - image: k8s.gcr.io/pause:3.2

--- a/bundle/tests/scorecard/kuttl/test-init-container-image/01-pod.yaml
+++ b/bundle/tests/scorecard/kuttl/test-init-container-image/01-pod.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdEnvironment
+metadata:
+  name: test-init-container-image
+spec:
+  targetNamespace: test-init-container-image
+  providers:
+    web:
+      port: 8000
+      mode: none
+    metrics:
+      port: 9000
+      mode: none
+    db:
+      mode: none
+    inMemoryDb:
+      mode: none
+    kafka:
+      mode: none
+    logging:
+      mode: none
+    objectStore:
+      mode: none
+  resourceDefaults:
+    limits:
+      cpu: 400m
+      memory: 1024Mi
+    requests:
+      cpu: 30m
+      memory: 512Mi
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: test-init-container-image
+  namespace: test-init-container-image
+spec:
+  envName: test-init-container-image
+  deployments:
+  - name: overridden
+    podSpec:
+      image: k8s.gcr.io/pause:3.2
+      initContainers:
+        - image: k8s.gcr.io/pause:3.1
+  - name: app
+    podSpec:
+      image: k8s.gcr.io/pause:3.2
+      initContainers:
+      - {}

--- a/bundle/tests/scorecard/kuttl/test-init-container-image/02-delete.yaml
+++ b/bundle/tests/scorecard/kuttl/test-init-container-image/02-delete.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdEnvironment
+  name: test-init-container-image
+- apiVersion: v1
+  kind: Namespace
+  name: test-init-container-image

--- a/config/crd/bases/cloud.redhat.com_clowdapps.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdapps.yaml
@@ -401,6 +401,11 @@ spec:
                                   - name
                                   type: object
                                 type: array
+                              image:
+                                description: Image refers to the container image used
+                                  to create the init container (if different from
+                                  the primary pod image).
+                                type: string
                               inheritEnv:
                                 description: If true, inheirts the environment variables
                                   from the parent pod. specification
@@ -2692,6 +2697,11 @@ spec:
                                   - name
                                   type: object
                                 type: array
+                              image:
+                                description: Image refers to the container image used
+                                  to create the init container (if different from
+                                  the primary pod image).
+                                type: string
                               inheritEnv:
                                 description: If true, inheirts the environment variables
                                   from the parent pod. specification

--- a/controllers/cloud.redhat.com/providers/deployment/impl.go
+++ b/controllers/cloud.redhat.com/providers/deployment/impl.go
@@ -149,9 +149,13 @@ func ProcessInitContainers(nn types.NamespacedName, c *core.Container, ics []crd
 	containerList := make([]core.Container, len(ics))
 
 	for i, ic := range ics {
+		image := c.Image
+		if ic.Image != "" {
+			image = ic.Image
+		}
 		icStruct := core.Container{
 			Name:            nn.Name + "-init",
-			Image:           c.Image,
+			Image:           image,
 			Command:         ic.Command,
 			Args:            ic.Args,
 			Resources:       c.Resources,

--- a/deploy-mutate.yml
+++ b/deploy-mutate.yml
@@ -417,6 +417,11 @@ objects:
                                     - name
                                     type: object
                                   type: array
+                                image:
+                                  description: Image refers to the container image
+                                    used to create the init container (if different
+                                    from the primary pod image).
+                                  type: string
                                 inheritEnv:
                                   description: If true, inheirts the environment variables
                                     from the parent pod. specification
@@ -2760,6 +2765,11 @@ objects:
                                     - name
                                     type: object
                                   type: array
+                                image:
+                                  description: Image refers to the container image
+                                    used to create the init container (if different
+                                    from the primary pod image).
+                                  type: string
                                 inheritEnv:
                                   description: If true, inheirts the environment variables
                                     from the parent pod. specification

--- a/deploy.yml
+++ b/deploy.yml
@@ -417,6 +417,11 @@ objects:
                                     - name
                                     type: object
                                   type: array
+                                image:
+                                  description: Image refers to the container image
+                                    used to create the init container (if different
+                                    from the primary pod image).
+                                  type: string
                                 inheritEnv:
                                   description: If true, inheirts the environment variables
                                     from the parent pod. specification
@@ -2760,6 +2765,11 @@ objects:
                                     - name
                                     type: object
                                   type: array
+                                image:
+                                  description: Image refers to the container image
+                                    used to create the init container (if different
+                                    from the primary pod image).
+                                  type: string
                                 inheritEnv:
                                   description: If true, inheirts the environment variables
                                     from the parent pod. specification


### PR DESCRIPTION
In order to support having DB migrations run via a separate container image.

Running the added kuttl test:

```
kubectl kuttl test -v2 bundle/tests/scorecard/kuttl/ --test test-init-container-image
```