### PR TITLE
Ensure cyndi has created hbi table

### DIFF
--- a/controllers/cloud.redhat.com/providers/kafka/cyndi.go
+++ b/controllers/cloud.redhat.com/providers/kafka/cyndi.go
@@ -48,6 +48,12 @@ func validateCyndiPipeline(
 		}
 	}
 
+	if pipeline.Status.ActiveTableName == "" {
+		return &errors.MissingDependencies{
+			MissingDeps: map[string][]string{"cyndiPipeline": {nn.Name}},
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This will prevent apps from crashing if they try to read from a table
that doesn't yet exist in their db.