### PR TITLE
Fix deletions for xjoin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IMAGE_TAG_BASE ?= quay.io/cloudservices/clowder
 CLOWDER_BUILD_TAG ?= $(shell git rev-parse --short=8 HEAD)
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.23
+ENVTEST_K8S_VERSION = 1.24
 
 # Image URL to use all building/pushing image targets
 ifeq ($(findstring -minikube,${MAKECMDGOALS}), -minikube)
@@ -90,7 +90,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 test: update-version manifests envtest generate fmt vet
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" CLOWDER_CONFIG_PATH=$(PROJECT_DIR)/test_config.json go test ./... -coverprofile cover.out
 
 vscode-debug: update-version manifests envtest generate fmt vet
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" code .

--- a/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
@@ -219,7 +219,8 @@ type KafkaConfig struct {
 	// Defines the secret reference for the Ephemeral Managed Kafka mode. Only used in (*_managed-ephem_*) mode.
 	EphemManagedSecretRef NamespacedName `json:"ephemManagedSecretRef,omitempty"`
 
-	// Defines a prefix whitelist value
+	// Deprecated: topics being deleted will be done so using the env name and a regex that combines - with .
+	// There is also a clowder top level setting to ensure that only certain topics can be deleted.
 	EphemManagedDeletePrefix string `json:"ephemManagedDeletePrefix,omitempty"`
 
 	// (Deprecated) Defines the cluster name to be used by the Kafka Provider this will

--- a/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
@@ -304,7 +304,10 @@ spec:
                         description: EnableLegacyStrimzi disables TLS + user auth
                         type: boolean
                       ephemManagedDeletePrefix:
-                        description: Defines a prefix whitelist value
+                        description: 'Deprecated: topics being deleted will be done
+                          so using the env name and a regex that combines - with .
+                          There is also a clowder top level setting to ensure that
+                          only certain topics can be deleted.'
                         type: string
                       ephemManagedSecretRef:
                         description: Defines the secret reference for the Ephemeral

--- a/config/deployment-template/clowder_config.yaml
+++ b/config/deployment-template/clowder_config.yaml
@@ -20,5 +20,8 @@ data:
             "watchStrimziResources": ${WATCH_STRIMZI_RESOURCES},
             "perProviderMetrics": ${PER_PROVIDER_METRICS},
             "reconciliationMetrics": ${RECONCILIATION_METRICS}
+        },
+        "settings": {
+            "managedKafkaEphemDeleteRegex": ${MANAGED_EPHEM_DELETE_REGEX}
         }
     }

--- a/controllers/cloud.redhat.com/clowderconfig/config.go
+++ b/controllers/cloud.redhat.com/clowderconfig/config.go
@@ -44,6 +44,9 @@ type ClowderConfig struct {
 		EnableExternalStrimzi       bool `json:"enableExternalStrimzi"`
 		DisableRandomRoutes         bool `json:"disableRandomRoutes"`
 	} `json:"features"`
+	Settings struct {
+		ManagedKafkaEphemDeleteRegex string `json:"managedKafkaEphemDeleteRegex"`
+	}
 }
 
 func getConfig() ClowderConfig {

--- a/deploy-mutate.yml
+++ b/deploy-mutate.yml
@@ -5900,7 +5900,10 @@ objects:
                           description: EnableLegacyStrimzi disables TLS + user auth
                           type: boolean
                         ephemManagedDeletePrefix:
-                          description: Defines a prefix whitelist value
+                          description: 'Deprecated: topics being deleted will be done
+                            so using the env name and a regex that combines - with
+                            . There is also a clowder top level setting to ensure
+                            that only certain topics can be deleted.'
                           type: string
                         ephemManagedSecretRef:
                           description: Defines the secret reference for the Ephemeral
@@ -7488,6 +7491,7 @@ objects:
       : {\n        \"createServiceMonitor\": ${CREATE_SERVICE_MONITORS},\n       \
       \ \"watchStrimziResources\": ${WATCH_STRIMZI_RESOURCES},\n        \"perProviderMetrics\"\
       : ${PER_PROVIDER_METRICS},\n        \"reconciliationMetrics\": ${RECONCILIATION_METRICS}\n\
+      \    },\n    \"settings\": {\n        \"managedKafkaEphemDeleteRegex\": ${MANAGED_EPHEM_DELETE_REGEX}\n\
       \    }\n}\n"
   kind: ConfigMap
   metadata:
@@ -7513,4 +7517,6 @@ parameters:
   value: 'false'
 - name: RECONCILIATION_METRICS
   value: 'false'
+- name: MANAGED_EPHEM_DELETE_REGEX
+  value: .*ephemeral.*
 

--- a/deploy.yml
+++ b/deploy.yml
@@ -5900,7 +5900,10 @@ objects:
                           description: EnableLegacyStrimzi disables TLS + user auth
                           type: boolean
                         ephemManagedDeletePrefix:
-                          description: Defines a prefix whitelist value
+                          description: 'Deprecated: topics being deleted will be done
+                            so using the env name and a regex that combines - with
+                            . There is also a clowder top level setting to ensure
+                            that only certain topics can be deleted.'
                           type: string
                         ephemManagedSecretRef:
                           description: Defines the secret reference for the Ephemeral
@@ -7461,6 +7464,7 @@ objects:
       : {\n        \"createServiceMonitor\": ${CREATE_SERVICE_MONITORS},\n       \
       \ \"watchStrimziResources\": ${WATCH_STRIMZI_RESOURCES},\n        \"perProviderMetrics\"\
       : ${PER_PROVIDER_METRICS},\n        \"reconciliationMetrics\": ${RECONCILIATION_METRICS}\n\
+      \    },\n    \"settings\": {\n        \"managedKafkaEphemDeleteRegex\": ${MANAGED_EPHEM_DELETE_REGEX}\n\
       \    }\n}\n"
   kind: ConfigMap
   metadata:
@@ -7486,4 +7490,6 @@ parameters:
   value: 'false'
 - name: RECONCILIATION_METRICS
   value: 'false'
+- name: MANAGED_EPHEM_DELETE_REGEX
+  value: .*ephemeral.*
 

--- a/docs/antora/modules/ROOT/pages/api_reference.adoc
+++ b/docs/antora/modules/ROOT/pages/api_reference.adoc
@@ -757,7 +757,7 @@ KafkaConfig configures the Clowder provider controlling the creation of Kafka in
 | *`managedSecretRef`* __xref:{anchor_prefix}-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-namespacedname[$$NamespacedName$$]__ | Defines the secret reference for the Managed Kafka mode. Only used in (*_managed_*) mode.
 | *`managedPrefix`* __string__ | Managed topic prefix for the managed cluster. Only used in (*_managed_*) mode.
 | *`ephemManagedSecretRef`* __xref:{anchor_prefix}-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-namespacedname[$$NamespacedName$$]__ | Defines the secret reference for the Ephemeral Managed Kafka mode. Only used in (*_managed-ephem_*) mode.
-| *`ephemManagedDeletePrefix`* __string__ | Defines a prefix whitelist value
+| *`ephemManagedDeletePrefix`* __string__ | Deprecated: topics being deleted will be done so using the env name and a regex that combines - with . There is also a clowder top level setting to ensure that only certain topics can be deleted.
 | *`clusterName`* __string__ | (Deprecated) Defines the cluster name to be used by the Kafka Provider this will be used in some modes to locate the Kafka instance.
 | *`namespace`* __string__ | (Deprecated) The Namespace the cluster is expected to reside in. This is only used in (*_app-interface_*) and (*_operator_*) modes.
 | *`connectNamespace`* __string__ | (Deprecated) The namespace that the Kafka Connect cluster is expected to reside in. This is only used in (*_app-interface_*) and (*_operator_*) modes.

--- a/template.yml
+++ b/template.yml
@@ -23,4 +23,6 @@ parameters:
   value: "false"
 - name: RECONCILIATION_METRICS
   value: "false"
+- name: MANAGED_EPHEM_DELETE_REGEX
+  value: ".*ephemeral.*"
 objects: []

--- a/test_config.json
+++ b/test_config.json
@@ -1,0 +1,5 @@
+{
+    "settings": {
+        "managedKafkaEphemDeleteRegex": ".*ephemeral[-\\.]managed[-\\.]kafka[-\\.]name.*"
+    }
+}


### PR DESCRIPTION
* Previously we would delete topics that matched a prefix. This was was open to abuse and allowed too much control to the owner of the ClowdEnvironment.
* Now, we have a top level clowder setting for the operator and delete only topics that match the env name in some way. The clowder config can be used to protect topics by setting an allowed regex.