### PR TITLE
Add option to disable Keda resource listing

### DIFF
--- a/clowder-config.yaml
+++ b/clowder-config.yaml
@@ -4,7 +4,8 @@ data:
     {
         "features": {
             "createServiceMonitor": true,
-            "watchStrimziResources": true
+            "watchStrimziResources": true,
+            "enableKedaResources": true
         }
     }
 kind: ConfigMap

--- a/controllers/cloud.redhat.com/clowder_config/config.go
+++ b/controllers/cloud.redhat.com/clowder_config/config.go
@@ -39,6 +39,7 @@ type ClowderConfig struct {
 		WatchStrimziResources       bool `json:"watchStrimziResources"`
 		UseComplexStrimziTopicNames bool `json:"useComplexStrimziTopicNames"`
 		EnableAuthSidecarHook       bool `json:"enableAuthSidecarHook"`
+		KedaResources               bool `json:"enableKedaResources"`
 	} `json:"features"`
 }
 

--- a/controllers/cloud.redhat.com/providers/resource_cache.go
+++ b/controllers/cloud.redhat.com/providers/resource_cache.go
@@ -102,6 +102,11 @@ func init() {
 	gvk, _ := utils.GetKindFromObj(scheme, &strimzi.KafkaTopic{})
 	protectedGVKs[gvk] = true
 
+	if !clowder_config.LoadedConfig.Features.KedaResources {
+		gvk, _ := utils.GetKindFromObj(scheme, &keda.ScaledObject{})
+		protectedGVKs[gvk] = true
+	}
+
 	secretCompare, _ = utils.GetKindFromObj(scheme, &core.Secret{})
 }
 


### PR DESCRIPTION
Currently Keda resources are not available on stage/prod, this means that during the reconcile process, Clowder will try to list Keda resources to see if any are available for it to delete. On stage, prod, this causes the Clowder operator to fail the reconciliation. An option to disable the Keda watching needs to be created.