### PR TITLE
Reduce complexity of Clowder methods

### DIFF
--- a/controllers/cloud.redhat.com/clowdapp_reconciliation.go
+++ b/controllers/cloud.redhat.com/clowdapp_reconciliation.go
@@ -172,7 +172,7 @@ func (r *ClowdAppReconciliation) isEnvLocked() (ctrl.Result, error) {
 	if ReadEnv() == r.app.Spec.EnvName {
 		r.recorder.Eventf(r.app, "Warning", "ClowdEnvLocked", "Clowder Environment [%s] is locked", r.app.Spec.EnvName)
 		r.log.Info("Env currently being reconciled")
-		return ctrl.Result{Requeue: true}, errors.New(SKIPRECONCILE)
+		return ctrl.Result{Requeue: true}, errors.New("ClowdEnvLocked - request requeued")
 	}
 	return ctrl.Result{}, nil
 }

--- a/controllers/cloud.redhat.com/clowdapp_reconciliation.go
+++ b/controllers/cloud.redhat.com/clowdapp_reconciliation.go
@@ -172,7 +172,7 @@ func (r *ClowdAppReconciliation) isEnvLocked() (ctrl.Result, error) {
 	if ReadEnv() == r.app.Spec.EnvName {
 		r.recorder.Eventf(r.app, "Warning", "ClowdEnvLocked", "Clowder Environment [%s] is locked", r.app.Spec.EnvName)
 		r.log.Info("Env currently being reconciled")
-		return ctrl.Result{Requeue: true}, errors.New("ClowdEnvLocked - request requeued")
+		return ctrl.Result{Requeue: true}, errors.New(SKIPRECONCILE)
 	}
 	return ctrl.Result{}, nil
 }

--- a/controllers/cloud.redhat.com/clowdapp_reconciliation.go
+++ b/controllers/cloud.redhat.com/clowdapp_reconciliation.go
@@ -1,0 +1,364 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	crd "github.com/RedHatInsights/clowder/apis/cloud.redhat.com/v1alpha1"
+	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/clowderconfig"
+	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/config"
+	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/errors"
+	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/providers"
+	provutils "github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/providers/utils"
+	rc "github.com/RedHatInsights/rhc-osdk-utils/resource_cache"
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	core "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+type ClowdAppReconciliation struct {
+	cache                 *rc.ObjectCache
+	recorder              record.EventRecorder
+	ctx                   *context.Context
+	client                client.Client
+	log                   *logr.Logger
+	app                   *crd.ClowdApp
+	req                   *ctrl.Request
+	env                   *crd.ClowdEnvironment
+	reconciliationMetrics ReconciliationMetrics
+}
+
+func (r *ClowdAppReconciliation) steps() []func() (ctrl.Result, error) {
+	return []func() (ctrl.Result, error){
+		r.getApp,
+		r.setPresentAndManagedApps,
+		r.startMetrics,
+		r.isAppMarkedForDeletion,
+		r.addFinalizer,
+		r.isEnvLocked,
+		r.isAppDisabled,
+		r.getClowdEnv,
+		r.isEnvNamespaceDeleted,
+		r.isAppNamespaceDeleted,
+		r.isClowdEnvReconciled,
+		r.isEnvReady,
+		r.createCache,
+		r.runProviders,
+		r.applyCache,
+		r.setAppResourceStatus,
+		r.deletedUnusedResources,
+		r.setReconciliationSuccessful,
+		r.stopMetrics,
+	}
+}
+
+func (r *ClowdAppReconciliation) Reconcile() (ctrl.Result, error) {
+	for _, step := range r.steps() {
+		result, err := step()
+		if err != nil {
+			return result, err
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdAppReconciliation) startMetrics() (ctrl.Result, error) {
+	r.reconciliationMetrics = ReconciliationMetrics{}
+	r.reconciliationMetrics.init(r.app.Name, r.app.Spec.EnvName)
+	r.reconciliationMetrics.start()
+
+	if clowderconfig.LoadedConfig.Features.PerProviderMetrics {
+		requestMetrics.With(prometheus.Labels{"type": "app", "name": r.app.GetIdent()}).Inc()
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdAppReconciliation) stopMetrics() (ctrl.Result, error) {
+	r.reconciliationMetrics.stop()
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdAppReconciliation) setPresentAndManagedApps() (ctrl.Result, error) {
+	presentApps[r.app.GetIdent()] = true
+
+	presentAppsMetric.Set(float64(len(presentApps)))
+
+	delete(managedApps, r.app.GetIdent())
+
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdAppReconciliation) getApp() (ctrl.Result, error) {
+	if getAppErr := r.client.Get(*r.ctx, r.req.NamespacedName, r.app); getAppErr != nil {
+		if k8serr.IsNotFound(getAppErr) {
+			// Must have been deleted
+			return ctrl.Result{}, errors.New(SKIPRECONCILE)
+		}
+		r.log.Info("App not found", "env", r.app.Spec.EnvName, "app", r.app.GetIdent(), "err", getAppErr)
+		return ctrl.Result{}, getAppErr
+	}
+	//This is kinda side-effecty but I couldn't think of a better place
+	//to put it.
+	logWithEnv := r.log.WithValues("env", r.app.Spec.EnvName)
+	r.log = &logWithEnv
+
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdAppReconciliation) isAppMarkedForDeletion() (ctrl.Result, error) {
+	isAppMarkedForDeletion := r.app.GetDeletionTimestamp() != nil
+	if isAppMarkedForDeletion {
+		if contains(r.app.GetFinalizers(), appFinalizer) {
+			if finalizeErr := r.finalizeApp(); finalizeErr != nil {
+				r.log.Info("Cloud not finalize", "err", finalizeErr)
+				return ctrl.Result{}, finalizeErr
+			}
+
+			controllerutil.RemoveFinalizer(r.app, appFinalizer)
+			removeFinalizeErr := r.client.Update(*r.ctx, r.app)
+			if removeFinalizeErr != nil {
+				r.log.Info("Cloud not remove finalizer", "err", removeFinalizeErr)
+				return ctrl.Result{}, removeFinalizeErr
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdAppReconciliation) finalizeApp() error {
+	//We remove it from the managed list because it may have been managed before, but it may not be after this reconcile.
+	delete(managedApps, r.app.GetIdent())
+	managedAppsMetric.Set(float64(len(managedApps)))
+
+	delete(presentApps, r.app.GetIdent())
+	presentAppsMetric.Set(float64(len(presentApps)))
+
+	r.log.Info("Successfully finalized ClowdApp")
+	return nil
+}
+
+func (r *ClowdAppReconciliation) addFinalizer() (ctrl.Result, error) {
+	if !contains(r.app.GetFinalizers(), appFinalizer) {
+		if addFinalizeErr := r.addFinalizerImplementation(); addFinalizeErr != nil {
+			r.log.Info("Cloud not add finalizer", "err", addFinalizeErr)
+			return ctrl.Result{}, addFinalizeErr
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdAppReconciliation) addFinalizerImplementation() error {
+	r.log.Info("Adding Finalizer for the ClowdApp")
+	controllerutil.AddFinalizer(r.app, appFinalizer)
+
+	// Update CR
+	err := r.client.Update(context.TODO(), r.app)
+	if err != nil {
+		r.log.Error(err, "Failed to update ClowdApp with finalizer")
+		return err
+	}
+	return nil
+}
+
+func (r *ClowdAppReconciliation) isEnvLocked() (ctrl.Result, error) {
+	if ReadEnv() == r.app.Spec.EnvName {
+		r.recorder.Eventf(r.app, "Warning", "ClowdEnvLocked", "Clowder Environment [%s] is locked", r.app.Spec.EnvName)
+		r.log.Info("Env currently being reconciled")
+		return ctrl.Result{Requeue: true}, errors.New(SKIPRECONCILE)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdAppReconciliation) isAppDisabled() (ctrl.Result, error) {
+	if r.app.Spec.Disabled {
+		r.log.Info("Reconciliation aborted - set to be disabled")
+		return ctrl.Result{}, errors.New(SKIPRECONCILE)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdAppReconciliation) getClowdEnv() (ctrl.Result, error) {
+	updatedContext := context.WithValue(*r.ctx, errors.ClowdKey("obj"), r.app)
+	r.ctx = &updatedContext
+	r.env = &crd.ClowdEnvironment{}
+
+	if getEnvErr := r.client.Get(*r.ctx, types.NamespacedName{Name: r.app.Spec.EnvName}, r.env); getEnvErr != nil {
+		r.log.Info("ClowdEnv missing", "err", getEnvErr)
+		r.recorder.Eventf(r.app, "Warning", "ClowdEnvMissing", "Clowder Environment [%s] is missing", r.app.Spec.EnvName)
+		if setClowdStatusErr := SetClowdAppConditions(*r.ctx, r.client, r.app, crd.ReconciliationFailed, getEnvErr); setClowdStatusErr != nil {
+			r.log.Info("Set status error", "err", setClowdStatusErr)
+			return ctrl.Result{Requeue: true}, setClowdStatusErr
+		}
+		return ctrl.Result{}, getEnvErr
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdAppReconciliation) isNamespaceDeleted(namespace string, message string) (ctrl.Result, error) {
+	ns := &core.Namespace{}
+	if getNSErr := r.client.Get(*r.ctx, types.NamespacedName{Name: namespace}, ns); getNSErr != nil {
+		return ctrl.Result{Requeue: true}, getNSErr
+	}
+
+	if ns.ObjectMeta.DeletionTimestamp != nil {
+		r.log.Info(message)
+		return ctrl.Result{}, errors.New(SKIPRECONCILE)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdAppReconciliation) isEnvNamespaceDeleted() (ctrl.Result, error) {
+	return r.isNamespaceDeleted(r.env.Status.TargetNamespace, "Env target namespace is to be deleted - skipping reconcile")
+}
+
+func (r *ClowdAppReconciliation) isAppNamespaceDeleted() (ctrl.Result, error) {
+	return r.isNamespaceDeleted(r.app.Namespace, "App namespace is to be deleted - skipping reconcile")
+}
+
+func (r *ClowdAppReconciliation) isClowdEnvReconciled() (ctrl.Result, error) {
+	if r.env.Generation != r.env.Status.Generation {
+		r.recorder.Eventf(r.app, "Warning", "ClowdEnvNotReconciled", "Clowder Environment [%s] is not reconciled", r.app.Spec.EnvName)
+		r.log.Info("Env not yet reconciled")
+		if setClowdStatusErr := SetClowdAppConditions(*r.ctx, r.client, r.app, crd.ReconciliationFailed, fmt.Errorf("clowd env not reconciled")); setClowdStatusErr != nil {
+			r.log.Info("Set status error", "err", setClowdStatusErr)
+			return ctrl.Result{Requeue: true}, setClowdStatusErr
+		}
+		return ctrl.Result{}, errors.New(SKIPRECONCILE)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdAppReconciliation) isEnvReady() (ctrl.Result, error) {
+	if !r.env.IsReady() {
+		r.recorder.Eventf(r.app, "Warning", "ClowdEnvNotReady", "Clowder Environment [%s] is not ready", r.app.Spec.EnvName)
+		r.log.Info("Env not yet ready")
+		if setClowdStatusErr := SetClowdAppConditions(*r.ctx, r.client, r.app, crd.ReconciliationFailed, fmt.Errorf("clowd env not ready")); setClowdStatusErr != nil {
+			r.log.Info("Set status error", "err", setClowdStatusErr)
+			return ctrl.Result{Requeue: true}, setClowdStatusErr
+		}
+
+		return ctrl.Result{Requeue: true}, errors.New(SKIPRECONCILE)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdAppReconciliation) createCache() (ctrl.Result, error) {
+	cacheConfig := rc.NewCacheConfig(Scheme, errors.ClowdKey("log"), ProtectedGVKs, DebugOptions)
+	cache := rc.NewObjectCache(*r.ctx, r.client, cacheConfig)
+	r.cache = &cache
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdAppReconciliation) runProviders() (ctrl.Result, error) {
+
+	provider := providers.Provider{
+		Client: r.client,
+		Ctx:    *r.ctx,
+		Env:    r.env,
+		Cache:  r.cache,
+		Log:    *r.log,
+	}
+
+	if provErr := r.runProvidersImplementation(&provider); provErr != nil {
+		r.recorder.Eventf(r.app, "Warning", "FailedReconciliation", "Clowdapp requeued [%s]", r.app.GetClowdName())
+		if setClowdStatusErr := SetClowdAppConditions(*r.ctx, r.client, r.app, crd.ReconciliationFailed, provErr); setClowdStatusErr != nil {
+			r.log.Info("Set status error", "err", setClowdStatusErr)
+			return ctrl.Result{Requeue: true}, setClowdStatusErr
+		}
+		r.log.Info("Provider error", "err", provErr)
+		return ctrl.Result{Requeue: true}, provErr
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdAppReconciliation) runProvidersImplementation(provider *providers.Provider) error {
+
+	c := config.AppConfig{}
+
+	// Update app metadata
+	updateMetadata(r.app, &c)
+
+	for _, provAcc := range providers.ProvidersRegistration.Registry {
+		provutils.DebugLog(*r.log, "running provider:", "name", provAcc.Name, "order", provAcc.Order)
+		start := time.Now()
+		prov, err := provAcc.SetupProvider(provider)
+		elapsed := time.Since(start).Seconds()
+		providerMetrics.With(prometheus.Labels{"provider": provAcc.Name, "source": "clowdenv"}).Observe(elapsed)
+		if err != nil {
+			return errors.Wrap(fmt.Sprintf("getprov: %s", provAcc.Name), err)
+		}
+		start = time.Now()
+		err = prov.Provide(r.app, &c)
+		elapsed = time.Since(start).Seconds()
+		providerMetrics.With(prometheus.Labels{"provider": provAcc.Name, "source": "clowdapp"}).Observe(elapsed)
+		if err != nil {
+			reterr := errors.Wrap(fmt.Sprintf("runapp: %s", provAcc.Name), err)
+			reterr.Requeue = true
+			return reterr
+		}
+		provutils.DebugLog(*r.log, "running provider: complete", "name", provAcc.Name, "order", provAcc.Order, "elapsed", fmt.Sprintf("%f", elapsed))
+	}
+
+	return nil
+}
+
+func (r *ClowdAppReconciliation) applyCache() (ctrl.Result, error) {
+
+	cacheErr := r.cache.ApplyAll()
+
+	if cacheErr != nil {
+		r.recorder.Eventf(r.app, "Warning", "FailedReconciliation", "Clowdapp requeued [%s]", r.app.GetClowdName())
+		if setClowdStatusErr := SetClowdAppConditions(*r.ctx, r.client, r.app, crd.ReconciliationFailed, cacheErr); setClowdStatusErr != nil {
+			r.log.Info("Set status error", "err", setClowdStatusErr)
+			return ctrl.Result{Requeue: true}, setClowdStatusErr
+		}
+		r.log.Info("Cache error", "err", cacheErr)
+		return ctrl.Result{Requeue: true}, cacheErr
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdAppReconciliation) setAppResourceStatus() (ctrl.Result, error) {
+	if statusErr := SetAppResourceStatus(*r.ctx, r.client, r.app); statusErr != nil {
+		r.log.Info("Set status error", "err", statusErr)
+		return ctrl.Result{Requeue: true}, statusErr
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdAppReconciliation) deletedUnusedResources() (ctrl.Result, error) {
+	opts := []client.ListOption{
+		client.MatchingLabels{r.app.GetPrimaryLabel(): r.app.GetClowdName()},
+		client.InNamespace(r.app.Namespace),
+	}
+
+	// Delete all resources that are not used anymore
+	rErr := r.cache.Reconcile(r.app.GetUID(), opts...)
+	if rErr != nil {
+		r.log.Info("Reconcile error", "err", rErr)
+		return ctrl.Result{Requeue: true}, errors.New(SKIPRECONCILE)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdAppReconciliation) setReconciliationSuccessful() (ctrl.Result, error) {
+	if setClowdStatusErr := SetClowdAppConditions(*r.ctx, r.client, r.app, crd.ReconciliationSuccessful, nil); setClowdStatusErr != nil {
+		r.log.Info("Set status error", "err", setClowdStatusErr)
+		return ctrl.Result{Requeue: true}, setClowdStatusErr
+	}
+	managedApps[r.app.GetIdent()] = true
+
+	r.recorder.Eventf(r.app, "Normal", "SuccessfulReconciliation", "Clowdapp reconciled [%s]", r.app.GetClowdName())
+	r.log.Info("Reconciliation successful")
+	return ctrl.Result{}, nil
+}

--- a/controllers/cloud.redhat.com/clowdenvironment_reconciliation.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_reconciliation.go
@@ -1,0 +1,474 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	crd "github.com/RedHatInsights/clowder/apis/cloud.redhat.com/v1alpha1"
+	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/clowderconfig"
+	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/errors"
+	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/providers"
+	rc "github.com/RedHatInsights/rhc-osdk-utils/resource_cache"
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	cond "sigs.k8s.io/cluster-api/util/conditions"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	SKIPRECONCILE = "SKIPRECONCILE"
+)
+
+//During reconciliation we handle errors in 2 ways: sometimes we want to error out of reconciliation and sometimes we want to skip reconciliation.
+func shouldSkipReconciliation(err error) bool {
+	if err != nil && err.Error() == SKIPRECONCILE {
+		return true
+	}
+	return false
+}
+
+//ClowdEnvironmentReconciliation represents a single reconciliation event
+//This type is created by ClowdEnvironmentReconciler which handles the reconciliation cycle as a whole
+//ClowdEnvironmentReconciliation encapsulates all of the state and logic requires for a single
+//reconciliation event
+type ClowdEnvironmentReconciliation struct {
+	cache    *rc.ObjectCache
+	recorder record.EventRecorder
+	ctx      *context.Context
+	client   client.Client
+	env      *crd.ClowdEnvironment
+	log      *logr.Logger
+}
+
+//Returns a list of step methods that should be run during reconciliation
+func (r *ClowdEnvironmentReconciliation) steps() []func() (ctrl.Result, error) {
+	return []func() (ctrl.Result, error){
+		r.markedForDeletion,
+		r.addFinalizerIfRequired,
+		r.perProviderMetrics,
+		r.setToBeDisabled,
+		r.initTargetNamespace,
+		r.isTargetNamespaceMarkedForDeletion,
+		r.runProviders,
+		r.applyCache,
+		r.setAppInfo,
+		r.setEnvResourceStatus,
+		r.setPrometheusStatus,
+		r.setEnvStatus,
+		r.finalStatusError,
+		r.deleteUnusedResources,
+		r.setClowdEnvConditions,
+		r.logSuccess,
+	}
+}
+
+//Public method to iterate through the steps of the reconciliation process
+func (r *ClowdEnvironmentReconciliation) Reconcile() (ctrl.Result, error) {
+	r.log.Info("Reconciliation started")
+	//The env stays locked for the entire reconciliation
+	//This is a slight change from the previous implementation
+	//where the lock wasn't initated until the target namespace had been initialized
+	SetEnv(r.env.Name)
+	defer ReleaseEnv()
+	for _, step := range r.steps() {
+		result, err := step()
+		if err != nil {
+			return result, err
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+//Determine if app is marked for deletion, and if so finalize and end resonciliation
+func (r *ClowdEnvironmentReconciliation) markedForDeletion() (ctrl.Result, error) {
+	isEnvMarkedForDeletion := r.env.GetDeletionTimestamp() != nil
+	if isEnvMarkedForDeletion {
+		if contains(r.env.GetFinalizers(), envFinalizer) {
+			if finalizeErr := r.finalizeEnvironmentImplementation(); finalizeErr != nil {
+				r.log.Info("Cloud not finalize", "err", finalizeErr)
+				return ctrl.Result{Requeue: true}, finalizeErr
+			}
+
+			controllerutil.RemoveFinalizer(r.env, envFinalizer)
+			removeFinalizeErr := r.client.Update(*r.ctx, r.env)
+			if removeFinalizeErr != nil {
+				r.log.Info("Cloud not remove finalizer", "err", removeFinalizeErr)
+				return ctrl.Result{}, removeFinalizeErr
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+	return ctrl.Result{}, nil
+}
+
+//Perform finalization of the environment. Called by markedForDeleteion
+//Note: _ at beginning of method name indicates that a method is called
+//by a step method, not directly by the reconcilation loop
+func (r *ClowdEnvironmentReconciliation) finalizeEnvironmentImplementation() error {
+
+	provider := providers.Provider{
+		Ctx:    *r.ctx,
+		Client: r.client,
+		Env:    r.env,
+		Cache:  r.cache,
+		Log:    *r.log,
+	}
+
+	err := runProvidersForEnvFinalize(*r.log, provider)
+	if err != nil {
+		return err
+	}
+
+	if r.env.Spec.TargetNamespace == "" {
+		namespace := &core.Namespace{}
+		namespace.SetName(r.env.Status.TargetNamespace)
+		r.log.Info(fmt.Sprintf("Removing auto-generated namespace for %s", r.env.Name))
+		r.recorder.Eventf(r.env, "Warning", "NamespaceDeletion", "Clowder Environment [%s] had no targetNamespace, deleting generated namespace", r.env.Name)
+		r.client.Delete(context.TODO(), namespace)
+	}
+	delete(managedEnvironments, r.env.Name)
+	managedEnvsMetric.Set(float64(len(managedEnvironments)))
+
+	delete(presentEnvironments, r.env.Name)
+	presentEnvsMetric.Set(float64(len(presentEnvironments)))
+
+	r.log.Info("Successfully finalized ClowdEnvironment")
+	return nil
+}
+
+//Adds a finalizer to the environment if one is not already present
+func (r *ClowdEnvironmentReconciliation) addFinalizerIfRequired() (ctrl.Result, error) {
+	// Add finalizer for this CR
+	if !contains(r.env.GetFinalizers(), envFinalizer) {
+		if addFinalizeErr := r.addFinalizerImplementation(); addFinalizeErr != nil {
+			r.log.Info("Cloud not add finalizer", "err", addFinalizeErr)
+			return ctrl.Result{}, addFinalizeErr
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+//Implementation method for addining a finalizer
+func (r *ClowdEnvironmentReconciliation) addFinalizerImplementation() error {
+	r.log.Info("Adding Finalizer for the ClowdEnvironment")
+	controllerutil.AddFinalizer(r.env, envFinalizer)
+
+	// Update CR
+	err := r.client.Update(context.TODO(), r.env)
+	if err != nil {
+		r.log.Error(err, "Failed to update ClowdEnvironment with finalizer")
+		return err
+	}
+	return nil
+}
+
+//Request per provider methods if the config calls for it
+func (r *ClowdEnvironmentReconciliation) perProviderMetrics() (ctrl.Result, error) {
+	if clowderconfig.LoadedConfig.Features.PerProviderMetrics {
+		requestMetrics.With(prometheus.Labels{"type": "env", "name": r.env.Name}).Inc()
+	}
+	return ctrl.Result{}, nil
+}
+
+//Get or create and then update the cache for the target namespace
+func (r *ClowdEnvironmentReconciliation) initTargetNamespace() (ctrl.Result, error) {
+	result := ctrl.Result{}
+	var err error = nil
+
+	if r.env.Status.TargetNamespace != "" {
+		return result, err
+	}
+
+	if r.env.Spec.TargetNamespace == "" {
+		result, err = r.makeTargetNamespace()
+	} else {
+		result, err = r.getTargetNamespace()
+	}
+	if err != nil {
+		return result, err
+	}
+
+	result, err = r.updateTargetNamespace()
+
+	return result, err
+}
+
+//Get the env target namespace
+func (r *ClowdEnvironmentReconciliation) getTargetNamespace() (ctrl.Result, error) {
+	namespace := core.Namespace{}
+	namespaceName := types.NamespacedName{
+		Name: r.env.Spec.TargetNamespace,
+	}
+	if nErr := r.client.Get(*r.ctx, namespaceName, &namespace); nErr != nil {
+		r.log.Info("Namespace get error", "err", nErr)
+		r.recorder.Eventf(r.env, "Warning", "NamespaceMissing", "Requested Target Namespace [%s] is missing", r.env.Spec.TargetNamespace)
+		if setClowdStatusErr := SetClowdEnvConditions(*r.ctx, r.client, r.env, crd.ReconciliationFailed, nErr); setClowdStatusErr != nil {
+			r.log.Info("Set status error", "err", setClowdStatusErr)
+			return ctrl.Result{Requeue: true}, setClowdStatusErr
+		}
+		return ctrl.Result{Requeue: true}, nErr
+	}
+	r.env.Status.TargetNamespace = r.env.Spec.TargetNamespace
+	return ctrl.Result{}, nil
+}
+
+//Make a new target namespace
+func (r *ClowdEnvironmentReconciliation) makeTargetNamespace() (ctrl.Result, error) {
+	r.env.Status.TargetNamespace = r.env.GenerateTargetNamespace()
+	namespace := &core.Namespace{}
+	namespace.SetName(r.env.Status.TargetNamespace)
+	if snErr := r.client.Create(*r.ctx, namespace); snErr != nil {
+		r.log.Info("Namespace create error", "err", snErr)
+		if setClowdStatusErr := SetClowdEnvConditions(*r.ctx, r.client, r.env, crd.ReconciliationFailed, snErr); setClowdStatusErr != nil {
+			r.log.Info("Set status error", "err", setClowdStatusErr)
+			return ctrl.Result{Requeue: true}, setClowdStatusErr
+		}
+		return ctrl.Result{Requeue: true}, snErr
+	}
+	return ctrl.Result{}, nil
+}
+
+//Update the target namespace
+func (r *ClowdEnvironmentReconciliation) updateTargetNamespace() (ctrl.Result, error) {
+	if statErr := r.client.Status().Update(*r.ctx, r.env); statErr != nil {
+		r.log.Info("Namespace create error", "err", statErr)
+		if setClowdStatusErr := SetClowdEnvConditions(*r.ctx, r.client, r.env, crd.ReconciliationFailed, statErr); setClowdStatusErr != nil {
+			r.log.Info("Set status error", "err", setClowdStatusErr)
+			return ctrl.Result{Requeue: true}, setClowdStatusErr
+		}
+		return ctrl.Result{Requeue: true}, statErr
+	}
+	return ctrl.Result{}, nil
+}
+
+//Determine if the target namespace is marked for deletion
+//If it is then we enter into the SKIPRECONCILE corner case
+//which is a special case where the reconciliation controller bails early
+//from reconcile WIHTOUT returning an error
+func (r *ClowdEnvironmentReconciliation) isTargetNamespaceMarkedForDeletion() (ctrl.Result, error) {
+	ens := &core.Namespace{}
+	if getNSErr := r.client.Get(*r.ctx, types.NamespacedName{Name: r.env.Status.TargetNamespace}, ens); getNSErr != nil {
+		return ctrl.Result{Requeue: true}, getNSErr
+	}
+
+	if ens.ObjectMeta.DeletionTimestamp != nil {
+		r.log.Info("Env target namespace is to be deleted - skipping reconcile")
+		return ctrl.Result{}, errors.New(SKIPRECONCILE)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdEnvironmentReconciliation) runProviders() (ctrl.Result, error) {
+	provider := providers.Provider{
+		Ctx:    *r.ctx,
+		Client: r.client,
+		Env:    r.env,
+		Cache:  r.cache,
+		Log:    *r.log,
+	}
+	provErr := runProvidersForEnv(*r.log, provider)
+
+	if provErr != nil {
+		r.log.Info("Prov err", "err", provErr)
+		if setClowdStatusErr := SetClowdEnvConditions(*r.ctx, r.client, r.env, crd.ReconciliationFailed, provErr); setClowdStatusErr != nil {
+			r.log.Info("Set status error", "err", setClowdStatusErr)
+			return ctrl.Result{Requeue: true}, setClowdStatusErr
+		}
+		return ctrl.Result{Requeue: true}, provErr
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdEnvironmentReconciliation) applyCache() (ctrl.Result, error) {
+	cacheErr := r.cache.ApplyAll()
+	if cacheErr != nil {
+		r.log.Info("Cache error", "err", cacheErr)
+		if setClowdStatusErr := SetClowdEnvConditions(*r.ctx, r.client, r.env, crd.ReconciliationFailed, cacheErr); setClowdStatusErr != nil {
+			r.log.Info("Set status error", "err", setClowdStatusErr)
+			return ctrl.Result{Requeue: true}, setClowdStatusErr
+		}
+		return ctrl.Result{Requeue: true}, cacheErr
+	}
+	return ctrl.Result{}, nil
+}
+
+//Sets info for the apps in the environment
+//This method is the step and contains most of the error handling, logging etc
+//The full implementaiton is pushed out into another method
+func (r *ClowdEnvironmentReconciliation) setAppInfo() (ctrl.Result, error) {
+	if setAppErr := r.setAppInfoImplementation(); setAppErr != nil {
+		r.log.Info("setAppInfo error", "err", setAppErr)
+		if setClowdStatusErr := SetClowdEnvConditions(*r.ctx, r.client, r.env, crd.ReconciliationFailed, setAppErr); setClowdStatusErr != nil {
+			r.log.Info("Set status error", "err", setClowdStatusErr)
+			return ctrl.Result{Requeue: true}, setClowdStatusErr
+		}
+		return ctrl.Result{Requeue: true}, setAppErr
+	}
+	return ctrl.Result{}, nil
+}
+
+//Performs the actual business logic for the setAppInfo step
+//TODO this is a bear of a method. Factor this out into pieces.
+func (r *ClowdEnvironmentReconciliation) setAppInfoImplementation() error {
+
+	// Get all the ClowdApp resources
+	appList, err := r.env.GetAppsInEnv(*r.ctx, r.client)
+
+	if err != nil {
+		return err
+	}
+	apps := []crd.AppInfo{}
+
+	appMap := map[string]crd.ClowdApp{}
+	names := []string{}
+
+	for _, app := range appList.Items {
+		name := fmt.Sprintf("%s-%s", app.Name, app.Namespace)
+		names = append(names, name)
+		appMap[name] = app
+	}
+
+	sort.Strings(names)
+
+	// Populate
+	for _, name := range names {
+		app := appMap[name]
+
+		if app.GetDeletionTimestamp() != nil {
+			continue
+		}
+
+		appstatus := crd.AppInfo{
+			Name:        app.Name,
+			Deployments: []crd.DeploymentInfo{},
+		}
+
+		depMap := map[string]crd.Deployment{}
+		depNames := []string{}
+
+		for _, pod := range app.Spec.Deployments {
+			depNames = append(depNames, pod.Name)
+			depMap[pod.Name] = pod
+		}
+
+		sort.Strings(depNames)
+
+		for _, podName := range depNames {
+			pod := depMap[podName]
+
+			deploymentStatus := crd.DeploymentInfo{
+				Name: fmt.Sprintf("%s-%s", app.Name, pod.Name),
+			}
+			if bool(pod.Web) || pod.WebServices.Public.Enabled {
+				deploymentStatus.Hostname = fmt.Sprintf("%s.%s.svc", deploymentStatus.Name, app.Namespace)
+				deploymentStatus.Port = r.env.Spec.Providers.Web.Port
+			}
+			appstatus.Deployments = append(appstatus.Deployments, deploymentStatus)
+		}
+		apps = append(apps, appstatus)
+	}
+
+	r.env.Status.Apps = apps
+	return nil
+}
+
+func (r *ClowdEnvironmentReconciliation) setEnvResourceStatus() (ctrl.Result, error) {
+	if statusErr := SetEnvResourceStatus(*r.ctx, r.client, r.env); statusErr != nil {
+		r.log.Info("SetEnvResourceStatus error", "err", statusErr)
+		if setClowdStatusErr := SetClowdEnvConditions(*r.ctx, r.client, r.env, crd.ReconciliationFailed, statusErr); setClowdStatusErr != nil {
+			r.log.Info("Set status error", "err", setClowdStatusErr)
+			return ctrl.Result{Requeue: true}, setClowdStatusErr
+		}
+		return ctrl.Result{Requeue: true}, statusErr
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdEnvironmentReconciliation) setPrometheusStatus() (ctrl.Result, error) {
+	var hostname string
+
+	if r.env.Spec.Providers.Metrics.Mode == "app-interface" {
+		hostname = r.env.Spec.Providers.Metrics.Prometheus.AppInterfaceHostname
+	} else {
+		hostname = fmt.Sprintf("prometheus-operated.%s.svc.cluster.local", r.env.Status.TargetNamespace)
+	}
+
+	r.env.Status.Prometheus = crd.PrometheusStatus{Hostname: hostname}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdEnvironmentReconciliation) setEnvStatus() (ctrl.Result, error) {
+	envReady, _, getEnvResErr := GetEnvResourceStatus(*r.ctx, r.client, r.env)
+	if getEnvResErr != nil {
+		r.log.Info("GetEnvResourceStatus error", "err", getEnvResErr)
+		return ctrl.Result{Requeue: true}, getEnvResErr
+	}
+
+	envStatus := core.ConditionFalse
+	successCond := cond.Get(r.env, crd.ReconciliationSuccessful)
+	if successCond != nil {
+		envStatus = successCond.Status
+	}
+
+	r.env.Status.Ready = envReady && (envStatus == core.ConditionTrue)
+	r.env.Status.Generation = r.env.Generation
+
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdEnvironmentReconciliation) finalStatusError() (ctrl.Result, error) {
+	if finalStatusErr := r.client.Status().Update(*r.ctx, r.env); finalStatusErr != nil {
+		r.log.Info("Final Status error", "err", finalStatusErr)
+		if setClowdStatusErr := SetClowdEnvConditions(*r.ctx, r.client, r.env, crd.ReconciliationFailed, finalStatusErr); setClowdStatusErr != nil {
+			r.log.Info("Set status error", "err", setClowdStatusErr)
+			return ctrl.Result{Requeue: true}, setClowdStatusErr
+		}
+		return ctrl.Result{Requeue: true}, finalStatusErr
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdEnvironmentReconciliation) deleteUnusedResources() (ctrl.Result, error) {
+	opts := []client.ListOption{
+		client.MatchingLabels{r.env.GetPrimaryLabel(): r.env.GetClowdName()},
+	}
+
+	// Delete all resources that are not used anymore
+	rErr := r.cache.Reconcile(r.env.GetUID(), opts...)
+	if rErr != nil {
+		return ctrl.Result{Requeue: true}, rErr
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdEnvironmentReconciliation) setClowdEnvConditions() (ctrl.Result, error) {
+	if successSetErr := SetClowdEnvConditions(*r.ctx, r.client, r.env, crd.ReconciliationSuccessful, nil); successSetErr != nil {
+		r.log.Info("Set status error", "err", successSetErr)
+		return ctrl.Result{Requeue: true}, successSetErr
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdEnvironmentReconciliation) logSuccess() (ctrl.Result, error) {
+	r.recorder.Eventf(r.env, "Normal", "SuccessfulReconciliation", "Environment reconciled [%s]", r.env.GetClowdName())
+	r.log.Info("Reconciliation successful")
+	return ctrl.Result{}, nil
+}
+
+func (r *ClowdEnvironmentReconciliation) setToBeDisabled() (ctrl.Result, error) {
+	if r.env.Spec.Disabled {
+		r.log.Info("Reconciliation aborted - set to be disabled")
+		return ctrl.Result{}, errors.New(SKIPRECONCILE)
+	}
+	return ctrl.Result{}, nil
+}

--- a/controllers/cloud.redhat.com/providers/deployment/impl.go
+++ b/controllers/cloud.redhat.com/providers/deployment/impl.go
@@ -17,6 +17,10 @@ import (
 	"github.com/RedHatInsights/rhc-osdk-utils/utils"
 )
 
+const (
+	TERMINATION_LOG_PATH = "/dev/termination-log"
+)
+
 func (dp *deploymentProvider) makeDeployment(deployment crd.Deployment, app *crd.ClowdApp) error {
 
 	d := &apps.Deployment{}
@@ -35,6 +39,19 @@ func (dp *deploymentProvider) makeDeployment(deployment crd.Deployment, app *crd
 	}
 
 	return nil
+}
+
+func setLocalAnnotations(env *crd.ClowdEnvironment, deployment crd.Deployment, d *apps.Deployment, app *crd.ClowdApp) {
+	if env.Spec.Providers.Web.Mode == "local" && (deployment.WebServices.Public.Enabled || bool(deployment.Web)) {
+		annotations := map[string]string{
+			"clowder/authsidecar-image":   provutils.GetCaddyImage(env),
+			"clowder/authsidecar-enabled": "true",
+			"clowder/authsidecar-port":    strconv.Itoa(int(env.Spec.Providers.Web.Port)),
+			"clowder/authsidecar-config":  fmt.Sprintf("caddy-config-%s-%s", app.Name, deployment.Name),
+		}
+		utils.UpdateAnnotations(&d.Spec.Template, annotations)
+	}
+
 }
 
 func setMinReplicas(deployment crd.Deployment, d *apps.Deployment) {
@@ -64,40 +81,7 @@ func setMinReplicas(deployment crd.Deployment, d *apps.Deployment) {
 
 }
 
-func initDeployment(app *crd.ClowdApp, env *crd.ClowdEnvironment, d *apps.Deployment, nn types.NamespacedName, deployment crd.Deployment) error {
-	labels := app.GetLabels()
-	labels["pod"] = nn.Name
-	app.SetObjectMeta(d, crd.Name(nn.Name), crd.Labels(labels))
-
-	d.Kind = "Deployment"
-
-	pod := deployment.PodSpec
-
-	utils.UpdateAnnotations(d, app.ObjectMeta.Annotations, pod.Metadata.Annotations)
-
-	if env.Spec.Providers.Web.Mode == "local" && (deployment.WebServices.Public.Enabled || bool(deployment.Web)) {
-		annotations := map[string]string{
-			"clowder/authsidecar-image":   provutils.GetCaddyImage(env),
-			"clowder/authsidecar-enabled": "true",
-			"clowder/authsidecar-port":    strconv.Itoa(int(env.Spec.Providers.Web.Port)),
-			"clowder/authsidecar-config":  fmt.Sprintf("caddy-config-%s-%s", app.Name, deployment.Name),
-		}
-		utils.UpdateAnnotations(&d.Spec.Template, annotations)
-	}
-
-	setMinReplicas(deployment, d)
-
-	d.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
-	d.Spec.Template.ObjectMeta.Labels = labels
-	d.Spec.Strategy = apps.DeploymentStrategy{
-		Type: apps.RollingUpdateDeploymentStrategyType,
-		RollingUpdate: &apps.RollingUpdateDeployment{
-			MaxSurge:       &intstr.IntOrString{Type: intstr.String, StrVal: string("25%")},
-			MaxUnavailable: &intstr.IntOrString{Type: intstr.String, StrVal: string("25%")},
-		},
-	}
-	d.Spec.ProgressDeadlineSeconds = utils.Int32Ptr(600)
-
+func setDeploymentStrategy(deployment crd.Deployment, d *apps.Deployment) {
 	if !deployment.WebServices.Public.Enabled {
 		if deployment.DeploymentStrategy != nil && deployment.DeploymentStrategy.PrivateStrategy != "" {
 			d.Spec.Strategy = apps.DeploymentStrategy{
@@ -109,24 +93,10 @@ func initDeployment(app *crd.ClowdApp, env *crd.ClowdEnvironment, d *apps.Deploy
 			}
 		}
 	}
+}
 
-	envvar := pod.Env
-	envvar = append(envvar, core.EnvVar{Name: "ACG_CONFIG", Value: "/cdapp/cdappconfig.json"})
-
-	for _, env := range envvar {
-		if env.ValueFrom != nil {
-			if env.ValueFrom.FieldRef != nil {
-				if env.ValueFrom.FieldRef.APIVersion == "" {
-					env.ValueFrom.FieldRef.APIVersion = "v1"
-				}
-			}
-		}
-	}
-
-	var livenessProbe core.Probe
-	var readinessProbe core.Probe
-
-	baseProbe := core.Probe{
+func makeBaseProbe(env *crd.ClowdEnvironment) core.Probe {
+	return core.Probe{
 		ProbeHandler: core.ProbeHandler{
 			HTTPGet: &core.HTTPGetAction{
 				Path:   "/healthz",
@@ -143,6 +113,11 @@ func initDeployment(app *crd.ClowdApp, env *crd.ClowdEnvironment, d *apps.Deploy
 		SuccessThreshold:    1,
 		TimeoutSeconds:      1,
 	}
+}
+
+func setLivenessProbe(pod *crd.PodSpec, deployment crd.Deployment, env *crd.ClowdEnvironment, c *core.Container) {
+	livenessProbe := core.Probe{}
+
 	if pod.LivenessProbe != nil {
 		livenessProbe = *pod.LivenessProbe
 
@@ -158,9 +133,15 @@ func initDeployment(app *crd.ClowdApp, env *crd.ClowdEnvironment, d *apps.Deploy
 		if livenessProbe.FailureThreshold == 0 {
 			livenessProbe.FailureThreshold = 3
 		}
+		c.LivenessProbe = &livenessProbe
 	} else if bool(deployment.Web) || deployment.WebServices.Public.Enabled {
-		livenessProbe = baseProbe
+		livenessProbe = makeBaseProbe(env)
+		c.LivenessProbe = &livenessProbe
 	}
+}
+
+func setReadinessProbe(pod *crd.PodSpec, deployment crd.Deployment, env *crd.ClowdEnvironment, c *core.Container) {
+	readinessProbe := core.Probe{}
 	if pod.ReadinessProbe != nil {
 		readinessProbe = *pod.ReadinessProbe
 
@@ -176,45 +157,94 @@ func initDeployment(app *crd.ClowdApp, env *crd.ClowdEnvironment, d *apps.Deploy
 		if readinessProbe.FailureThreshold == 0 {
 			readinessProbe.FailureThreshold = 3
 		}
+
+		c.ReadinessProbe = &readinessProbe
 	} else if bool(deployment.Web) || deployment.WebServices.Public.Enabled {
-		readinessProbe = baseProbe
+		readinessProbe := makeBaseProbe(env)
 		readinessProbe.InitialDelaySeconds = 45
+		c.ReadinessProbe = &readinessProbe
 	}
+}
+
+func setImagePullPolicy(env *crd.ClowdEnvironment, c *core.Container) {
+	if !env.Spec.Providers.Deployment.OmitPullPolicy {
+		c.ImagePullPolicy = core.PullIfNotPresent
+		return
+	}
+	imageComponents := strings.Split(c.Image, ":")
+	if len(imageComponents) > 1 {
+		if imageComponents[1] == "latest" {
+			c.ImagePullPolicy = core.PullAlways
+		} else {
+			c.ImagePullPolicy = core.PullIfNotPresent
+		}
+		return
+	}
+	c.ImagePullPolicy = core.PullIfNotPresent
+
+}
+
+func loadEnvVars(pod crd.PodSpec) []core.EnvVar {
+	envvars := pod.Env
+	envvars = append(envvars, core.EnvVar{Name: "ACG_CONFIG", Value: "/cdapp/cdappconfig.json"})
+
+	for _, envvar := range envvars {
+		if envvar.ValueFrom != nil {
+			if envvar.ValueFrom.FieldRef != nil {
+				if envvar.ValueFrom.FieldRef.APIVersion == "" {
+					envvar.ValueFrom.FieldRef.APIVersion = "v1"
+				}
+			}
+		}
+	}
+
+	return envvars
+}
+
+func initDeployment(app *crd.ClowdApp, env *crd.ClowdEnvironment, d *apps.Deployment, nn types.NamespacedName, deployment crd.Deployment) error {
+	labels := app.GetLabels()
+	labels["pod"] = nn.Name
+	app.SetObjectMeta(d, crd.Name(nn.Name), crd.Labels(labels))
+
+	d.Kind = "Deployment"
+
+	pod := deployment.PodSpec
+
+	utils.UpdateAnnotations(d, app.ObjectMeta.Annotations, pod.Metadata.Annotations)
+
+	setLocalAnnotations(env, deployment, d, app)
+
+	setMinReplicas(deployment, d)
+
+	d.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
+	d.Spec.Template.ObjectMeta.Labels = labels
+	d.Spec.Strategy = apps.DeploymentStrategy{
+		Type: apps.RollingUpdateDeploymentStrategyType,
+		RollingUpdate: &apps.RollingUpdateDeployment{
+			MaxSurge:       &intstr.IntOrString{Type: intstr.String, StrVal: string("25%")},
+			MaxUnavailable: &intstr.IntOrString{Type: intstr.String, StrVal: string("25%")},
+		},
+	}
+	d.Spec.ProgressDeadlineSeconds = utils.Int32Ptr(600)
+
+	setDeploymentStrategy(deployment, d)
 
 	c := core.Container{
 		Name:                     nn.Name,
 		Image:                    pod.Image,
 		Command:                  pod.Command,
 		Args:                     pod.Args,
-		Env:                      envvar,
+		Env:                      loadEnvVars(pod),
 		Resources:                ProcessResources(&pod, env),
 		VolumeMounts:             pod.VolumeMounts,
-		TerminationMessagePath:   "/dev/termination-log",
+		TerminationMessagePath:   TERMINATION_LOG_PATH,
 		TerminationMessagePolicy: core.TerminationMessageReadFile,
 		ImagePullPolicy:          core.PullIfNotPresent,
 	}
 
-	if !env.Spec.Providers.Deployment.OmitPullPolicy {
-		c.ImagePullPolicy = core.PullIfNotPresent
-	} else {
-		imageComponents := strings.Split(c.Image, ":")
-		if len(imageComponents) > 1 {
-			if imageComponents[1] == "latest" {
-				c.ImagePullPolicy = core.PullAlways
-			} else {
-				c.ImagePullPolicy = core.PullIfNotPresent
-			}
-		} else {
-			c.ImagePullPolicy = core.PullIfNotPresent
-		}
-	}
-
-	if (core.Probe{}) != livenessProbe {
-		c.LivenessProbe = &livenessProbe
-	}
-	if (core.Probe{}) != readinessProbe {
-		c.ReadinessProbe = &readinessProbe
-	}
+	setLivenessProbe(&pod, deployment, env, &c)
+	setReadinessProbe(&pod, deployment, env, &c)
+	setImagePullPolicy(env, &c)
 
 	c.VolumeMounts = append(c.VolumeMounts, core.VolumeMount{
 		Name:      "config-secret",
@@ -254,21 +284,41 @@ func initDeployment(app *crd.ClowdApp, env *crd.ClowdEnvironment, d *apps.Deploy
 	})
 
 	for _, vol := range d.Spec.Template.Spec.Volumes {
-		if vol.VolumeSource.PersistentVolumeClaim != nil {
-			d.Spec.Strategy = apps.DeploymentStrategy{
-				Type: apps.RecreateDeploymentStrategyType,
-			}
-			break
-		} else if vol.VolumeSource.ConfigMap != nil && (vol.VolumeSource.ConfigMap.DefaultMode == nil || *vol.VolumeSource.ConfigMap.DefaultMode == 0) {
-			vol.VolumeSource.ConfigMap.DefaultMode = utils.Int32Ptr(420)
-		} else if vol.VolumeSource.Secret != nil && (vol.VolumeSource.Secret.DefaultMode == nil || *vol.VolumeSource.Secret.DefaultMode == 0) {
-			vol.VolumeSource.Secret.DefaultMode = utils.Int32Ptr(420)
-		}
+		setRecreateDeploymentStrategyForPVCs(vol, d)
+		setVolumeSourceConfigMapDefaultMode(&vol)
+		setVolumeSourceSecretDefaultMode(&vol)
 	}
 
 	ApplyPodAntiAffinity(&d.Spec.Template)
 
 	return nil
+}
+
+func setRecreateDeploymentStrategyForPVCs(vol core.Volume, d *apps.Deployment) {
+	if vol.VolumeSource.PersistentVolumeClaim == nil {
+		return
+	}
+	d.Spec.Strategy = apps.DeploymentStrategy{
+		Type: apps.RecreateDeploymentStrategyType,
+	}
+}
+
+func setVolumeSourceConfigMapDefaultMode(vol *core.Volume) {
+	if vol.VolumeSource.PersistentVolumeClaim != nil {
+		return
+	}
+	if vol.VolumeSource.ConfigMap != nil && vol.VolumeSource.Secret == nil && (vol.VolumeSource.ConfigMap.DefaultMode == nil || *vol.VolumeSource.ConfigMap.DefaultMode == 0) {
+		vol.VolumeSource.ConfigMap.DefaultMode = utils.Int32Ptr(420)
+	}
+}
+
+func setVolumeSourceSecretDefaultMode(vol *core.Volume) {
+	if vol.VolumeSource.PersistentVolumeClaim != nil {
+		return
+	}
+	if vol.VolumeSource.ConfigMap == nil && vol.VolumeSource.Secret != nil && (vol.VolumeSource.Secret.DefaultMode == nil || *vol.VolumeSource.Secret.DefaultMode == 0) {
+		vol.VolumeSource.Secret.DefaultMode = utils.Int32Ptr(420)
+	}
 }
 
 // ProcessInitContainers returns a container object which has been processed from the container spec.
@@ -302,7 +352,7 @@ func ProcessInitContainers(nn types.NamespacedName, c *core.Container, ics []crd
 			Resources:                c.Resources,
 			VolumeMounts:             c.VolumeMounts,
 			ImagePullPolicy:          c.ImagePullPolicy,
-			TerminationMessagePath:   "/dev/termination-log",
+			TerminationMessagePath:   TERMINATION_LOG_PATH,
 			TerminationMessagePolicy: core.TerminationMessageReadFile,
 		}
 

--- a/controllers/cloud.redhat.com/providers/deployment/impl.go
+++ b/controllers/cloud.redhat.com/providers/deployment/impl.go
@@ -30,7 +30,7 @@ func (dp *deploymentProvider) makeDeployment(deployment crd.Deployment, app *crd
 		return err
 	}
 
-	if err := initDeployment(app, dp.Env, d, nn, &&deployment); err != nil {
+	if err := initDeployment(app, dp.Env, d, nn, &deployment); err != nil {
 		return err
 	}
 

--- a/controllers/cloud.redhat.com/providers/deployment/test.go
+++ b/controllers/cloud.redhat.com/providers/deployment/test.go
@@ -142,7 +142,9 @@ func TestResourceDefaults(t *testing.T) {
 				Namespace: app.Namespace,
 			}
 
-			initDeployment(app, env, d, nn, app.Spec.Deployments[0])
+			deployment := app.Spec.Deployments[0]
+
+			initDeployment(app, env, d, nn, &deployment)
 
 			var expectedLimitCPU, expectedLimitMemory, expectedRequestsCPU, expectedRequestsMemory resource.Quantity
 


### PR DESCRIPTION
The goal of this PR is to reduce the complexity of Clowder methods as much as possible during the tech debt sprint. In an effort to go about this in a data driven way I'm using complexity measures based on cyclonic complexity and halstead metrics as provided by the go-complexity-analysis go vet plugin. The goal to to get as many high complexity methods under a cyclonic measure of 10 as possible within the time frame.