### PR TITLE
Add support for parsing 'cacert' out of managed kafka secret

### DIFF
--- a/controllers/cloud.redhat.com/providers/kafka/managed.go
+++ b/controllers/cloud.redhat.com/providers/kafka/managed.go
@@ -69,8 +69,8 @@ func (k *managedKafkaProvider) destructureSecret(secret *core.Secret) (int, stri
 	username := string(secret.Data["username"])
 	hostname := string(secret.Data["hostname"])
 	cacert := ""
-	if _, ok := secret.Data["cacert"]; ok {
-		cacert = string(secret.Data["cacert"])
+	if val, ok := secret.Data["cacert"]; ok {
+		cacert = string(val)
 	}
 	return port, password, username, hostname, cacert, nil
 }

--- a/controllers/cloud.redhat.com/providers/kafka/managed.go
+++ b/controllers/cloud.redhat.com/providers/kafka/managed.go
@@ -60,21 +60,25 @@ func (k *managedKafkaProvider) appendTopic(topic crd.KafkaTopicSpec, kafkaConfig
 	)
 }
 
-func (k *managedKafkaProvider) destructureSecret(secret *core.Secret) (int, string, string, string, error) {
+func (k *managedKafkaProvider) destructureSecret(secret *core.Secret) (int, string, string, string, string, error) {
 	port, err := strconv.Atoi(string(secret.Data["port"]))
 	if err != nil {
-		return 0, "", "", "", err
+		return 0, "", "", "", "", err
 	}
 	password := string(secret.Data["password"])
 	username := string(secret.Data["username"])
 	hostname := string(secret.Data["hostname"])
-	return port, password, username, hostname, nil
+	cacert := ""
+	if _, ok := secret.Data["cacert"]; ok {
+		cacert = string(secret.Data["cacert"])
+	}
+	return port, password, username, hostname, cacert, nil
 }
 
 func (k *managedKafkaProvider) getBrokerConfig(secret *core.Secret) (config.BrokerConfig, error) {
 	broker := config.BrokerConfig{}
 
-	port, password, username, hostname, err := k.destructureSecret(secret)
+	port, password, username, hostname, cacert, err := k.destructureSecret(secret)
 	if err != nil {
 		return broker, err
 	}
@@ -84,6 +88,9 @@ func (k *managedKafkaProvider) getBrokerConfig(secret *core.Secret) (config.Brok
 	broker.Hostname = hostname
 	broker.Port = &port
 	broker.Authtype = &saslType
+	if cacert != "" {
+		broker.Cacert = &cacert
+	}
 	broker.Sasl = &config.KafkaSASLConfig{
 		Password:         &password,
 		Username:         &username,

--- a/tests/kuttl/test-kafka-managed/01-pods.yaml
+++ b/tests/kuttl/test-kafka-managed/01-pods.yaml
@@ -62,6 +62,7 @@ data:
   port: MjcwMTU= # 27015
   username: a2Fma2EtdXNlcm5hbWU= # kafka-username
   password: a2Fma2EtcGFzc3dvcmQ= # kafka-password
+  cacert: c29tZS1wZW0K
 kind: Secret
 metadata:
   name: managed-secret

--- a/tests/kuttl/test-kafka-managed/01-pods.yaml
+++ b/tests/kuttl/test-kafka-managed/01-pods.yaml
@@ -62,7 +62,7 @@ data:
   port: MjcwMTU= # 27015
   username: a2Fma2EtdXNlcm5hbWU= # kafka-username
   password: a2Fma2EtcGFzc3dvcmQ= # kafka-password
-  cacert: c29tZS1wZW0K
+  cacert: c29tZS1wZW0=
 kind: Secret
 metadata:
   name: managed-secret

--- a/tests/kuttl/test-kafka-managed/02-json-asserts.yaml
+++ b/tests/kuttl/test-kafka-managed/02-json-asserts.yaml
@@ -9,6 +9,7 @@ commands:
 - script: jq -r '.kafka.topics[] | select(.requestedName == "topicOne") | .name == "topicOne"' -e < /tmp/test-kafka-managed-json
 - script: jq -r '.kafka.topics[] | select(.requestedName == "topicTwo") | .name == "topicTwo"' -e < /tmp/test-kafka-managed-json
 - script: jq -r '.kafka.brokers[].hostname == "kafka-host-name"' -e < /tmp/test-kafka-managed-json
+- script: jq -r '.kafka.brokers[].cacert == "some-pem"' -e < /tmp/test-kafka-managed-json
 - script: jq -r '.kafka.brokers[].port == 27015' -e < /tmp/test-kafka-managed-json
 - script: jq -r '.kafka.brokers[].sasl.username == "kafka-username"' -e < /tmp/test-kafka-managed-json
 - script: jq -r '.kafka.brokers[].sasl.password == "kafka-password"' -e < /tmp/test-kafka-managed-json


### PR DESCRIPTION
If the 'cacert' field is present in the managed kafka Secret, we will set the cacert field in the cdapp broker config