### PR TITLE
Scale Deployments to 0 when minReplicas is set to 0.

### DIFF
--- a/controllers/cloud.redhat.com/providers/deployment/impl.go
+++ b/controllers/cloud.redhat.com/providers/deployment/impl.go
@@ -58,8 +58,9 @@ func initDeployment(app *crd.ClowdApp, env *crd.ClowdEnvironment, d *apps.Deploy
 		utils.UpdateAnnotations(&d.Spec.Template, annotations)
 	}
 
-	if d.Spec.Replicas == nil || (deployment.MinReplicas != nil && *d.Spec.Replicas < *deployment.MinReplicas) {
-		// Reset replicas to minReplicas if it somehow falls below minReplicas
+	// 1. deployment is nil on first initialization
+	// 2. only manually set the replicas if the autoscaler isn't set up for this deployment and it isn't synced
+	if d.Spec.Replicas == nil || (deployment.AutoScaler == nil && *d.Spec.Replicas != *deployment.MinReplicas) {
 		d.Spec.Replicas = deployment.MinReplicas
 	}
 


### PR DESCRIPTION
It became apparent during a DB upgrade that when we update `minReplicas` to 0 on our clowdapps that the deployment resources wouldn't be scaled to 0. I think this is due to the check that the deployment replicas is _less than_ the configured replicas - e.g. it scales up the deployments but refuses to scale them down.

This PR basically changes that check to do a few things:
1. If the deployment is nil -> set it to the configured value for initialization
2. Otherwise, (if autoscaling is disabled) sync the deployment + podSpec replica count

Let me know if this isn't the fix you're looking for, I was just playing around here to see if it was in this little check. cc @psav 