### PR TITLE
[RHCLOUD-17256] Streamline the creation of SA and pullsecrets

### DIFF
--- a/controllers/cloud.redhat.com/object/object.go
+++ b/controllers/cloud.redhat.com/object/object.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -14,6 +15,7 @@ type ClowdObject interface {
 	GetUID() types.UID
 	GetClowdSAName() string
 	GetPrimaryLabel() string
+	GroupVersionKind() schema.GroupVersionKind
 }
 
 // LabeledClowdObject is used to be able to treat ClowdEnv and ClowdApp as the same type


### PR DESCRIPTION
* Currently Clowder does a lot of pull secret copying at the env
  reconciliation stage. This introduces many more API calls
  than are necessary in a multi-namespace environment
  and can end up with contention.
* The copying has been moved into the relevant controller step to make
  things more streamlined. The app controller now will only write app
  SAs and PullSecrets for that single,
app.