### PR TITLE
Remove Partial Reconciliation

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
@@ -340,8 +340,6 @@ const (
 	DeploymentsReady ClowdConditionType = "DeploymentsReady"
 	// ReconciliationSuccessful represents status of successful reconciliation
 	ReconciliationSuccessful ClowdConditionType = "ReconciliationSuccessful"
-	// ReconciliationPartiallySuccessful means the reconciliation is in a partial success state
-	ReconciliationPartiallySuccessful ClowdConditionType = "ReconciliationPartiallySuccessful"
 	// ReconciliationFailed means the reconciliation failed
 	ReconciliationFailed ClowdConditionType = "ReconciliationFailed"
 	// JobInvocationComplete means all the Jobs have finished
@@ -496,7 +494,15 @@ func (i *ClowdApp) GetCronJobNamespacedName(d *Job) types.NamespacedName {
 
 // IsReady returns true when all the ManagedDeployments are Ready
 func (i *ClowdApp) IsReady() bool {
-	return (i.Status.Deployments.ManagedDeployments == i.Status.Deployments.ReadyDeployments)
+	conditionCheck := false
+
+	for _, condition := range i.Status.Conditions {
+		if condition.Type == ReconciliationSuccessful {
+			conditionCheck = true
+		}
+	}
+
+	return i.Status.Ready && conditionCheck
 }
 
 // GetClowdSAName returns the ServiceAccount Name for the App

--- a/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
@@ -492,7 +492,7 @@ func (i *ClowdApp) GetCronJobNamespacedName(d *Job) types.NamespacedName {
 	}
 }
 
-// IsReady returns true when all the ManagedDeployments are Ready
+// IsReady returns true when all deployments are ready and the reconciliation is successful
 func (i *ClowdApp) IsReady() bool {
 	conditionCheck := false
 

--- a/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
@@ -573,7 +573,7 @@ func (i *ClowdEnvironment) GenerateTargetNamespace() string {
 	return fmt.Sprintf("clowdenv-%s-%s", i.Name, strings.ToLower(utils.RandString(6)))
 }
 
-// IsReady returns true when all the ManagedDeployments are Ready
+// IsReady returns true when all deployments are ready and the reconciliation is successful
 func (i *ClowdEnvironment) IsReady() bool {
 	conditionCheck := false
 

--- a/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
@@ -575,7 +575,15 @@ func (i *ClowdEnvironment) GenerateTargetNamespace() string {
 
 // IsReady returns true when all the ManagedDeployments are Ready
 func (i *ClowdEnvironment) IsReady() bool {
-	return (i.Status.Deployments.ManagedDeployments == i.Status.Deployments.ReadyDeployments)
+	conditionCheck := false
+
+	for _, condition := range i.Status.Conditions {
+		if condition.Type == ReconciliationSuccessful {
+			conditionCheck = true
+		}
+	}
+
+	return i.Status.Ready && conditionCheck
 }
 
 // ConvertDeprecatedKafkaSpec converts values from the old Kafka provider spec into the new format

--- a/controllers/cloud.redhat.com/clowdapp_controller.go
+++ b/controllers/cloud.redhat.com/clowdapp_controller.go
@@ -309,6 +309,24 @@ func ignoreStatusUpdatePredicate(logr logr.Logger, ctrlName string) predicate.Pr
 				}
 			}
 
+			if _, ok := e.ObjectOld.(*strimzi.KafkaTopic); ok {
+				if _, ok := e.ObjectNew.(*strimzi.KafkaTopic); ok {
+					return true
+				}
+			}
+
+			if _, ok := e.ObjectOld.(*strimzi.KafkaUser); ok {
+				if _, ok := e.ObjectNew.(*strimzi.KafkaUser); ok {
+					return true
+				}
+			}
+
+			if _, ok := e.ObjectOld.(*strimzi.KafkaConnect); ok {
+				if _, ok := e.ObjectNew.(*strimzi.KafkaConnect); ok {
+					return true
+				}
+			}
+
 			// Ignore updates to CR status in which case metadata.Generation does not change
 			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
 		},

--- a/controllers/cloud.redhat.com/clowdapp_controller.go
+++ b/controllers/cloud.redhat.com/clowdapp_controller.go
@@ -144,7 +144,8 @@ func (r *ClowdAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	if ReadEnv() == app.Spec.EnvName {
 		r.Recorder.Eventf(&app, "Warning", "ClowdEnvLocked", "Clowder Environment [%s] is locked", app.Spec.EnvName)
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, fmt.Errorf("env currently being reconciled")
+		log.Info("Env currently being reconciled", "app", app.Name, "namespace", app.Namespace, "env", app.Spec.EnvName)
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, nil
 	}
 
 	log.Info("Reconciliation started", "app", fmt.Sprintf("%s:%s", app.Namespace, app.Name))

--- a/controllers/cloud.redhat.com/clowdapp_controller.go
+++ b/controllers/cloud.redhat.com/clowdapp_controller.go
@@ -144,7 +144,7 @@ func (r *ClowdAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	if ReadEnv() == app.Spec.EnvName {
 		r.Recorder.Eventf(&app, "Warning", "ClowdEnvLocked", "Clowder Environment [%s] is locked", app.Spec.EnvName)
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, fmt.Errorf("env currently being reconciled")
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, fmt.Errorf("env currently being reconciled")
 	}
 
 	log.Info("Reconciliation started", "app", fmt.Sprintf("%s:%s", app.Namespace, app.Name))
@@ -164,19 +164,19 @@ func (r *ClowdAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if err != nil {
 		r.Recorder.Eventf(&app, "Warning", "ClowdEnvMissing", "Clowder Environment [%s] is missing", app.Spec.EnvName)
 		SetClowdAppConditions(ctx, r.Client, &app, crd.ReconciliationFailed, err)
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, err
 	}
 
 	if env.Generation != env.Status.Generation {
 		r.Recorder.Eventf(&app, "Warning", "ClowdEnvNotReconciled", "Clowder Environment [%s] is not reconciled", app.Spec.EnvName)
 		log.Info("Env not yet reconciled", "app", app.Name, "namespace", app.Namespace)
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, nil
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, nil
 	}
 
 	if !env.IsReady() {
 		r.Recorder.Eventf(&app, "Warning", "ClowdEnvNotReady", "Clowder Environment [%s] is not ready", app.Spec.EnvName)
 		log.Info("Env not yet ready", "app", app.Name, "namespace", app.Namespace)
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, nil
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, nil
 	}
 
 	cache := providers.NewObjectCache(ctx, r.Client, scheme)
@@ -195,9 +195,9 @@ func (r *ClowdAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		r.Recorder.Eventf(&app, "Warning", "FailedReconciliation", "Clowdapp requeued [%s]", app.GetClowdName())
 		err := SetClowdAppConditions(ctx, r.Client, &app, crd.ReconciliationFailed, provErr)
 		if err != nil {
-			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, err
 		}
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, provErr
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, provErr
 	}
 
 	cacheErr := cache.ApplyAll()
@@ -206,13 +206,13 @@ func (r *ClowdAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		r.Recorder.Eventf(&app, "Warning", "FailedReconciliation", "Clowdapp requeued [%s]", app.GetClowdName())
 		err := SetClowdAppConditions(ctx, r.Client, &app, crd.ReconciliationFailed, cacheErr)
 		if err != nil {
-			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, err
 		}
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, cacheErr
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, cacheErr
 	}
 
 	if statusErr := SetAppResourceStatus(ctx, r.Client, &app); statusErr != nil {
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, err
 	}
 
 	// Delete all resources that are not used anymore
@@ -221,7 +221,7 @@ func (r *ClowdAppReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	rErr := cache.Reconcile(&app)
 	if rErr != nil {
 		log.Info("Reconcile error", "error", rErr)
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, nil
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, nil
 	}
 	err = SetClowdAppConditions(ctx, r.Client, &app, crd.ReconciliationSuccessful, nil)
 

--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -156,7 +156,7 @@ func (r *ClowdEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			if err != nil {
 				r.Recorder.Eventf(&env, "Warning", "NamespaceMissing", "Requested Target Namespace [%s] is missing", env.Spec.TargetNamespace)
 				SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationFailed, err)
-				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
+				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, err
 			}
 			env.Status.TargetNamespace = env.Spec.TargetNamespace
 		} else {
@@ -166,13 +166,13 @@ func (r *ClowdEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			err := r.Client.Create(ctx, namespace)
 			if err != nil {
 				SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationFailed, err)
-				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
+				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, err
 			}
 		}
 		err := r.Client.Status().Update(ctx, &env)
 		if err != nil {
 			SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationFailed, err)
-			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, err
 		}
 	}
 
@@ -195,9 +195,9 @@ func (r *ClowdEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if provErr != nil {
 		err := SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationFailed, provErr)
 		if err != nil {
-			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, err
 		}
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, provErr
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, provErr
 	}
 
 	cacheErr := cache.ApplyAll()
@@ -205,9 +205,9 @@ func (r *ClowdEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if cacheErr != nil {
 		err := SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationFailed, cacheErr)
 		if err != nil {
-			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, err
 		}
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, cacheErr
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, cacheErr
 	}
 
 	if err == nil {
@@ -220,12 +220,12 @@ func (r *ClowdEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	err = r.setAppInfo(provider)
 	if err != nil {
 		SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationFailed, err)
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, err
 	}
 
 	if statusErr := SetEnvResourceStatus(ctx, r.Client, &env); statusErr != nil {
 		SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationFailed, err)
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, err
 	}
 
 	setPrometheusStatus(&env)
@@ -240,7 +240,7 @@ func (r *ClowdEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	if err := r.Client.Status().Update(ctx, &env); err != nil {
 		SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationFailed, err)
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, err
 	}
 
 	r.Recorder.Eventf(&env, "Normal", "SuccessfulReconciliation", "Environment reconciled [%s]", env.GetClowdName())
@@ -249,12 +249,12 @@ func (r *ClowdEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// Delete all resources that are not used anymore
 	rErr := cache.Reconcile(&env)
 	if rErr != nil {
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, nil
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, nil
 	}
 
 	err = SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationSuccessful, err)
 	if err != nil {
-		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, nil
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 2}, nil
 	}
 
 	return ctrl.Result{}, nil

--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"sync"
+	"time"
 
 	strimzi "github.com/RedHatInsights/strimzi-client-go/apis/kafka.strimzi.io/v1beta2"
 	"github.com/go-logr/logr"
@@ -65,9 +65,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var mu sync.RWMutex
-var cEnv = ""
-
 const envFinalizer = "finalizer.env.cloud.redhat.com"
 
 // ClowdEnvironmentReconciler reconciles a ClowdEnvironment object
@@ -80,24 +77,6 @@ type ClowdEnvironmentReconciler struct {
 
 // +kubebuilder:rbac:groups=cloud.redhat.com,resources=clowdenvironments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cloud.redhat.com,resources=clowdenvironments/status,verbs=get;update;patch
-
-func SetEnv(name string) {
-	mu.Lock()
-	defer mu.Unlock()
-	cEnv = name
-}
-
-func ReleaseEnv() {
-	mu.Lock()
-	defer mu.Unlock()
-	cEnv = ""
-}
-
-func ReadEnv() string {
-	mu.RLock()
-	defer mu.RUnlock()
-	return cEnv
-}
 
 //Reconcile fn
 func (r *ClowdEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -114,7 +93,7 @@ func (r *ClowdEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 		return ctrl.Result{}, err
 	}
-
+	GetEnvResourceStatus(ctx, r.Client, &env)
 	isEnvMarkedForDeletion := env.GetDeletionTimestamp() != nil
 	if isEnvMarkedForDeletion {
 		if contains(env.GetFinalizers(), envFinalizer) {
@@ -155,7 +134,7 @@ func (r *ClowdEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			if err != nil {
 				r.Recorder.Eventf(&env, "Warning", "NamespaceMissing", "Requested Target Namespace [%s] is missing", env.Spec.TargetNamespace)
 				SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationFailed, err)
-				return ctrl.Result{Requeue: true}, err
+				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
 			}
 			env.Status.TargetNamespace = env.Spec.TargetNamespace
 		} else {
@@ -165,13 +144,13 @@ func (r *ClowdEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			err := r.Client.Create(ctx, namespace)
 			if err != nil {
 				SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationFailed, err)
-				return ctrl.Result{Requeue: true}, err
+				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
 			}
 		}
 		err := r.Client.Status().Update(ctx, &env)
 		if err != nil {
 			SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationFailed, err)
-			return ctrl.Result{Requeue: true}, err
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
 		}
 	}
 
@@ -187,32 +166,24 @@ func (r *ClowdEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		Log:    log,
 	}
 
-	var requeue = false
-
-	SetEnv(env.Name)
-	defer ReleaseEnv()
 	provErr := runProvidersForEnv(log, provider)
 
 	if provErr != nil {
-		if non_fatal := errors.HandleError(ctx, provErr); !non_fatal {
-			SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationFailed, provErr)
-			return ctrl.Result{}, provErr
-
-		} else {
-			requeue = true
+		err := SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationFailed, provErr)
+		if err != nil {
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
 		}
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, provErr
 	}
 
 	cacheErr := cache.ApplyAll()
 
 	if cacheErr != nil {
-		if non_fatal := errors.HandleError(ctx, cacheErr); !non_fatal {
-			SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationFailed, cacheErr)
-			return ctrl.Result{}, cacheErr
-
-		} else {
-			requeue = true
+		err := SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationFailed, cacheErr)
+		if err != nil {
+			return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
 		}
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, cacheErr
 	}
 
 	if err == nil {
@@ -225,47 +196,44 @@ func (r *ClowdEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	err = r.setAppInfo(provider)
 	if err != nil {
 		SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationFailed, err)
-		return ctrl.Result{Requeue: true}, err
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
 	}
 
 	if statusErr := SetEnvResourceStatus(ctx, r.Client, &env); statusErr != nil {
 		SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationFailed, err)
-		return ctrl.Result{}, err
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
 	}
 
 	setPrometheusStatus(&env)
 
-	env.Status.Ready = env.IsReady()
+	ready, err := GetEnvResourceStatus(ctx, r.Client, &env)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	env.Status.Ready = ready
 	env.Status.Generation = env.Generation
 
 	if err := r.Client.Status().Update(ctx, &env); err != nil {
 		SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationFailed, err)
-		return ctrl.Result{}, err
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, err
 	}
 
-	if !requeue {
-		r.Recorder.Eventf(&env, "Normal", "SuccessfulReconciliation", "Environment reconciled [%s]", env.GetClowdName())
-		log.Info("Reconciliation successful", "env", env.Name)
+	r.Recorder.Eventf(&env, "Normal", "SuccessfulReconciliation", "Environment reconciled [%s]", env.GetClowdName())
+	log.Info("Reconciliation successful", "env", env.Name)
 
-		// Delete all resources that are not used anymore
-		err := cache.Reconcile(&env)
-		if err != nil {
-			return ctrl.Result{Requeue: requeue}, nil
-		}
-		SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationSuccessful, err)
-	} else {
-		var err error
-		if provErr != nil {
-			err = provErr
-		} else if cacheErr != nil {
-			err = cacheErr
-		}
-		log.Info("Reconciliation partially successful", "env", fmt.Sprintf("%s:%s", env.Namespace, env.Name))
-		r.Recorder.Eventf(&env, "Warning", "SuccessfulPartialReconciliation", "Environment requeued [%s]", env.GetClowdName())
-		SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationPartiallySuccessful, err)
+	// Delete all resources that are not used anymore
+	rErr := cache.Reconcile(&env)
+	if rErr != nil {
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, nil
 	}
 
-	return ctrl.Result{Requeue: requeue}, nil
+	err = SetClowdEnvConditions(ctx, r.Client, &env, crd.ReconciliationSuccessful, err)
+	if err != nil {
+		return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 10}, nil
+	}
+
+	return ctrl.Result{}, nil
 }
 
 func setPrometheusStatus(env *crd.ClowdEnvironment) {

--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -276,6 +276,8 @@ func (r *ClowdEnvironmentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if clowder_config.LoadedConfig.Features.WatchStrimziResources {
 		controller.Owns(&strimzi.Kafka{})
 		controller.Owns(&strimzi.KafkaConnect{})
+		controller.Owns(&strimzi.KafkaUser{})
+		controller.Owns(&strimzi.KafkaTopic{})
 	}
 
 	return controller.Complete(r)

--- a/controllers/cloud.redhat.com/providers/kafka/strimzi.go
+++ b/controllers/cloud.redhat.com/providers/kafka/strimzi.go
@@ -283,7 +283,7 @@ func (s *strimziProvider) configureKafkaCluster() error {
 	k.SetLabels(providers.Labels{"env": s.Env.Name})
 	k.SetOwnerReferences([]metav1.OwnerReference{s.Env.MakeOwnerReference()})
 
-	if err := s.Cache.Update(KafkaInstance, k); err != nil {
+	if err := s.Cache.Update(KafkaInstance, k, providers.CacheOption{WriteNow: true}); err != nil {
 		return err
 	}
 
@@ -308,7 +308,7 @@ func (s *strimziProvider) createKafkaMetricsConfigMap() (types.NamespacedName, e
 	cm.SetLabels(providers.Labels{"env": s.Env.Name})
 	cm.SetOwnerReferences([]metav1.OwnerReference{s.Env.MakeOwnerReference()})
 
-	if err := s.Cache.Update(KafkaMetricsConfigMap, cm); err != nil {
+	if err := s.Cache.Update(KafkaMetricsConfigMap, cm, providers.CacheOption{WriteNow: true}); err != nil {
 		return types.NamespacedName{}, err
 	}
 
@@ -380,7 +380,7 @@ func (s *strimziProvider) createKafkaConnectUser() error {
 		},
 	})
 
-	if err := s.Cache.Update(KafkaConnectUser, ku); err != nil {
+	if err := s.Cache.Update(KafkaConnectUser, ku, providers.CacheOption{WriteNow: true}); err != nil {
 		return err
 	}
 
@@ -480,7 +480,7 @@ func (s *strimziProvider) configureKafkaConnectCluster() error {
 	k.SetNamespace(getConnectNamespace(s.Env))
 	k.SetLabels(providers.Labels{"env": s.Env.Name})
 
-	if err := s.Cache.Update(KafkaConnect, k); err != nil {
+	if err := s.Cache.Update(KafkaConnect, k, providers.CacheOption{WriteNow: true}); err != nil {
 		return err
 	}
 
@@ -641,7 +641,7 @@ func createNetworkPolicies(p *providers.Provider) error {
 	labeler := utils.GetCustomLabeler(nil, nn, p.Env)
 	labeler(np)
 
-	if err := p.Cache.Update(KafkaNetworkPolicy, np); err != nil {
+	if err := p.Cache.Update(KafkaNetworkPolicy, np, providers.CacheOption{WriteNow: true}); err != nil {
 		return err
 	}
 
@@ -783,7 +783,7 @@ func (s *strimziProvider) createKafkaUser(app *crd.ClowdApp) error {
 		},
 	})
 
-	if err := s.Cache.Update(KafkaUser, ku); err != nil {
+	if err := s.Cache.Update(KafkaUser, ku, providers.CacheOption{WriteNow: true}); err != nil {
 		return err
 	}
 
@@ -837,7 +837,7 @@ func (s *strimziProvider) processTopics(app *crd.ClowdApp) error {
 			return err
 		}
 
-		if err := s.Cache.Update(KafkaTopic, k); err != nil {
+		if err := s.Cache.Update(KafkaTopic, k, providers.CacheOption{WriteNow: true}); err != nil {
 			return err
 		}
 

--- a/controllers/cloud.redhat.com/providers/providers.go
+++ b/controllers/cloud.redhat.com/providers/providers.go
@@ -113,8 +113,8 @@ func createResource(cache *ObjectCache, resourceIdent ResourceIdent, nn types.Na
 	return nobj, nil
 }
 
-func updateResource(cache *ObjectCache, resourceIdent ResourceIdent, object client.Object) error {
-	err := cache.Update(resourceIdent, object)
+func updateResource(cache *ObjectCache, resourceIdent ResourceIdent, object client.Object, opts ...CacheOption) error {
+	err := cache.Update(resourceIdent, object, opts...)
 
 	if err != nil {
 		return err
@@ -127,7 +127,7 @@ type ObjectMap map[ResourceIdent]client.Object
 
 // CachedMakeComponent is a generalised function that, given a ClowdObject will make the given service,
 // deployment and PVC, based on the makeFn that is passed in.
-func CachedMakeComponent(cache *ObjectCache, objList []ResourceIdent, o obj.ClowdObject, suffix string, fn makeFnCache, usePVC bool, nodePort bool) error {
+func CachedMakeComponent(cache *ObjectCache, objList []ResourceIdent, o obj.ClowdObject, suffix string, fn makeFnCache, usePVC bool, nodePort bool, opts ...CacheOption) error {
 	nn := GetNamespacedName(o, suffix)
 
 	makeFnMap := make(map[ResourceIdent]client.Object)
@@ -146,7 +146,7 @@ func CachedMakeComponent(cache *ObjectCache, objList []ResourceIdent, o obj.Clow
 	fn(o, makeFnMap, usePVC, nodePort)
 
 	for k, v := range makeFnMap {
-		err := updateResource(cache, k, v)
+		err := updateResource(cache, k, v, opts...)
 
 		if err != nil {
 			return errors.Wrap(fmt.Sprintf("make-%s: get", suffix), err)
@@ -241,7 +241,7 @@ func MakeOrGetSecret(ctx context.Context, obj obj.ClowdObject, cache *ObjectCach
 		}
 	}
 
-	if err := cache.Update(resourceIdent, secret); err != nil {
+	if err := cache.Update(resourceIdent, secret, CacheOption{WriteNow: true}); err != nil {
 		return nil, err
 	}
 

--- a/controllers/cloud.redhat.com/providers/web/local.go
+++ b/controllers/cloud.redhat.com/providers/web/local.go
@@ -93,7 +93,7 @@ func NewLocalWebProvider(p *providers.Provider) (providers.ClowderProvider, erro
 		WebKeycloakService,
 	}
 
-	if err := providers.CachedMakeComponent(p.Cache, objList, p.Env, "keycloak", makeKeycloak, false, p.Env.IsNodePort()); err != nil {
+	if err := providers.CachedMakeComponent(p.Cache, objList, p.Env, "keycloak", makeKeycloak, false, p.Env.IsNodePort(), providers.CacheOption{WriteNow: true}); err != nil {
 		return nil, err
 	}
 
@@ -230,7 +230,7 @@ func makeAuthIngress(p *providers.Provider) error {
 		},
 	}
 
-	if err := p.Cache.Update(WebKeycloakIngress, netobj); err != nil {
+	if err := p.Cache.Update(WebKeycloakIngress, netobj, providers.CacheOption{WriteNow: true}); err != nil {
 		return err
 	}
 	return nil

--- a/controllers/cloud.redhat.com/status.go
+++ b/controllers/cloud.redhat.com/status.go
@@ -335,7 +335,7 @@ func GetEnvResourceStatus(ctx context.Context, client client.Client, o *crd.Clow
 func SetClowdEnvConditions(ctx context.Context, client client.Client, o *crd.ClowdEnvironment, state crd.ClowdConditionType, err error) error {
 	conditions := []crd.ClowdCondition{}
 
-	loopConditions := []crd.ClowdConditionType{crd.ReconciliationSuccessful, crd.ReconciliationPartiallySuccessful, crd.ReconciliationFailed}
+	loopConditions := []crd.ClowdConditionType{crd.ReconciliationSuccessful, crd.ReconciliationFailed}
 	for _, conditionType := range loopConditions {
 		condition := &crd.ClowdCondition{}
 		condition.Type = conditionType
@@ -389,7 +389,7 @@ func SetClowdEnvConditions(ctx context.Context, client client.Client, o *crd.Clo
 func SetClowdAppConditions(ctx context.Context, client client.Client, o *crd.ClowdApp, state crd.ClowdConditionType, err error) error {
 	conditions := []crd.ClowdCondition{}
 
-	loopConditions := []crd.ClowdConditionType{crd.ReconciliationSuccessful, crd.ReconciliationPartiallySuccessful, crd.ReconciliationFailed}
+	loopConditions := []crd.ClowdConditionType{crd.ReconciliationSuccessful, crd.ReconciliationFailed}
 	for _, conditionType := range loopConditions {
 		condition := &crd.ClowdCondition{}
 		condition.Type = conditionType
@@ -592,7 +592,7 @@ func UpdateClowdJobInvocationCondition(status *crd.ClowdJobInvocationStatus, con
 func SetClowdJobInvocationConditions(ctx context.Context, client client.Client, o *crd.ClowdJobInvocation, state crd.ClowdConditionType, err error) error {
 	conditions := []crd.ClowdCondition{}
 
-	loopConditions := []crd.ClowdConditionType{crd.ReconciliationSuccessful, crd.ReconciliationPartiallySuccessful, crd.ReconciliationFailed}
+	loopConditions := []crd.ClowdConditionType{crd.ReconciliationSuccessful, crd.ReconciliationFailed}
 	for _, conditionType := range loopConditions {
 		condition := &crd.ClowdCondition{}
 		condition.Type = conditionType


### PR DESCRIPTION
This PR removes partial reconciliation completely. This was originally introduced to try to circumvent the issue of requiring some resources to be created and acted upon by other operators during a single reconciliation event. Taking the example of deploying Kafka. We require a `KafkaUser` resource to be created, and from strimzi to populate it with a `Status.Username` field. However it is not a good idea to sit and wait for this to happen as:
* The controller is single threaded so this will hold up all other reconciliations of this type
* We do not know if it will successfully complete
To combat this the idea of a partial reconciliation was introduced to allow all the resources up until that point to be written out. The problem with this approach is that if the reconciliation is bombed halfway through, some resources do not receive all their updates, meaning that when a reconciliation IS complete, more change are made, sometimes bouncing a pod.

This PR removes that process and instead INSTANT writes certain resources that are required, and then FAILS the reconciliation. This means nothing is written out until a reconciliation succeeds.