### PR TITLE
Update CI pipeline trigger conditions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,11 @@ name: Submit docs
 
 on:
   push:
-    branches: 
-    - master
+    branches:
+      - master
+    paths:
+      - 'docs/**'
+      - '**/*.adoc'
 
 jobs:
   docs_build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,11 @@
 name: Go
 
 on:
-  - pull_request
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.adoc'
+      - '.github/**'
 
 permissions:
   contents: read

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,8 +1,12 @@
 ---
 name: Run Unit Tests
 
-'on':
-  - pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.adoc'
+      - '.github/**'
 
 jobs:
 


### PR DESCRIPTION
CI triggers updated to:

- Trigger Doc pipeline on changes to docs
- Don't trigger Lint pipeline for doc updates
- Don't trigger test pipeline for doc updates

should close #421 