### PR TITLE
No longer using random ident in env hostname

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
@@ -700,14 +700,12 @@ func (i *ClowdEnvironment) GenerateHostname(ctx context.Context, pClient client.
 		return i.Name
 	}
 
-	randomIdent := strings.ToLower(utils.RandString(8))
-
 	obj := ic.Object
 	if obj["spec"] != nil {
 		spec := obj["spec"].(map[string]interface{})
 		domain := spec["domain"]
 		if domain != "" {
-			return fmt.Sprintf("%s-%s.%s", i.Name, randomIdent, domain)
+			return fmt.Sprintf("%s.%s", i.Name, domain)
 		}
 	}
 


### PR DESCRIPTION
A ClowdEnvironment name is unique on a cluster anyways, so we shouldn't need an additional layer of uniqueness.

This makes it easier for the NS operator to set up a FrontendEnvironment because the hostname follows a predictable format