### PR TITLE
Add logLevel to CJI spec which sets IQE_LOG_LEVEL

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdjobinvocation_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdjobinvocation_types.go
@@ -68,7 +68,7 @@ type IqeJobSpec struct {
 	// sets pytest -k args
 	Filter string `json:"filter,omitempty"`
 
-	// used when desiring to run `oc debug`on the Job to cause pod to immediately & gracefully exit
+	// Use to start the IQE pod without running tests and leave it up so that 'rsh' can be invoked
 	Debug bool `json:"debug,omitempty"`
 
 	// sets values passed to IQE '--requirements' arg
@@ -79,6 +79,10 @@ type IqeJobSpec struct {
 
 	// sets values passed to IQE '--test-importance' arg
 	TestImportance *[]string `json:"testImportance,omitempty"`
+
+	// sets value for IQE_LOG_LEVEL (default if empty: "info")
+	//+kubebuilder:validation:Enum={"", "critical", "error", "warning", "info", "debug", "notset"}
+	LogLevel string `json:"logLevel,omitempty"`
 }
 
 type IqeUISpec struct {

--- a/config/crd/bases/cloud.redhat.com_clowdjobinvocations.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdjobinvocations.yaml
@@ -58,8 +58,8 @@ spec:
                       ClowdApp's definition of the job
                     properties:
                       debug:
-                        description: used when desiring to run `oc debug`on the Job
-                          to cause pod to immediately & gracefully exit
+                        description: Use to start the IQE pod without running tests
+                          and leave it up so that 'rsh' can be invoked
                         type: boolean
                       dynaconfEnvName:
                         description: sets value for ENV_FOR_DYNACONF
@@ -71,6 +71,18 @@ spec:
                         description: By default, Clowder will set the image on the
                           ClowdJob to be the baseImage:name-of-iqe-plugin, but only
                           the tag can be overridden here
+                        type: string
+                      logLevel:
+                        description: 'sets value for IQE_LOG_LEVEL (default if empty:
+                          "info")'
+                        enum:
+                        - ""
+                        - critical
+                        - error
+                        - warning
+                        - info
+                        - debug
+                        - notset
                         type: string
                       marker:
                         description: sets the pytest -m args

--- a/controllers/cloud.redhat.com/providers/iqe/impl.go
+++ b/controllers/cloud.redhat.com/providers/iqe/impl.go
@@ -43,6 +43,12 @@ func createIqeContainer(j *batchv1.Job, nn types.NamespacedName, cji *crd.ClowdJ
 	if cji.Spec.Testing.Iqe.IqePlugins != "" {
 		iqePlugins = cji.Spec.Testing.Iqe.IqePlugins
 	}
+
+	logLevel := cji.Spec.Testing.Iqe.LogLevel
+	if cji.Spec.Testing.Iqe.LogLevel == "" {
+		logLevel = "info"
+	}
+
 	envVars := []core.EnvVar{
 		{Name: "ENV_FOR_DYNACONF", Value: cji.Spec.Testing.Iqe.DynaconfEnvName},
 		{Name: "NAMESPACE", Value: nn.Namespace},
@@ -51,6 +57,7 @@ func createIqeContainer(j *batchv1.Job, nn types.NamespacedName, cji *crd.ClowdJ
 		{Name: "IQE_PLUGINS", Value: iqePlugins},
 		{Name: "IQE_MARKER_EXPRESSION", Value: cji.Spec.Testing.Iqe.Marker},
 		{Name: "IQE_FILTER_EXPRESSION", Value: cji.Spec.Testing.Iqe.Filter},
+		{Name: "IQE_LOG_LEVEL", Value: logLevel},
 		{Name: "IQE_REQUIREMENTS", Value: joinNullableSlice(cji.Spec.Testing.Iqe.Requirements)},
 		{Name: "IQE_REQUIREMENTS_PRIORITY", Value: joinNullableSlice(cji.Spec.Testing.Iqe.RequirementsPriority)},
 		{Name: "IQE_TEST_IMPORTANCE", Value: joinNullableSlice(cji.Spec.Testing.Iqe.TestImportance)},

--- a/deploy-mutate.yml
+++ b/deploy-mutate.yml
@@ -6544,8 +6544,8 @@ objects:
                         ClowdApp's definition of the job
                       properties:
                         debug:
-                          description: used when desiring to run `oc debug`on the
-                            Job to cause pod to immediately & gracefully exit
+                          description: Use to start the IQE pod without running tests
+                            and leave it up so that 'rsh' can be invoked
                           type: boolean
                         dynaconfEnvName:
                           description: sets value for ENV_FOR_DYNACONF
@@ -6557,6 +6557,18 @@ objects:
                           description: By default, Clowder will set the image on the
                             ClowdJob to be the baseImage:name-of-iqe-plugin, but only
                             the tag can be overridden here
+                          type: string
+                        logLevel:
+                          description: 'sets value for IQE_LOG_LEVEL (default if empty:
+                            "info")'
+                          enum:
+                          - ''
+                          - critical
+                          - error
+                          - warning
+                          - info
+                          - debug
+                          - notset
                           type: string
                         marker:
                           description: sets the pytest -m args

--- a/deploy.yml
+++ b/deploy.yml
@@ -6544,8 +6544,8 @@ objects:
                         ClowdApp's definition of the job
                       properties:
                         debug:
-                          description: used when desiring to run `oc debug`on the
-                            Job to cause pod to immediately & gracefully exit
+                          description: Use to start the IQE pod without running tests
+                            and leave it up so that 'rsh' can be invoked
                           type: boolean
                         dynaconfEnvName:
                           description: sets value for ENV_FOR_DYNACONF
@@ -6557,6 +6557,18 @@ objects:
                           description: By default, Clowder will set the image on the
                             ClowdJob to be the baseImage:name-of-iqe-plugin, but only
                             the tag can be overridden here
+                          type: string
+                        logLevel:
+                          description: 'sets value for IQE_LOG_LEVEL (default if empty:
+                            "info")'
+                          enum:
+                          - ''
+                          - critical
+                          - error
+                          - warning
+                          - info
+                          - debug
+                          - notset
                           type: string
                         marker:
                           description: sets the pytest -m args

--- a/docs/antora/modules/ROOT/pages/api_reference.adoc
+++ b/docs/antora/modules/ROOT/pages/api_reference.adoc
@@ -587,10 +587,11 @@ InitContainer is a struct defining a k8s init container. This will be deployed a
 | *`marker`* __string__ | sets the pytest -m args
 | *`dynaconfEnvName`* __string__ | sets value for ENV_FOR_DYNACONF
 | *`filter`* __string__ | sets pytest -k args
-| *`debug`* __boolean__ | used when desiring to run `oc debug`on the Job to cause pod to immediately & gracefully exit
+| *`debug`* __boolean__ | Use to start the IQE pod without running tests and leave it up so that 'rsh' can be invoked
 | *`requirements`* __string__ | sets values passed to IQE '--requirements' arg
 | *`requirementsPriority`* __string__ | sets values passed to IQE '--requirements-priority' arg
 | *`testImportance`* __string__ | sets values passed to IQE '--test-importance' arg
+| *`logLevel`* __string__ | sets value for IQE_LOG_LEVEL (default if empty: "info")
 |===
 
 

--- a/tests/kuttl/test-iqe-jobs-selenium/01-assert.yaml
+++ b/tests/kuttl/test-iqe-jobs-selenium/01-assert.yaml
@@ -53,6 +53,8 @@ spec:
               value: /cdapp/cdappconfig.json
             - name: IQE_PLUGINS
               value: "host-inventory"
+            - name: IQE_LOG_LEVEL
+              value: "info"
             - name: IQE_MARKER_EXPRESSION
               value: "smoke"
             - name: IQE_FILTER_EXPRESSION

--- a/tests/kuttl/test-iqe-jobs-selenium/01-assert.yaml
+++ b/tests/kuttl/test-iqe-jobs-selenium/01-assert.yaml
@@ -53,12 +53,12 @@ spec:
               value: /cdapp/cdappconfig.json
             - name: IQE_PLUGINS
               value: "host-inventory"
-            - name: IQE_LOG_LEVEL
-              value: "info"
             - name: IQE_MARKER_EXPRESSION
               value: "smoke"
             - name: IQE_FILTER_EXPRESSION
               value: "test_plugin_accessible"
+            - name: IQE_LOG_LEVEL
+              value: "info"
             - name: IQE_REQUIREMENTS
             - name: IQE_REQUIREMENTS_PRIORITY
             - name: IQE_TEST_IMPORTANCE

--- a/tests/kuttl/test-iqe-jobs-vault/01-assert.yaml
+++ b/tests/kuttl/test-iqe-jobs-vault/01-assert.yaml
@@ -58,6 +58,8 @@ spec:
               value: "host-inventory"
             - name: IQE_MARKER_EXPRESSION
               value: "smoke"
+            - name: IQE_LOG_LEVEL
+              value: "info"
             - name: IQE_FILTER_EXPRESSION
               value: "test_plugin_accessible"
             - name: IQE_REQUIREMENTS

--- a/tests/kuttl/test-iqe-jobs-vault/01-assert.yaml
+++ b/tests/kuttl/test-iqe-jobs-vault/01-assert.yaml
@@ -58,10 +58,10 @@ spec:
               value: "host-inventory"
             - name: IQE_MARKER_EXPRESSION
               value: "smoke"
-            - name: IQE_LOG_LEVEL
-              value: "info"
             - name: IQE_FILTER_EXPRESSION
               value: "test_plugin_accessible"
+            - name: IQE_LOG_LEVEL
+              value: "info"
             - name: IQE_REQUIREMENTS
             - name: IQE_REQUIREMENTS_PRIORITY
             - name: IQE_TEST_IMPORTANCE

--- a/tests/kuttl/test-iqe-jobs/01-assert.yaml
+++ b/tests/kuttl/test-iqe-jobs/01-assert.yaml
@@ -46,6 +46,8 @@ spec:
               value: /cdapp/cdappconfig.json
             - name: IQE_PLUGINS
               value: "some,different,plugins"
+            - name: IQE_LOG_LEVEL
+              value: "debug"
             - name: IQE_MARKER_EXPRESSION
               value: "smoke"
             - name: IQE_FILTER_EXPRESSION

--- a/tests/kuttl/test-iqe-jobs/01-assert.yaml
+++ b/tests/kuttl/test-iqe-jobs/01-assert.yaml
@@ -46,12 +46,12 @@ spec:
               value: /cdapp/cdappconfig.json
             - name: IQE_PLUGINS
               value: "some,different,plugins"
-            - name: IQE_LOG_LEVEL
-              value: "debug"
             - name: IQE_MARKER_EXPRESSION
               value: "smoke"
             - name: IQE_FILTER_EXPRESSION
               value: "test_plugin_accessible"
+            - name: IQE_LOG_LEVEL
+              value: "debug"
             - name: IQE_REQUIREMENTS
               value: "some,requirements"
             - name: IQE_REQUIREMENTS_PRIORITY

--- a/tests/kuttl/test-iqe-jobs/01-pods.yaml
+++ b/tests/kuttl/test-iqe-jobs/01-pods.yaml
@@ -78,6 +78,7 @@ spec:
       marker: "smoke"
       dynaconfEnvName: "clowder_smoke"
       filter: "test_plugin_accessible"
+      logLevel: "debug"
       requirements:
       - "some"
       - "requirements"

--- a/tests/kuttl/test-iqe-jobs/03-assert-with-view.yaml
+++ b/tests/kuttl/test-iqe-jobs/03-assert-with-view.yaml
@@ -40,6 +40,8 @@ spec:
               value: "true"
             - name: ACG_CONFIG
               value: /cdapp/cdappconfig.json
+            - name: IQE_LOG_LEVEL
+              value: "info"
             - name: IQE_PLUGINS
               value: "host-inventory"
             - name: IQE_MARKER_EXPRESSION

--- a/tests/kuttl/test-iqe-jobs/03-assert-with-view.yaml
+++ b/tests/kuttl/test-iqe-jobs/03-assert-with-view.yaml
@@ -40,14 +40,14 @@ spec:
               value: "true"
             - name: ACG_CONFIG
               value: /cdapp/cdappconfig.json
-            - name: IQE_LOG_LEVEL
-              value: "info"
             - name: IQE_PLUGINS
               value: "host-inventory"
             - name: IQE_MARKER_EXPRESSION
               value: "smoke"
             - name: IQE_FILTER_EXPRESSION
               value: "test_plugin_accessible"
+            - name: IQE_LOG_LEVEL
+              value: "info"
             - name: IQE_REQUIREMENTS
             - name: IQE_REQUIREMENTS_PRIORITY
             - name: IQE_TEST_IMPORTANCE

--- a/tests/kuttl/test-iqe-jobs/05-assert-with-default.yaml
+++ b/tests/kuttl/test-iqe-jobs/05-assert-with-default.yaml
@@ -42,12 +42,12 @@ spec:
               value: /cdapp/cdappconfig.json
             - name: IQE_PLUGINS
               value: "host-inventory"
-            - name: IQE_LOG_LEVEL
-              value: "info"
             - name: IQE_MARKER_EXPRESSION
               value: "smoke"
             - name: IQE_FILTER_EXPRESSION
               value: "test_plugin_accessible"
+            - name: IQE_LOG_LEVEL
+              value: "info"
             - name: IQE_REQUIREMENTS
             - name: IQE_REQUIREMENTS_PRIORITY
             - name: IQE_TEST_IMPORTANCE

--- a/tests/kuttl/test-iqe-jobs/05-assert-with-default.yaml
+++ b/tests/kuttl/test-iqe-jobs/05-assert-with-default.yaml
@@ -42,6 +42,8 @@ spec:
               value: /cdapp/cdappconfig.json
             - name: IQE_PLUGINS
               value: "host-inventory"
+            - name: IQE_LOG_LEVEL
+              value: "info"
             - name: IQE_MARKER_EXPRESSION
               value: "smoke"
             - name: IQE_FILTER_EXPRESSION


### PR DESCRIPTION
Currently we're unable to change the log level of IQE when a CJI is invoked. This PR gives us that ability. Default log level passed to the pod will be 'info' and the field allows 'omitempty' for backward compatibility.