### PR TITLE
(needs testing)[RHCLOUD-16525] Use default image pull policy

### DIFF
--- a/controllers/cloud.redhat.com/providers/cronjob/impl.go
+++ b/controllers/cloud.redhat.com/providers/cronjob/impl.go
@@ -75,7 +75,6 @@ func buildPodTemplate(app *crd.ClowdApp, env *crd.ClowdEnvironment, pt *core.Pod
 			Name:          "metrics",
 			ContainerPort: env.Spec.Providers.Metrics.Port,
 		}},
-		ImagePullPolicy: core.PullIfNotPresent,
 	}
 
 	// set service account for pod

--- a/controllers/cloud.redhat.com/providers/deployment/impl.go
+++ b/controllers/cloud.redhat.com/providers/deployment/impl.go
@@ -100,7 +100,6 @@ func initDeployment(app *crd.ClowdApp, env *crd.ClowdEnvironment, d *apps.Deploy
 		Env:             envvar,
 		Resources:       ProcessResources(&pod, env),
 		VolumeMounts:    pod.VolumeMounts,
-		ImagePullPolicy: core.PullIfNotPresent,
 	}
 
 	if (core.Probe{}) != livenessProbe {

--- a/controllers/cloud.redhat.com/providers/job/impl.go
+++ b/controllers/cloud.redhat.com/providers/job/impl.go
@@ -57,7 +57,6 @@ func CreateJobResource(cji *crd.ClowdJobInvocation, env *crd.ClowdEnvironment, a
 			Name:          "metrics",
 			ContainerPort: env.Spec.Providers.Metrics.Port,
 		}},
-		ImagePullPolicy: core.PullIfNotPresent,
 	}
 
 	if (core.Probe{}) != livenessProbe {


### PR DESCRIPTION
Removes ImagePullPolicy on Deployment, Job and CronJob providers in
order to leverage defaults image pull policy.

The default policy is set based on the image tag usage:
* no tag or :latest -> PullAlways
* any other tag -> PullIfNotPresent

See
https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting

This improves a workflow when a deployment uses a single image tag (e.g.
latest) that is constantly being updated during development.

Ref:
* https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy

**This needs testing.** Once I get familiar with the build/test/deploy process I'll update it. Anyhow feel free to help testing this. 
Thank you!