### PR TITLE
[RHCLOUD-24805] Add TLS certs to init containers

### DIFF
--- a/controllers/cloud.redhat.com/providers/web/envoy.go
+++ b/controllers/cloud.redhat.com/providers/web/envoy.go
@@ -226,4 +226,14 @@ func addCertVolume(d *apps.Deployment, dnn string) {
 		}
 		d.Spec.Template.Spec.Containers[i].VolumeMounts = vms
 	}
+
+	for i, iContainer := range d.Spec.Template.Spec.InitContainers {
+		vms := iContainer.VolumeMounts
+		vms = append(vms, v1.VolumeMount{
+			Name:      "tls-ca",
+			ReadOnly:  true,
+			MountPath: "/cdapp/certs",
+		})
+		d.Spec.Template.Spec.InitContainers[i].VolumeMounts = vms
+	}
 }

--- a/tests/kuttl/test-tls-web-services/01-assert.yaml
+++ b/tests/kuttl/test-tls-web-services/01-assert.yaml
@@ -20,6 +20,13 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+      - volumeMounts:
+        - mountPath: /cdapp/
+          name: config-secret
+        - mountPath: /cdapp/certs
+          name: tls-ca
+          readOnly: true
       containers:
       - env:
         - name: ENV_VAR_1

--- a/tests/kuttl/test-tls-web-services/01-pods.yaml
+++ b/tests/kuttl/test-tls-web-services/01-pods.yaml
@@ -52,6 +52,12 @@ spec:
           value: env_var_1
         - name: ENV_VAR_2
           value: env_var_2
+      initContainers:
+        - env:
+          - name: ENV_VAR_1
+            value: override_1
+          - name: ENV_VAR_3
+            value: env_var_3
     webServices:
       private:
         enabled: True


### PR DESCRIPTION
Init Containers were not receiving the mount for the certificates in clowder. This commit fixes this and adds a test for the condition.