### PR TITLE
Fix sidecar support for cronjobs

### DIFF
--- a/bundle/tests/scorecard/kuttl/test-sidecars/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-sidecars/01-assert.yaml
@@ -24,3 +24,17 @@ spec:
       containers:
       - name: puptoo-processor
       - name: token-refresher
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: puptoo-cron
+  namespace: test-sidecars
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: puptoo-cron
+          - name: token-refresher

--- a/bundle/tests/scorecard/kuttl/test-sidecars/01-pods.yaml
+++ b/bundle/tests/scorecard/kuttl/test-sidecars/01-pods.yaml
@@ -48,6 +48,14 @@ spec:
       sidecars:
         - name: token-refresher
           enabled: true
+  jobs:
+    - name: cron
+      schedule: "*/1 * * * *"
+      podSpec:
+        image: quay.io/psav/clowder-hello
+        sidecars:
+          - name: token-refresher
+            enabled: true
 ---
 apiVersion: v1
 data:

--- a/controllers/cloud.redhat.com/providers/sidecar/default.go
+++ b/controllers/cloud.redhat.com/providers/sidecar/default.go
@@ -66,7 +66,7 @@ func (sc *sidecarProvider) Provide(app *crd.ClowdApp, c *config.AppConfig) error
 				return fmt.Errorf("%s is not a valid sidecar name", sidecar.Name)
 			}
 
-			sc.Cache.Update(deployProvider.CoreDeployment, cj)
+			sc.Cache.Update(cronjobProvider.CoreCronJob, cj)
 		}
 	}
 


### PR DESCRIPTION
Running the modified test:

```
kubectl kuttl test -v2 bundle/tests/scorecard/kuttl/ --test test-sidecars
```