### PR TITLE
Set secretData on managed ephem provider after MK secret is fetched

### DIFF
--- a/controllers/cloud.redhat.com/providers/kafka/managed-ephem.go
+++ b/controllers/cloud.redhat.com/providers/kafka/managed-ephem.go
@@ -61,6 +61,7 @@ func (mep *managedEphemProvider) Provide(app *crd.ClowdApp) error {
 	if err != nil {
 		return err
 	}
+	mep.secretData = sec.Data
 
 	username, password, hostname, tokenURL, adminHostname, cacert := destructureSecret(sec)
 


### PR DESCRIPTION
It doesn't appear that we are storing the data of the ephemeral managed kafka secret on the managed ephemeral provider