### PR TITLE
[RHCLOUD-19621] Add external listener to strimzi kafka resource

### DIFF
--- a/bundle/tests/scorecard/kuttl/test-kafka-strimzi-ephemeral/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-kafka-strimzi-ephemeral/01-assert.yaml
@@ -17,6 +17,15 @@ spec:
         port: 9092
         type: internal
         tls: false
+      - name: ext
+        port: 9094
+        tls: false
+        type: nodeport
+        configuration:
+          brokers:
+            - broker: 0
+              advertisedHost: localhost
+              advertisedPort: 9094
     storage:
       type: ephemeral
     resources:  # assert resource settings from ClowdEnvironment are used

--- a/bundle/tests/scorecard/kuttl/test-kafka-strimzi-pvc/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-kafka-strimzi-pvc/01-assert.yaml
@@ -17,6 +17,15 @@ spec:
         port: 9092
         type: internal
         tls: false
+      - name: ext
+        port: 9094
+        tls: false
+        type: nodeport
+        configuration:
+          brokers:
+            - broker: 0
+              advertisedHost: localhost
+              advertisedPort: 9094
     storage:
       type: persistent-claim
       size: 100Mi

--- a/controllers/cloud.redhat.com/providers/kafka/strimzi.go
+++ b/controllers/cloud.redhat.com/providers/kafka/strimzi.go
@@ -255,6 +255,27 @@ func (s *strimziProvider) configureKafkaCluster() error {
 
 	k.Spec.Kafka.Listeners = []strimzi.KafkaSpecKafkaListenersElem{listener}
 
+	if s.Env.Spec.Providers.Kafka.EnableLegacyStrimzi {
+		externalHost := "localhost"
+		externalPort := int32(9094)
+		externalListener := strimzi.KafkaSpecKafkaListenersElem{
+			Name: "ext",
+			Port: 9094,
+			Tls:  false,
+			Type: "nodeport",
+			Configuration: &strimzi.KafkaSpecKafkaListenersElemConfiguration{
+				Brokers: []strimzi.KafkaSpecKafkaListenersElemConfigurationBrokersElem{
+					{
+						AdvertisedHost: &externalHost,
+						AdvertisedPort: &externalPort,
+						Broker:         0,
+					},
+				},
+			},
+		}
+		k.Spec.Kafka.Listeners = append(k.Spec.Kafka.Listeners, externalListener)
+	}
+
 	if s.Env.Spec.Providers.Kafka.PVC {
 		k.Spec.Kafka.Storage = strimzi.KafkaSpecKafkaStorage{
 			Type:        strimzi.KafkaSpecKafkaStorageTypePersistentClaim,


### PR DESCRIPTION
This adds an external listener to the Kafka instance in ephemeral. This will be useful when forwarding the port to connect to Kafka locally. By using the external port (9094), Kafka can be connected at `localhost:9094` without requiring a DNS mapping in /etc/hosts.