### PR TITLE
Add ability to override IQE plugins on CJI

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdjobinvocation_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdjobinvocation_types.go
@@ -50,6 +50,11 @@ type IqeJobSpec struct {
 	// baseImage:name-of-iqe-plugin, but only the tag can be overridden here
 	ImageTag string `json:"imageTag,omitempty"`
 
+	// By default, Clowder will use the plugin name indicated in the ClowdApp's
+	// spec.testing.iqePlugin field. A comma,separated,list of plugins can be supplied
+	// here if you wish you override the plugins.
+	IqePlugins string `json:"plugins,omitempty"`
+
 	// Indiciates the presence of a selenium container
 	// Note: currently not implemented
 	UI IqeUISpec `json:"ui,omitempty"`

--- a/bundle/tests/scorecard/kuttl/test-iqe-jobs/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-iqe-jobs/01-assert.yaml
@@ -41,7 +41,7 @@ spec:
             - name: ACG_CONFIG
               value: /cdapp/cdappconfig.json
             - name: IQE_PLUGINS
-              value: "host-inventory"
+              value: "some,different,plugins"
             - name: IQE_MARKER_EXPRESSION
               value: "smoke"
             - name: IQE_FILTER_EXPRESSION

--- a/bundle/tests/scorecard/kuttl/test-iqe-jobs/01-pods.yaml
+++ b/bundle/tests/scorecard/kuttl/test-iqe-jobs/01-pods.yaml
@@ -72,6 +72,7 @@ spec:
   testing:
     iqe:
       imageTag: latest
+      plugins: "some,different,plugins"
       ui:
         enabled: false
       marker: "smoke"

--- a/bundle/tests/scorecard/kuttl/test-iqe-jobs/01-pods.yaml
+++ b/bundle/tests/scorecard/kuttl/test-iqe-jobs/01-pods.yaml
@@ -65,7 +65,7 @@ spec:
 apiVersion: cloud.redhat.com/v1alpha1
 kind: ClowdJobInvocation
 metadata:
-  name: host-inventory-smoke 
+  name: host-inventory-smoke
   namespace: test-iqe-jobs
 spec:
   appName: host-inventory

--- a/bundle/tests/scorecard/kuttl/test-iqe-jobs/02-delete-env.yaml
+++ b/bundle/tests/scorecard/kuttl/test-iqe-jobs/02-delete-env.yaml
@@ -8,3 +8,7 @@ delete:
 - apiVersion: rbac.authorization.k8s.io/v1 
   kind: RoleBinding 
   name: iqe-test-iqe-jobs
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  name: host-inventory-smoke 
+  namespace: test-iqe-jobs

--- a/bundle/tests/scorecard/kuttl/test-iqe-jobs/03-assert-with-view.yaml
+++ b/bundle/tests/scorecard/kuttl/test-iqe-jobs/03-assert-with-view.yaml
@@ -47,11 +47,8 @@ spec:
             - name: IQE_FILTER_EXPRESSION
               value: "test_plugin_accessible"
             - name: IQE_REQUIREMENTS
-              value: "some,requirements"
             - name: IQE_REQUIREMENTS_PRIORITY
-              value: "some-priority"
             - name: IQE_TEST_IMPORTANCE
-              value: "critical,high"
           resources:
             limits:
               cpu: "2"

--- a/bundle/tests/scorecard/kuttl/test-iqe-jobs/04-delete-env-view.yaml
+++ b/bundle/tests/scorecard/kuttl/test-iqe-jobs/04-delete-env-view.yaml
@@ -5,3 +5,7 @@ delete:
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdEnvironment
   name: test-iqe-jobs
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  name: host-inventory-smoke 
+  namespace: test-iqe-jobs

--- a/config/crd/bases/cloud.redhat.com_clowdjobinvocations.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdjobinvocations.yaml
@@ -76,6 +76,12 @@ spec:
                       marker:
                         description: sets the pytest -m args
                         type: string
+                      plugins:
+                        description: By default, Clowder will use the plugin name
+                          indicated in the ClowdApp's spec.testing.iqePlugin field.
+                          A comma,separated,list of plugins can be supplied here if
+                          you wish you override the plugins.
+                        type: string
                       requirements:
                         description: sets values passed to IQE '--requirements' arg
                         items:

--- a/controllers/cloud.redhat.com/providers/iqe/impl.go
+++ b/controllers/cloud.redhat.com/providers/iqe/impl.go
@@ -35,12 +35,16 @@ func joinNullableSlice(s *[]string) string {
 
 func createIqeContainer(j *batchv1.Job, nn types.NamespacedName, cji *crd.ClowdJobInvocation, env *crd.ClowdEnvironment, app *crd.ClowdApp) *core.Container {
 	// create env vars
+	iqePlugins := app.Spec.Testing.IqePlugin
+	if cji.Spec.Testing.Iqe.IqePlugins != "" {
+		iqePlugins = cji.Spec.Testing.Iqe.IqePlugins
+	}
 	envVars := []core.EnvVar{
 		{Name: "ENV_FOR_DYNACONF", Value: cji.Spec.Testing.Iqe.DynaconfEnvName},
 		{Name: "NAMESPACE", Value: nn.Namespace},
 		{Name: "CLOWDER_ENABLED", Value: "true"},
 		{Name: "ACG_CONFIG", Value: "/cdapp/cdappconfig.json"},
-		{Name: "IQE_PLUGINS", Value: app.Spec.Testing.IqePlugin},
+		{Name: "IQE_PLUGINS", Value: iqePlugins},
 		{Name: "IQE_MARKER_EXPRESSION", Value: cji.Spec.Testing.Iqe.Marker},
 		{Name: "IQE_FILTER_EXPRESSION", Value: cji.Spec.Testing.Iqe.Filter},
 		{Name: "IQE_REQUIREMENTS", Value: joinNullableSlice(cji.Spec.Testing.Iqe.Requirements)},

--- a/deploy-mutate.yml
+++ b/deploy-mutate.yml
@@ -6277,6 +6277,12 @@ objects:
                         marker:
                           description: sets the pytest -m args
                           type: string
+                        plugins:
+                          description: By default, Clowder will use the plugin name
+                            indicated in the ClowdApp's spec.testing.iqePlugin field.
+                            A comma,separated,list of plugins can be supplied here
+                            if you wish you override the plugins.
+                          type: string
                         requirements:
                           description: sets values passed to IQE '--requirements'
                             arg

--- a/deploy.yml
+++ b/deploy.yml
@@ -6277,6 +6277,12 @@ objects:
                         marker:
                           description: sets the pytest -m args
                           type: string
+                        plugins:
+                          description: By default, Clowder will use the plugin name
+                            indicated in the ClowdApp's spec.testing.iqePlugin field.
+                            A comma,separated,list of plugins can be supplied here
+                            if you wish you override the plugins.
+                          type: string
                         requirements:
                           description: sets values passed to IQE '--requirements'
                             arg

--- a/docs/antora/modules/ROOT/pages/api_reference.adoc
+++ b/docs/antora/modules/ROOT/pages/api_reference.adoc
@@ -26,7 +26,7 @@ Package v1alpha1 contains API Schema definitions for the cloud.redhat.com v1alph
 [id="{anchor_prefix}-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-appinfo"]
 ==== AppInfo 
 
-
+AppInfo details information about a specific app.
 
 .Appears In:
 ****
@@ -62,7 +62,7 @@ Package v1alpha1 contains API Schema definitions for the cloud.redhat.com v1alph
 [id="{anchor_prefix}-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-autoscaler"]
 ==== AutoScaler 
 
-
+AutoScaler defines the autoscaling parameters of a KEDA ScaledObject targeting the given deployment.
 
 .Appears In:
 ****
@@ -283,7 +283,7 @@ ClowdJobInvocationSpec defines the desired state of ClowdJobInvocation
 |===
 | Field | Description
 | *`appName`* __string__ | Name of the ClowdApp who owns the jobs
-| *`jobs`* __string__ | Jobs is the set of jobs to be run by the invocation
+| *`jobs`* __string array__ | Jobs is the set of jobs to be run by the invocation
 | *`testing`* __xref:{anchor_prefix}-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-jobtestingspec[$$JobTestingSpec$$]__ | Testing is the struct for building out test jobs (iqe, etc) in a CJI
 |===
 
@@ -391,7 +391,7 @@ Deployment defines a service running inside a ClowdApp and will output a deploym
 [id="{anchor_prefix}-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-deploymentinfo"]
 ==== DeploymentInfo 
 
-
+DeploymentInfo defailts information about a specific deployment.
 
 .Appears In:
 ****
@@ -539,6 +539,7 @@ InitContainer is a struct defining a k8s init container. This will be deployed a
 |===
 | Field | Description
 | *`imageTag`* __string__ | By default, Clowder will set the image on the ClowdJob to be the baseImage:name-of-iqe-plugin, but only the tag can be overridden here
+| *`plugins`* __string__ | By default, Clowder will use the plugin name indicated in the ClowdApp's spec.testing.iqePlugin field. A comma,separated,list of plugins can be supplied here if you wish you override the plugins.
 | *`ui`* __xref:{anchor_prefix}-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-iqeuispec[$$IqeUISpec$$]__ | Indiciates the presence of a selenium container Note: currently not implemented
 | *`marker`* __string__ | sets the pytest -m args
 | *`dynaconfEnvName`* __string__ | sets value for ENV_FOR_DYNACONF
@@ -858,7 +859,7 @@ PodSpec defines a container running inside a ClowdApp.
 | *`initContainers`* __xref:{anchor_prefix}-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-initcontainer[$$InitContainer$$]__ | A list of init containers used to perform at-startup operations.
 | *`command`* __string array__ | The command that will be invoked inside the pod at startup.
 | *`args`* __string array__ | A list of args to be passed to the pod container.
-| *`env`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#envvar-v1-core[$$EnvVar$$] array__ | A list of environment variables in k8s defined format.
+| *`env`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#envvar-v1-core[$$EnvVar$$]__ | A list of environment variables in k8s defined format.
 | *`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ | A pass-through of a resource requirements in k8s ResourceRequirements format. If omitted, the default resource requirements from the ClowdEnvironment will be used.
 | *`livenessProbe`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#probe-v1-core[$$Probe$$]__ | A pass-through of a Liveness Probe specification in standard k8s format. If omitted, a standard probe will be setup point to the webPort defined in the ClowdEnvironment and a path of /healthz. Ignored if Web is set to false.
 | *`readinessProbe`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#probe-v1-core[$$Probe$$]__ | A pass-through of a Readiness Probe specification in standard k8s format. If omitted, a standard probe will be setup point to the webPort defined in the ClowdEnvironment and a path of /healthz. Ignored if Web is set to false.


### PR DESCRIPTION
This adds a `plugins` field to the CJI IQE spec. By default, Clowder will use the plugin specified on the ClowdApp's `.spec.testing.iqePlugin` field (as it always has) -- but it can now be overridden using the 'plugins' field if desired when applying a CJI.