### PR TITLE
[RHCLOUD-21108] - Add parallelism and completions to job specs

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
@@ -90,6 +90,12 @@ type Job struct {
 	// Defines the schedule for the job to run
 	Schedule string `json:"schedule,omitempty"`
 
+  // Defines the parallelism of the job
+  Parallelism *int32 `json:"parallelism,omitempty"`
+
+  // Defines the completions of the job
+  Completions *int32 `json:"completions,omitempty"`
+
 	// PodSpec defines a container running inside the CronJob.
 	PodSpec PodSpec `json:"podSpec"`
 

--- a/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
@@ -90,11 +90,11 @@ type Job struct {
 	// Defines the schedule for the job to run
 	Schedule string `json:"schedule,omitempty"`
 
-  // Defines the parallelism of the job
-  Parallelism *int32 `json:"parallelism,omitempty"`
+	// Defines the parallelism of the job
+	Parallelism *int32 `json:"parallelism,omitempty"`
 
-  // Defines the completions of the job
-  Completions *int32 `json:"completions,omitempty"`
+	// Defines the completions of the job
+	Completions *int32 `json:"completions,omitempty"`
 
 	// PodSpec defines a container running inside the CronJob.
 	PodSpec PodSpec `json:"podSpec"`

--- a/config/crd/bases/cloud.redhat.com_clowdapps.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdapps.yaml
@@ -2876,6 +2876,10 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/controllers/job/'
                       format: int64
                       type: integer
+                    completions:
+                      description: Defines the completions of the job
+                      format: int32
+                      type: integer
                     concurrencyPolicy:
                       description: Defines the concurrency policy for the CronJob,
                         defaults to Allow Only applies to Cronjobs
@@ -2891,6 +2895,10 @@ spec:
                         be used to name the CronJob resource, the container will be
                         name identically.
                       type: string
+                    parallelism:
+                      description: Defines the parallelism of the job
+                      format: int32
+                      type: integer
                     podSpec:
                       description: PodSpec defines a container running inside the
                         CronJob.

--- a/controllers/cloud.redhat.com/providers/cronjob/impl.go
+++ b/controllers/cloud.redhat.com/providers/cronjob/impl.go
@@ -205,6 +205,15 @@ func applyCronJob(app *crd.ClowdApp, env *crd.ClowdEnvironment, cj *batch.CronJo
 		cj.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy = cronjob.RestartPolicy
 	}
 
+  if cronjob.Parallelism != nil {
+    cj.Spec.JobTemplate.Spec.Parallelism = cronjob.Parallelism
+  } // implicit else => default is 1
+
+  if cronjob.Completions != nil {
+    cj.Spec.JobTemplate.Spec.Completions = cronjob.Completions
+  } // implicit else => default is 1
+
+
 	deployProvider.ApplyPodAntiAffinity(&cj.Spec.JobTemplate.Spec.Template)
 
 }

--- a/controllers/cloud.redhat.com/providers/cronjob/impl.go
+++ b/controllers/cloud.redhat.com/providers/cronjob/impl.go
@@ -205,14 +205,13 @@ func applyCronJob(app *crd.ClowdApp, env *crd.ClowdEnvironment, cj *batch.CronJo
 		cj.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy = cronjob.RestartPolicy
 	}
 
-  if cronjob.Parallelism != nil {
-    cj.Spec.JobTemplate.Spec.Parallelism = cronjob.Parallelism
-  } // implicit else => default is 1
+	if cronjob.Parallelism != nil {
+		cj.Spec.JobTemplate.Spec.Parallelism = cronjob.Parallelism
+	} // implicit else => default is 1
 
-  if cronjob.Completions != nil {
-    cj.Spec.JobTemplate.Spec.Completions = cronjob.Completions
-  } // implicit else => default is 1
-
+	if cronjob.Completions != nil {
+		cj.Spec.JobTemplate.Spec.Completions = cronjob.Completions
+	} // implicit else => default is 1
 
 	deployProvider.ApplyPodAntiAffinity(&cj.Spec.JobTemplate.Spec.Template)
 

--- a/controllers/cloud.redhat.com/providers/job/impl.go
+++ b/controllers/cloud.redhat.com/providers/job/impl.go
@@ -34,6 +34,14 @@ func CreateJobResource(cji *crd.ClowdJobInvocation, env *crd.ClowdEnvironment, a
 		j.Spec.Template.Spec.RestartPolicy = job.RestartPolicy
 	}
 
+  if job.Parallelism != nil {
+    j.Spec.Parallelism = job.Parallelism
+  }
+
+  if job.Completions != nil {
+    j.Spec.Completions = job.Completions
+  }
+
 	envvar := pod.Env
 	envvar = append(envvar, core.EnvVar{Name: "ACG_CONFIG", Value: "/cdapp/cdappconfig.json"})
 

--- a/controllers/cloud.redhat.com/providers/job/impl.go
+++ b/controllers/cloud.redhat.com/providers/job/impl.go
@@ -34,13 +34,13 @@ func CreateJobResource(cji *crd.ClowdJobInvocation, env *crd.ClowdEnvironment, a
 		j.Spec.Template.Spec.RestartPolicy = job.RestartPolicy
 	}
 
-  if job.Parallelism != nil {
-    j.Spec.Parallelism = job.Parallelism
-  }
+	if job.Parallelism != nil {
+		j.Spec.Parallelism = job.Parallelism
+	}
 
-  if job.Completions != nil {
-    j.Spec.Completions = job.Completions
-  }
+	if job.Completions != nil {
+		j.Spec.Completions = job.Completions
+	}
 
 	envvar := pod.Env
 	envvar = append(envvar, core.EnvVar{Name: "ACG_CONFIG", Value: "/cdapp/cdappconfig.json"})

--- a/deploy-mutate.yml
+++ b/deploy-mutate.yml
@@ -2954,6 +2954,10 @@ objects:
                           More info: https://kubernetes.io/docs/concepts/workloads/controllers/job/'
                         format: int64
                         type: integer
+                      completions:
+                        description: Defines the completions of the job
+                        format: int32
+                        type: integer
                       concurrencyPolicy:
                         description: Defines the concurrency policy for the CronJob,
                           defaults to Allow Only applies to Cronjobs
@@ -2969,6 +2973,10 @@ objects:
                           will be used to name the CronJob resource, the container
                           will be name identically.
                         type: string
+                      parallelism:
+                        description: Defines the parallelism of the job
+                        format: int32
+                        type: integer
                       podSpec:
                         description: PodSpec defines a container running inside the
                           CronJob.

--- a/deploy.yml
+++ b/deploy.yml
@@ -2954,6 +2954,10 @@ objects:
                           More info: https://kubernetes.io/docs/concepts/workloads/controllers/job/'
                         format: int64
                         type: integer
+                      completions:
+                        description: Defines the completions of the job
+                        format: int32
+                        type: integer
                       concurrencyPolicy:
                         description: Defines the concurrency policy for the CronJob,
                           defaults to Allow Only applies to Cronjobs
@@ -2969,6 +2973,10 @@ objects:
                           will be used to name the CronJob resource, the container
                           will be name identically.
                         type: string
+                      parallelism:
+                        description: Defines the parallelism of the job
+                        format: int32
+                        type: integer
                       podSpec:
                         description: PodSpec defines a container running inside the
                           CronJob.

--- a/docs/antora/modules/usage/pages/jobs.adoc
+++ b/docs/antora/modules/usage/pages/jobs.adoc
@@ -68,6 +68,8 @@ objects:
     jobs:
       - name: hello-twenty
         schedule: "*/20 * * * *"
+        parallelism: 2
+        completions: 2
         podSpec:
           name: hello
           image: busybox

--- a/tests/kuttl/test-clowder-jobs/01-assert.yaml
+++ b/tests/kuttl/test-clowder-jobs/01-assert.yaml
@@ -77,6 +77,39 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
+  name: puptoo-parallel-cron
+  namespace: test-clowder-jobs
+spec:
+  concurrencyPolicy: Allow
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
+  suspend: false
+  jobTemplate:
+    spec:
+      parallelism: 3
+      completions: 2
+      activeDeadlineSeconds: 6000
+      template:
+        metadata:
+          annotations:
+            "ignore-check.kube-linter.io/no-liveness-probe": "probes not required on Job pods"
+            "ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods"
+        spec:
+          serviceAccount: puptoo-app
+          serviceAccountName: puptoo-app
+          containers:
+            - name: puptoo-parallel-cron
+              image: quay.io/psav/clowder-hello
+          restartPolicy: Never
+          tolerations:
+          - key: "memory"
+            value: "true"
+            operator: "Equal"
+            effect: "NoSchedule"
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
   name: puptoo-restart-on-failure
   namespace: test-clowder-jobs
 spec:

--- a/tests/kuttl/test-clowder-jobs/01-pods.yaml
+++ b/tests/kuttl/test-clowder-jobs/01-pods.yaml
@@ -67,6 +67,20 @@ spec:
         args:
           - ./clowder-hello
           - boo
+    - name: parallel-cron
+      parallelism: 3
+      completions: 2
+      schedule: "*/1 * * * *"
+      suspend: false 
+      successfulJobsHistoryLimit: 2
+      failedJobsHistoryLimit: 2
+      activeDeadlineSeconds: 6000
+      podSpec:
+        image: quay.io/psav/clowder-hello
+        args:
+          - ./clowder-hello
+          - boo
+        machinePool: memory
     - name: restart-on-failure 
       schedule: "*/1 * * * *"
       restartPolicy: OnFailure


### PR DESCRIPTION
- feat: Add completions and parallelism to clowdjob
- feat: add completions parallelsim to job spec

This feature adds the ability to set parallelism and completion to jobs and cronjobs
using clowder.

RHCLOUD-21108
