### PR TITLE
Fix autoscalar replicas

### DIFF
--- a/controllers/cloud.redhat.com/providers/deployment/impl.go
+++ b/controllers/cloud.redhat.com/providers/deployment/impl.go
@@ -48,12 +48,16 @@ func initDeployment(app *crd.ClowdApp, env *crd.ClowdEnvironment, d *apps.Deploy
 		d.Spec.Template.Annotations["clowder/authsidecar-config"] = fmt.Sprintf("caddy-config-%s-%s", app.Name, deployment.Name)
 	}
 
-	// let autoscaler scale without reconciliation re-writing the replicas
-	if d.Spec.Replicas == nil {
-		// Replicas is nil during deployment initialisation
-		d.Spec.Replicas = deployment.MinReplicas
-	} else if deployment.MinReplicas != nil && *d.Spec.Replicas < *deployment.MinReplicas {
-		// Reset replicas to minReplicas if it somehow falls below minReplicas
+	if deployment.AutoScaler != nil {
+		// let autoscaler scale without reconciliation re-writing the replicas
+		if d.Spec.Replicas == nil {
+			// Replicas is nil during deployment initialisation
+			d.Spec.Replicas = deployment.MinReplicas
+		} else if deployment.MinReplicas != nil && *d.Spec.Replicas < *deployment.MinReplicas {
+			// Reset replicas to minReplicas if it somehow falls below minReplicas
+			d.Spec.Replicas = deployment.MinReplicas
+		}
+	} else {
 		d.Spec.Replicas = deployment.MinReplicas
 	}
 


### PR DESCRIPTION
* If a clowdapp increased the minReplica count and then reduces it, the
  the deployment does not reduce in kind.
* This PR adds in a check to ensure that autoscaler is enabled
  if it is not, it returns to the old behaviour where replicas is
  always overidden.