### PR TITLE
RHCLOUD-19668: Use 'ignore all' kubelint annotation on Job pods

### DIFF
--- a/bundle/tests/scorecard/kuttl/test-clowder-jobs/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-clowder-jobs/01-assert.yaml
@@ -34,8 +34,7 @@ spec:
       template:
         metadata:
           annotations:
-            "ignore-check.kube-linter.io/no-liveness-probe": "probes not required on Job pods"
-            "ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods"
+            "kube-linter.io/ignore-all": "kubelint disabled for job pods"
         spec:
           serviceAccount: puptoo-app
           serviceAccountName: puptoo-app
@@ -64,8 +63,7 @@ spec:
       template:
         metadata:
           annotations:
-            "ignore-check.kube-linter.io/no-liveness-probe": "probes not required on Job pods"
-            "ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods"
+            "kube-linter.io/ignore-all": "kubelint disabled for job pods"
         spec:
           serviceAccount: puptoo-app
           serviceAccountName: puptoo-app
@@ -86,8 +84,7 @@ spec:
       template:
         metadata:
           annotations:
-            "ignore-check.kube-linter.io/no-liveness-probe": "probes not required on Job pods"
-            "ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods"
+            "kube-linter.io/ignore-all": "kubelint disabled for job pods"
         spec:
           serviceAccount: puptoo-app
           serviceAccountName: puptoo-app
@@ -107,8 +104,7 @@ spec:
   template:
     metadata:
       annotations:
-        "ignore-check.kube-linter.io/no-liveness-probe": "probes not required on Job pods"
-        "ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods"
+        "kube-linter.io/ignore-all": "kubelint disabled for job pods"
     spec:
       serviceAccount: puptoo-app
       serviceAccountName: puptoo-app

--- a/bundle/tests/scorecard/kuttl/test-iqe-jobs/01-assert.yaml
+++ b/bundle/tests/scorecard/kuttl/test-iqe-jobs/01-assert.yaml
@@ -28,8 +28,7 @@ spec:
   template:
     metadata:
       annotations:
-        "ignore-check.kube-linter.io/no-liveness-probe": "probes not required on Job pods"
-        "ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods"
+        "kube-linter.io/ignore-all": "kubelint disabled for job pods"
     spec:
       containers:
         - args:

--- a/controllers/cloud.redhat.com/providers/cronjob/impl.go
+++ b/controllers/cloud.redhat.com/providers/cronjob/impl.go
@@ -169,10 +169,7 @@ func applyCronCronJob(app *crd.ClowdApp, env *crd.ClowdEnvironment, cj *batch.Cr
 	app.SetObjectMeta(cj, crd.Name(nn.Name), crd.Labels(labels))
 
 	// add kubelinter annotations to ignore liveness/readiness probes on CronJobs
-	annotations := map[string]string{
-		"ignore-check.kube-linter.io/no-liveness-probe":  "probes not required on Job pods",
-		"ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods",
-	}
+	annotations := map[string]string{"kube-linter.io/ignore-all": "kubelint disabled for job pods"}
 	utils.UpdatePodTemplateAnnotations(pt, annotations)
 
 	cj.Spec.Schedule = cronjob.Schedule

--- a/controllers/cloud.redhat.com/providers/iqe/impl.go
+++ b/controllers/cloud.redhat.com/providers/iqe/impl.go
@@ -238,10 +238,7 @@ func CreateIqeJobResource(cache *rc.ObjectCache, cji *crd.ClowdJobInvocation, en
 	j.Spec.Template.Spec.Containers = containers
 
 	// add kubelinter annotations to ignore liveness/readiness probes on Jobs
-	annotations := map[string]string{
-		"ignore-check.kube-linter.io/no-liveness-probe":  "probes not required on Job pods",
-		"ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods",
-	}
+	annotations := map[string]string{"kube-linter.io/ignore-all": "kubelint disabled for job pods"}
 	utils.UpdatePodTemplateAnnotations(&j.Spec.Template, annotations)
 
 	return nil

--- a/controllers/cloud.redhat.com/providers/job/impl.go
+++ b/controllers/cloud.redhat.com/providers/job/impl.go
@@ -129,10 +129,7 @@ func CreateJobResource(cji *crd.ClowdJobInvocation, env *crd.ClowdEnvironment, a
 	})
 
 	// add kubelinter annotations to ignore liveness/readiness probes on Jobs
-	annotations := map[string]string{
-		"ignore-check.kube-linter.io/no-liveness-probe":  "probes not required on Job pods",
-		"ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods",
-	}
+	annotations := map[string]string{"kube-linter.io/ignore-all": "kubelint disabled for job pods"}
 	utils.UpdatePodTemplateAnnotations(&j.Spec.Template, annotations)
 
 	return nil


### PR DESCRIPTION
Teams are hitting other alerts for jobs now, such as 'min replicas' alerts. This PR adds an annotation to fully disable kubelinter checks on job pods.

https://github.com/stackrox/kube-linter/blob/main/docs/configuring-kubelinter.md#ignoring-violations-for-specific-cases