### PR TITLE
Calc authsidecar-confighash w/ only secret data

### DIFF
--- a/controllers/cloud.redhat.com/providers/web/local.go
+++ b/controllers/cloud.redhat.com/providers/web/local.go
@@ -341,7 +341,7 @@ func (web *localWebProvider) Provide(app *crd.ClowdApp, c *config.AppConfig) err
 			"whitelist":   strings.Join(deployment.WebServices.Public.WhitelistPaths, ","),
 		}
 
-		jsonData, err := json.Marshal(sec)
+		jsonData, err := json.Marshal(sec.StringData)
 		if err != nil {
 			return errors.Wrap("Failed to marshal config JSON", err)
 		}

--- a/controllers/cloud.redhat.com/providers/web/local.go
+++ b/controllers/cloud.redhat.com/providers/web/local.go
@@ -163,7 +163,7 @@ func makeMocktitlementsSecret(p *providers.Provider, web *localWebProvider) erro
 		"whitelist":   "",
 	}
 
-	jsonData, err := json.Marshal(sec)
+	jsonData, err := json.Marshal(sec.StringData)
 	if err != nil {
 		return errors.Wrap("Failed to marshal config JSON", err)
 	}


### PR DESCRIPTION
The current calculation returns a different result the second time the hash is calculated, which results in a needless deployment update (and rolling deployment).

Note that I was unable to reproduce locally to verify what fields cause the hash to change, but I believe it must be fields other than data.

If someone can reproduce in an environment with sufficient logging it may be worth adding the following line to determine what fields specifically caused problems:

```
web.Log.Info("AuthConfigJson", "json", string(jsonData), "hash", hash)
```

Note this actually makes it so that `authsidecar-confighash` works more like the regular `confighash`, hashing only the data, and not the cached secret.