### PR TITLE
Fix Keda assertions

### DIFF
--- a/controllers/cloud.redhat.com/providers/deployment/impl.go
+++ b/controllers/cloud.redhat.com/providers/deployment/impl.go
@@ -37,6 +37,8 @@ func initDeployment(app *crd.ClowdApp, env *crd.ClowdEnvironment, d *apps.Deploy
 	labels["pod"] = nn.Name
 	app.SetObjectMeta(d, crd.Name(nn.Name), crd.Labels(labels))
 
+	d.Kind = "Deployment"
+
 	pod := deployment.PodSpec
 	d.Spec.Template.SetAnnotations(make(map[string]string))
 	if env.Spec.Providers.Web.Mode == "local" && (deployment.WebServices.Public.Enabled || bool(deployment.Web)) {

--- a/controllers/cloud.redhat.com/suite_test.go
+++ b/controllers/cloud.redhat.com/suite_test.go
@@ -773,12 +773,12 @@ func scaledObjectValidation(t *testing.T, app *crd.ClowdApp, scaler *keda.Scaled
 		},
 	}
 	for _, trigger := range scaler.Spec.Triggers {
-		assert.Equal(t, trigger.Type, expectedTrigger.Type)
-		assert.Equal(t, trigger.Metadata, expectedTrigger.Metadata)
+		assert.Equal(t, expectedTrigger.Type, trigger.Type)
+		assert.Equal(t, expectedTrigger.Metadata, trigger.Metadata)
 	}
 
-	assert.Equal(t, scaler.Spec.ScaleTargetRef.Kind, expectTarget.Kind)
-	assert.Equal(t, scaler.Spec.ScaleTargetRef.Name, expectTarget.Name)
+	assert.Equal(t, expectTarget.Kind, scaler.Spec.ScaleTargetRef.Kind)
+	assert.Equal(t, expectTarget.Name, scaler.Spec.ScaleTargetRef.Name)
 }
 
 func fetchWithDefaults(name types.NamespacedName, resource client.Object) error {


### PR DESCRIPTION
A couple of fixes here
* The test had reversed expectations and actuals which made it harder to read the test failure
* There was a condition during test suite run where we could error out because of a race condition. If the reconciliation was only achieved once when the conditions were checked, the deployment kind that the autoscaler provider uses had not yet been populated. However if the app reconciliation had been run once, the deployment already existed in k8s and had the correct type, in this way when the autoscaler provider ran it would correctly pick up the kind from the cached Deployment object, and the test would pass. The fix for this is to pre-set the deployment type. Usually this is not necessary as it is set by the client on write. It may be an idea to get the cache to set this information if it is not already present by noting if this is an update/create.