### PR TITLE
[RHCLOUD-24815] Added SA for FF deployment

### DIFF
--- a/controllers/cloud.redhat.com/providers/serviceaccount/default.go
+++ b/controllers/cloud.redhat.com/providers/serviceaccount/default.go
@@ -61,6 +61,7 @@ func (sa *serviceaccountProvider) EnvProvide() error {
 
 	resourceIdentsToUpdate := []rc.ResourceIdent{
 		featureflags.LocalFFDBDeployment,
+		featureflags.LocalFFDeployment,
 		objectstore.MinioDeployment,
 		database.SharedDBDeployment,
 	}

--- a/tests/kuttl/test-ff-local/01-assert.yaml
+++ b/tests/kuttl/test-ff-local/01-assert.yaml
@@ -23,3 +23,9 @@ kind: Deployment
 metadata:
   name: test-ff-local-featureflags
   namespace: test-ff-local
+spec:
+  template:
+    spec:
+      serviceAccountName: test-ff-local-env
+      serviceAccount: test-ff-local-env
+        


### PR DESCRIPTION
The Service Account for Feature Flag deployments in local mode was not getting applied. This change adds the local deployment to the list of resource to have the service account applied, and adds a test to ensure it is present after reconciliation.