### PR TITLE
[RHCLOUD-18694] Use pre-push to remove excessive files being updated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,9 +153,16 @@ deploy-minikube: bundle docker-build-no-test docker-push-minikube deploy
 
 deploy-minikube-quick: bundle docker-build-no-test-quick docker-push-minikube deploy
 
+# we can't git ignore these files, but we want to avoid overwriting them
+no-update:
+	git checkout origin/master -- config/manager/kustomization.yaml \
+								  bundle/metadata/annotations.yaml \
+								  controllers/cloud.redhat.com/version.txt \
+								  config/manifests/bases/clowder.clusterserviceversion.yaml
+
 ##@ Deployment
 
-pre-push: manifests generate build-template api-docs
+pre-push: manifests generate build-template api-docs no-update
 
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/crd | kubectl apply -f -

--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,7 @@ deploy-minikube-quick: bundle docker-build-no-test-quick docker-push-minikube de
 
 # we can't git ignore these files, but we want to avoid overwriting them
 no-update:
+	git fetch origin
 	git checkout origin/master -- config/manager/kustomization.yaml \
 								  bundle/metadata/annotations.yaml \
 								  controllers/cloud.redhat.com/version.txt \

--- a/docs/antora/modules/ROOT/pages/api_reference.adoc
+++ b/docs/antora/modules/ROOT/pages/api_reference.adoc
@@ -26,7 +26,7 @@ Package v1alpha1 contains API Schema definitions for the cloud.redhat.com v1alph
 [id="{anchor_prefix}-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-appinfo"]
 ==== AppInfo 
 
-AppInfo details information about a specific app.
+
 
 .Appears In:
 ****
@@ -62,7 +62,7 @@ AppInfo details information about a specific app.
 [id="{anchor_prefix}-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-autoscaler"]
 ==== AutoScaler 
 
-AutoScaler defines the autoscaling parameters of a KEDA ScaledObject targeting the given deployment.
+
 
 .Appears In:
 ****
@@ -283,7 +283,7 @@ ClowdJobInvocationSpec defines the desired state of ClowdJobInvocation
 |===
 | Field | Description
 | *`appName`* __string__ | Name of the ClowdApp who owns the jobs
-| *`jobs`* __string array__ | Jobs is the set of jobs to be run by the invocation
+| *`jobs`* __string__ | Jobs is the set of jobs to be run by the invocation
 | *`testing`* __xref:{anchor_prefix}-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-jobtestingspec[$$JobTestingSpec$$]__ | Testing is the struct for building out test jobs (iqe, etc) in a CJI
 |===
 
@@ -391,7 +391,7 @@ Deployment defines a service running inside a ClowdApp and will output a deploym
 [id="{anchor_prefix}-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-deploymentinfo"]
 ==== DeploymentInfo 
 
-DeploymentInfo defailts information about a specific deployment.
+
 
 .Appears In:
 ****
@@ -859,13 +859,14 @@ PodSpec defines a container running inside a ClowdApp.
 | *`initContainers`* __xref:{anchor_prefix}-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-initcontainer[$$InitContainer$$]__ | A list of init containers used to perform at-startup operations.
 | *`command`* __string array__ | The command that will be invoked inside the pod at startup.
 | *`args`* __string array__ | A list of args to be passed to the pod container.
-| *`env`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#envvar-v1-core[$$EnvVar$$]__ | A list of environment variables in k8s defined format.
+| *`env`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#envvar-v1-core[$$EnvVar$$] array__ | A list of environment variables in k8s defined format.
 | *`resources`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#resourcerequirements-v1-core[$$ResourceRequirements$$]__ | A pass-through of a resource requirements in k8s ResourceRequirements format. If omitted, the default resource requirements from the ClowdEnvironment will be used.
 | *`livenessProbe`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#probe-v1-core[$$Probe$$]__ | A pass-through of a Liveness Probe specification in standard k8s format. If omitted, a standard probe will be setup point to the webPort defined in the ClowdEnvironment and a path of /healthz. Ignored if Web is set to false.
 | *`readinessProbe`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#probe-v1-core[$$Probe$$]__ | A pass-through of a Readiness Probe specification in standard k8s format. If omitted, a standard probe will be setup point to the webPort defined in the ClowdEnvironment and a path of /healthz. Ignored if Web is set to false.
 | *`volumes`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#volume-v1-core[$$Volume$$] array__ | A pass-through of a list of Volumes in standa k8s format.
 | *`volumeMounts`* __link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#volumemount-v1-core[$$VolumeMount$$] array__ | A pass-through of a list of VolumesMounts in standa k8s format.
 | *`sidecars`* __xref:{anchor_prefix}-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-sidecar[$$Sidecar$$] array__ | Lists the expected side cars, will be validated in the validating webhook
+| *`machinePool`* __string__ | MachinePool allows the pod to be scheduled to a particular machine pool.
 |===
 
 


### PR DESCRIPTION
Since we have lots of errant files being modified locally and pushed up, we should clear those out as part of our pre-push target. These files can't really be git ignored, but they need to be restricted when they update instead of updated by default.

* config/manager/kustomization.yaml
* bundle/metadata/annotations.yaml 
* cloud.redhat.com/version.txt 
* config/manifests/bases/clowder.clusterserviceversion.yaml

Will now be reverted to the master version and not pushed up.