### PR TITLE
Add envName to cdappconfig metadata

### DIFF
--- a/controllers/cloud.redhat.com/clowdapp_controller.go
+++ b/controllers/cloud.redhat.com/clowdapp_controller.go
@@ -466,8 +466,8 @@ func updateMetadata(app *crd.ClowdApp, appConfig *config.AppConfig) {
 	}
 
 	appConfig.Metadata = &metadata
-
 	appConfig.Metadata.Name = &app.Name
+	appConfig.Metadata.EnvName = &app.Spec.EnvName
 }
 
 func (r *ClowdAppReconciler) runProviders(log logr.Logger, provider *providers.Provider, a *crd.ClowdApp) error {

--- a/controllers/cloud.redhat.com/config/schema.json
+++ b/controllers/cloud.redhat.com/config/schema.json
@@ -100,6 +100,10 @@
                     "description": "Name of the ClowdApp",
                     "type": "string"
                 },
+                "envName": {
+                    "description": "Name of the ClowdEnvironment this ClowdApp runs in",
+                    "type": "string"
+                },
                 "deployments": {
                     "description": "Metadata pertaining to an application's deployments",
                     "type": "array",

--- a/controllers/cloud.redhat.com/config/types.go
+++ b/controllers/cloud.redhat.com/config/types.go
@@ -242,6 +242,9 @@ type AppMetadata struct {
 	// Metadata pertaining to an application's deployments
 	Deployments []DeploymentMetadata `json:"deployments,omitempty"`
 
+	// Name of the ClowdEnvironment this ClowdApp runs in
+	EnvName *string `json:"envName,omitempty"`
+
 	// Name of the ClowdApp
 	Name *string `json:"name,omitempty"`
 }

--- a/controllers/cloud.redhat.com/suite_test.go
+++ b/controllers/cloud.redhat.com/suite_test.go
@@ -636,6 +636,7 @@ func TestCreateClowdApp(t *testing.T) {
 
 func metadataValidation(t *testing.T, app *crd.ClowdApp, jsonContent *config.AppConfig) {
 	assert.Equal(t, *jsonContent.Metadata.Name, app.Name)
+	assert.Equal(t, *jsonContent.Metadata.EnvName, app.Spec.EnvName)
 
 	for _, deployment := range app.Spec.Deployments {
 		expected := config.DeploymentMetadata{


### PR DESCRIPTION
So that the IQE CJI's can be aware of what ClowdEnvironment they are running in and behave differently if running in stage/prod