### PR TITLE
Set mep.secretData on envProvide instead of app Provide

### DIFF
--- a/controllers/cloud.redhat.com/providers/kafka/managed-ephem.go
+++ b/controllers/cloud.redhat.com/providers/kafka/managed-ephem.go
@@ -53,6 +53,12 @@ func NewManagedEphemKafka(p *providers.Provider) (providers.ClowderProvider, err
 }
 
 func (mep *managedEphemProvider) EnvProvide() error {
+	sec, err := getSecret(&mep.Provider)
+	if err != nil {
+		return err
+	}
+	mep.secretData = sec.Data
+
 	return mep.configureBrokers()
 }
 
@@ -61,7 +67,6 @@ func (mep *managedEphemProvider) Provide(app *crd.ClowdApp) error {
 	if err != nil {
 		return err
 	}
-	mep.secretData = sec.Data
 
 	username, password, hostname, tokenURL, adminHostname, cacert := destructureSecret(sec)
 


### PR DESCRIPTION
We need to set the secretData in the env provider since we do not yet have a ClowdApp present at the point this code runs