### PR TITLE
Support customizable rds ca bundle URL

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
@@ -258,6 +258,11 @@ type DatabaseConfig struct {
 	// where the provider will spin up a local instance of the database.
 	Mode DatabaseMode `json:"mode"`
 
+	// Indicates where Clowder will fetch the database CA certificate bundle from. Currently only used in
+	// (*_app-interface_*) mode. If none is specified, the AWS RDS combined CA bundle is used.
+	// +kubebuilder:validation:Pattern=`^https?:\/\/.+$`
+	CaBundleURL string `json:"caBundleURL,omitempty"`
+
 	// If using the (*_local_*) mode and PVC is set to true, this instructs the local
 	// Database instance to use a PVC instead of emptyDir for its volumes.
 	PVC bool `json:"pvc,omitempty"`

--- a/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
@@ -72,6 +72,13 @@ spec:
                     description: Defines the Configuration for the Clowder Database
                       Provider.
                     properties:
+                      caBundleURL:
+                        description: Indicates where Clowder will fetch the database
+                          CA certificate bundle from. Currently only used in (*_app-interface_*)
+                          mode. If none is specified, the AWS RDS combined CA bundle
+                          is used.
+                        pattern: ^https?:\/\/.+$
+                        type: string
                       mode:
                         description: 'The mode of operation of the Clowder Database
                           Provider. Valid options are: (*_app-interface_*) where the

--- a/controllers/cloud.redhat.com/providers/kafka/cyndi.go
+++ b/controllers/cloud.redhat.com/providers/kafka/cyndi.go
@@ -173,7 +173,8 @@ func getDbSecretInSameEnv(s prov.RootProvider, app *crd.ClowdApp, name string) (
 			}
 		case "app-interface":
 			if app.Spec.Database.Name != "" {
-				dbConfig, err := db.GetDbConfig(s.GetCtx(), s.GetClient(), app.Namespace, app.Name, app.Name, app.Spec.Database)
+				rdsCaBundleURL := s.GetEnv().Spec.Providers.Database.CaBundleURL
+				dbConfig, err := db.GetDbConfig(s.GetCtx(), s.GetClient(), app.Namespace, app.Name, app.Name, app.Spec.Database, rdsCaBundleURL)
 
 				if err != nil {
 					return nil, errors.Wrap("could not get database config", err)

--- a/deploy-mutate.yml
+++ b/deploy-mutate.yml
@@ -5665,6 +5665,13 @@ objects:
                       description: Defines the Configuration for the Clowder Database
                         Provider.
                       properties:
+                        caBundleURL:
+                          description: Indicates where Clowder will fetch the database
+                            CA certificate bundle from. Currently only used in (*_app-interface_*)
+                            mode. If none is specified, the AWS RDS combined CA bundle
+                            is used.
+                          pattern: ^https?:\/\/.+$
+                          type: string
                         mode:
                           description: 'The mode of operation of the Clowder Database
                             Provider. Valid options are: (*_app-interface_*) where

--- a/deploy.yml
+++ b/deploy.yml
@@ -5665,6 +5665,13 @@ objects:
                       description: Defines the Configuration for the Clowder Database
                         Provider.
                       properties:
+                        caBundleURL:
+                          description: Indicates where Clowder will fetch the database
+                            CA certificate bundle from. Currently only used in (*_app-interface_*)
+                            mode. If none is specified, the AWS RDS combined CA bundle
+                            is used.
+                          pattern: ^https?:\/\/.+$
+                          type: string
                         mode:
                           description: 'The mode of operation of the Clowder Database
                             Provider. Valid options are: (*_app-interface_*) where

--- a/docs/antora/modules/ROOT/pages/api_reference.adoc
+++ b/docs/antora/modules/ROOT/pages/api_reference.adoc
@@ -344,6 +344,7 @@ DatabaseConfig configures the Clowder provider controlling the creation of Datab
 |===
 | Field | Description
 | *`mode`* __DatabaseMode__ | The mode of operation of the Clowder Database Provider. Valid options are: (*_app-interface_*) where the provider will pass through database credentials found in the secret defined by the database name in the ClowdApp, and (*_local_*) where the provider will spin up a local instance of the database.
+| *`caBundleURL`* __string__ | Indicates where Clowder will fetch the database CA certificate bundle from. Currently only used in (*_app-interface_*) mode. If none is specified, the AWS RDS combined CA bundle is used.
 | *`pvc`* __boolean__ | If using the (*_local_*) mode and PVC is set to true, this instructs the local Database instance to use a PVC instead of emptyDir for its volumes.
 |===
 

--- a/tests/kuttl/test-multi-app-interface-db/00-install.yaml
+++ b/tests/kuttl/test-multi-app-interface-db/00-install.yaml
@@ -5,3 +5,11 @@ metadata:
 spec:
   finalizers:
   - kubernetes
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-multi-app-interface-db-default-ca
+spec:
+  finalizers:
+  - kubernetes

--- a/tests/kuttl/test-multi-app-interface-db/01-pods.yaml
+++ b/tests/kuttl/test-multi-app-interface-db/01-pods.yaml
@@ -17,6 +17,7 @@ spec:
       mode: none
     db:
       mode: app-interface
+      caBundleURL: https://truststore.pki.rds.amazonaws.com/us-east-1/us-east-1-bundle.pem
     logging:
       mode: none
     objectStore:
@@ -30,6 +31,109 @@ spec:
     requests:
       cpu: 30m
       memory: 512Mi
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdEnvironment
+metadata:
+  name: test-multi-app-interface-db-default-ca
+spec:
+  targetNamespace: test-multi-app-interface-db-default-ca
+  providers:
+    web:
+      port: 8000
+      mode: operator
+    metrics:
+      port: 9000
+      mode: operator
+      path: "/metrics"
+    kafka:
+      mode: none
+    db:
+      mode: app-interface
+    logging:
+      mode: none
+    objectStore:
+      mode: none
+    inMemoryDb:
+      mode: none
+  resourceDefaults:
+    limits:
+      cpu: 400m
+      memory: 1024Mi
+    requests:
+      cpu: 30m
+      memory: 512Mi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-default-ca-db
+  namespace: test-multi-app-interface-db-default-ca
+  annotations:
+    clowder/database: app-default-ca
+type: Opaque
+data:
+  db.host: YXBwLWRlZmF1bHQtY2EucmRzLmV4YW1wbGUuY29t  # app-default-ca.rds.example.com
+  db.name: ZGJuYW1l  # dbname
+  db.port: NTQzMg==  # 5432
+  db.user: dXNlcg==  # user
+  db.password:  cGFzc3dvcmQxMjM=  # password123
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-b-readonly-db
+  namespace: test-multi-app-interface-db
+type: Opaque
+data:
+  db.host: YXBwLWItc3RhZ2UucmRzLmV4YW1wbGUuY29t  # app-b-stage.rds.example.com
+  db.name: ZGJuYW1l  # dbname
+  db.port: NTQzMg==  # 5432
+  db.user: dXNlcg==  # user
+  db.password:  cGFzc3dvcmQxMjM=  # password123
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-c-readonly-db
+  namespace: test-multi-app-interface-db
+type: Opaque
+data:
+  db.host: YXBwLWItc3RhZ2UucmRzLmV4YW1wbGUuY29t  # app-b-stage.rds.example.com
+  db.name: ZGJuYW1l  # dbname
+  db.port: NTQzMg==  # 5432
+  db.user: dXNlcmJhZAo=  # userbad
+  db.password:  cGFzc3dvcmQxMjM=  # password123
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-c-readonly-db
+  namespace: test-multi-app-interface-db
+  annotations:
+    clowder/database: app-d
+type: Opaque
+data:
+  db.host: dW51c3VhbC5kYi5uYW1lLmV4YW1wbGUuY29t  # app-b-stage.rds.example.com
+  db.name: ZGJuYW1l  # dbname
+  db.port: NTQzMg==  # 5432
+  db.user: dXNlcmJhZAo=  # userbad
+  db.password:  cGFzc3dvcmQxMjM=  # password123
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: app-default-ca
+  namespace: test-multi-app-interface-db-default-ca
+spec:
+  envName: test-multi-app-interface-db-default-ca
+  deployments:
+  - name: processor
+    podSpec:
+      image: quay.io/psav/clowder-hello
+  database:
+    name: app-default-ca
+    version: 10
 ---
 apiVersion: cloud.redhat.com/v1alpha1
 kind: ClowdApp
@@ -63,32 +167,6 @@ spec:
   dependencies:
   - app-b
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: app-b-readonly-db
-  namespace: test-multi-app-interface-db
-type: Opaque
-data:
-  db.host: YXBwLWItc3RhZ2UucmRzLmV4YW1wbGUuY29t  # app-b-stage.rds.example.com
-  db.name: ZGJuYW1l  # dbname
-  db.port: NTQzMg==  # 5432
-  db.user: dXNlcg==  # user
-  db.password:  cGFzc3dvcmQxMjM=  # password123
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: app-c-readonly-db
-  namespace: test-multi-app-interface-db
-type: Opaque
-data:
-  db.host: YXBwLWItc3RhZ2UucmRzLmV4YW1wbGUuY29t  # app-b-stage.rds.example.com
-  db.name: ZGJuYW1l  # dbname
-  db.port: NTQzMg==  # 5432
-  db.user: dXNlcmJhZAo=  # userbad
-  db.password:  cGFzc3dvcmQxMjM=  # password123
----
 apiVersion: cloud.redhat.com/v1alpha1
 kind: ClowdApp
 metadata:
@@ -103,21 +181,6 @@ spec:
   database:
     name: app-d
     version: 10
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: app-c-readonly-db
-  namespace: test-multi-app-interface-db
-  annotations:
-    clowder/database: app-d
-type: Opaque
-data:
-  db.host: dW51c3VhbC5kYi5uYW1lLmV4YW1wbGUuY29t  # app-b-stage.rds.example.com
-  db.name: ZGJuYW1l  # dbname
-  db.port: NTQzMg==  # 5432
-  db.user: dXNlcmJhZAo=  # userbad
-  db.password:  cGFzc3dvcmQxMjM=  # password123
 ---
 apiVersion: cloud.redhat.com/v1alpha1
 kind: ClowdApp

--- a/tests/kuttl/test-multi-app-interface-db/02-json-asserts.yaml
+++ b/tests/kuttl/test-multi-app-interface-db/02-json-asserts.yaml
@@ -3,13 +3,24 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
 - script: sleep 5
+- script: curl https://truststore.pki.rds.amazonaws.com/us-east-1/us-east-1-bundle.pem > us-east-1-bundle.pem
+- script: curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem > default-ca-bundle.pem
+
+- script: kubectl get secret --namespace=test-multi-app-interface-db-default-ca app-default-ca -o json > /tmp/test-multi-app-interface-db-default-ca
+- script: jq -r '.data["cdappconfig.json"]' < /tmp/test-multi-app-interface-db-default-ca | base64 -d > /tmp/test-multi-app-interface-db-default-ca-json
+- script: jq -r '.database.hostname == "app-default-ca.rds.example.com"' -e < /tmp/test-multi-app-interface-db-default-ca-json
+- script: jq -r '.database.sslMode == "verify-full"' -e < /tmp/test-multi-app-interface-db-default-ca-json
+- script: jq -r '.database.username == "user"' -e < /tmp/test-multi-app-interface-db-default-ca-json
+- script: jq -r '.database.rdsCa' < /tmp/test-multi-app-interface-db-default-ca-json > actual.pem
+- script: diff --ignore-blank-lines actual.pem default-ca-bundle.pem
+
 - script: kubectl get secret --namespace=test-multi-app-interface-db app-c -o json > /tmp/test-multi-app-interface-db-c
 - script: jq -r '.data["cdappconfig.json"]' < /tmp/test-multi-app-interface-db-c | base64 -d > /tmp/test-multi-app-interface-db-json-c
-
 - script: jq -r '.database.hostname == "app-b-stage.rds.example.com"' -e < /tmp/test-multi-app-interface-db-json-c
 - script: jq -r '.database.sslMode == "verify-full"' -e < /tmp/test-multi-app-interface-db-json-c
 - script: jq -r '.database.username == "user"' -e < /tmp/test-multi-app-interface-db-json-c
-
+- script: jq -r '.database.rdsCa' < /tmp/test-multi-app-interface-db-json-c > actual.pem
+- script: diff --ignore-blank-lines actual.pem us-east-1-bundle.pem
 
 - script: kubectl get secret --namespace=test-multi-app-interface-db app-b -o json > /tmp/test-multi-app-interface-db-b
 - script: jq -r '.data["cdappconfig.json"]' < /tmp/test-multi-app-interface-db-b | base64 -d > /tmp/test-multi-app-interface-db-json-b
@@ -17,6 +28,8 @@ commands:
 - script: jq -r '.database.hostname == "app-b-stage.rds.example.com"' -e < /tmp/test-multi-app-interface-db-json-b
 - script: jq -r '.database.sslMode == "verify-full"' -e < /tmp/test-multi-app-interface-db-json-b
 - script: jq -r '.database.username == "user"' -e < /tmp/test-multi-app-interface-db-json-b
+- script: jq -r '.database.rdsCa' < /tmp/test-multi-app-interface-db-json-c > actual.pem
+- script: diff --ignore-blank-lines actual.pem us-east-1-bundle.pem
 
 - script: kubectl get secret --namespace=test-multi-app-interface-db app-d -o json > /tmp/test-multi-app-interface-db-d
 - script: jq -r '.data["cdappconfig.json"]' < /tmp/test-multi-app-interface-db-d | base64 -d > /tmp/test-multi-app-interface-db-json-d

--- a/tests/kuttl/test-multi-app-interface-db/03-delete.yaml
+++ b/tests/kuttl/test-multi-app-interface-db/03-delete.yaml
@@ -5,6 +5,12 @@ delete:
 - apiVersion: v1
   kind: Namespace
   name: test-multi-app-interface-db
+- apiVersion: v1
+  kind: Namespace
+  name: test-multi-app-interface-db-default-ca
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdEnvironment
   name: test-multi-app-interface-db
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdEnvironment
+  name: test-multi-app-interface-db-default-ca


### PR DESCRIPTION
Currently when the DB provider is in 'app-interface' mode, it fetches an rds CA bundle .pem from a hard-coded URL. The CA bundle used in AWS govcloud is a completely different bundle, so we need a way to adjust the bundle URL.

This PR adds support for a new field under the ClowdEnvironment's database config named 'caBundleURL'. If it is not present, we continue to use the same URL we've been using all this time.

If it is present, Clowder will download the bundle from that URL instead.

Previously we were storing the downloaded bundle in a string to prevent re-downloading it every time the ClowdEnvironment was reconciled. Now since it is possible to have a different URL across different ClowdEnvironments, we store the downloaded bundle in a map where the keys are the 'bundle URL' and the values are the 'bundle content'. This should help prevent us from re-downloading a bundle, but we now will cache the fetched bundle for each separate URL. 