### PR TITLE
[RHCLOUD-24811] Adds ability for jobs to be disabled

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
@@ -86,6 +86,10 @@ type Job struct {
 	// CronJob resource, the container will be name identically.
 	Name string `json:"name"`
 
+	// Disabled allows a job to be disabled, as such, the resource is not
+	// created on the system and cannot be invoked with a CJI
+	Disabled bool `json:"disabled,omitempty"`
+
 	// Defines the schedule for the job to run
 	Schedule string `json:"schedule,omitempty"`
 

--- a/config/crd/bases/cloud.redhat.com_clowdapps.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdapps.yaml
@@ -2926,6 +2926,11 @@ spec:
                       description: Defines the concurrency policy for the CronJob,
                         defaults to Allow Only applies to Cronjobs
                       type: string
+                    disabled:
+                      description: Disabled allows a job to be disabled, as such,
+                        the resource is not created on the system and cannot be invoked
+                        with a CJI
+                      type: boolean
                     failedJobsHistoryLimit:
                       description: The number of failed finished jobs to retain. Value
                         must be non-negative integer. Defaults to 1. Only applies

--- a/controllers/cloud.redhat.com/providers/cronjob/default.go
+++ b/controllers/cloud.redhat.com/providers/cronjob/default.go
@@ -27,7 +27,7 @@ func (j *cronjobProvider) Provide(app *crd.ClowdApp) error {
 
 	for _, cronjob := range app.Spec.Jobs {
 		innerCronjob := cronjob
-		if innerCronjob.Schedule != "" {
+		if innerCronjob.Schedule != "" && !innerCronjob.Disabled {
 			if err := j.makeCronJob(&innerCronjob, app); err != nil {
 				return err
 			}

--- a/controllers/cloud.redhat.com/providers/sidecar/default.go
+++ b/controllers/cloud.redhat.com/providers/sidecar/default.go
@@ -56,7 +56,7 @@ func (sc *sidecarProvider) Provide(app *crd.ClowdApp) error {
 
 	for _, cronJob := range app.Spec.Jobs {
 		innerCronJob := cronJob
-		if innerCronJob.Schedule == "" {
+		if innerCronJob.Schedule == "" || innerCronJob.Disabled {
 			continue
 		}
 		cj := &batch.CronJob{}

--- a/deploy-mutate.yml
+++ b/deploy-mutate.yml
@@ -2995,6 +2995,11 @@ objects:
                         description: Defines the concurrency policy for the CronJob,
                           defaults to Allow Only applies to Cronjobs
                         type: string
+                      disabled:
+                        description: Disabled allows a job to be disabled, as such,
+                          the resource is not created on the system and cannot be
+                          invoked with a CJI
+                        type: boolean
                       failedJobsHistoryLimit:
                         description: The number of failed finished jobs to retain.
                           Value must be non-negative integer. Defaults to 1. Only

--- a/deploy.yml
+++ b/deploy.yml
@@ -2995,6 +2995,11 @@ objects:
                         description: Defines the concurrency policy for the CronJob,
                           defaults to Allow Only applies to Cronjobs
                         type: string
+                      disabled:
+                        description: Disabled allows a job to be disabled, as such,
+                          the resource is not created on the system and cannot be
+                          invoked with a CJI
+                        type: boolean
                       failedJobsHistoryLimit:
                         description: The number of failed finished jobs to retain.
                           Value must be non-negative integer. Defaults to 1. Only

--- a/docs/antora/modules/ROOT/pages/api_reference.adoc
+++ b/docs/antora/modules/ROOT/pages/api_reference.adoc
@@ -682,6 +682,7 @@ Job defines a ClowdJob A Job struct will deploy as a CronJob if `schedule` is se
 |===
 | Field | Description
 | *`name`* __string__ | Name defines identifier of the Job. This name will be used to name the CronJob resource, the container will be name identically.
+| *`disabled`* __boolean__ | Disabled allows a job to be disabled, as such, the resource is not created on the system and cannot be invoked with a CJI
 | *`schedule`* __string__ | Defines the schedule for the job to run
 | *`parallelism`* __integer__ | Defines the parallelism of the job
 | *`completions`* __integer__ | Defines the completions of the job

--- a/tests/kuttl/test-clowder-jobs/01-assert.yaml
+++ b/tests/kuttl/test-clowder-jobs/01-assert.yaml
@@ -1,4 +1,12 @@
 ---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: puptoo
+  namespace: test-clowder-jobs
+status:
+  ready: true
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -151,3 +159,26 @@ spec:
           - /bin/sh
           - -c
           - echo "Hello!"
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdJobInvocation
+metadata:
+  name: runner-disabled
+  namespace: test-clowder-jobs
+spec:
+  appName: puptoo
+  jobs:
+  - hello-cji-disabled
+status:
+  completed: false
+  conditions:
+  - message: Some Jobs are still incomplete
+    reason: 'Job [hello-cji-disabled] is disabled: '
+    status: "False"
+    type: JobInvocationComplete
+  - reason: 'Job [hello-cji-disabled] is disabled: '
+    status: "True"
+    type: ReconciliationFailed
+  - status: "False"
+    type: ReconciliationSuccessful
+  jobMap: {}

--- a/tests/kuttl/test-clowder-jobs/01-errors.yaml
+++ b/tests/kuttl/test-clowder-jobs/01-errors.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: puptoo-im-disabled
+  namespace: test-clowder-jobs
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            "ignore-check.kube-linter.io/no-liveness-probe": "probes not required on Job pods"
+            "ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods"
+        spec:
+          serviceAccount: puptoo-app
+          serviceAccountName: puptoo-app
+          containers:
+            - name: puptoo-im-disabled
+              image: quay.io/psav/clowder-hello
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: test-clowder-jobs
+  labels:
+    job: puptoo-hello-cji-disabled
+spec:
+  activeDeadlineSeconds: 6000
+  template:
+    metadata:
+      annotations:
+        "ignore-check.kube-linter.io/no-liveness-probe": "probes not required on Job pods"
+        "ignore-check.kube-linter.io/no-readiness-probe": "probes not required on Job pods"
+    spec:
+      serviceAccount: puptoo-app
+      serviceAccountName: puptoo-app
+      containers:
+        - image: busybox
+          args:
+          - /bin/sh
+          - -c
+          - echo "Hello!"

--- a/tests/kuttl/test-clowder-jobs/01-pods.yaml
+++ b/tests/kuttl/test-clowder-jobs/01-pods.yaml
@@ -102,6 +102,31 @@ spec:
         - /bin/sh
         - -c
         - echo "Hello!"
+    - name: im-disabled
+      # testing that a cronjob is not created
+      # when the disabled flag is set to false
+      schedule: "*/1 * * * *"
+      restartPolicy: OnFailure
+      podSpec:
+        image: quay.io/psav/clowder-hello
+        args:
+          - ./clowder-hello
+          - boo
+      disabled: true
+    - name: hello-cji-disabled
+      # Testing incorrect specs, should be thrown away
+      # because it goes to a different controller
+      # without a schedule attribute
+      disabled: true
+      suspend: false
+      activeDeadlineSeconds: 6000
+      successfulJobsHistoryLimit: 1
+      podSpec:
+        image: busybox
+        args:
+        - /bin/sh
+        - -c
+        - echo "Hello!"
 ---
 apiVersion: cloud.redhat.com/v1alpha1
 kind: ClowdJobInvocation
@@ -112,3 +137,13 @@ spec:
   appName: puptoo
   jobs:
     - hello-cji
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdJobInvocation
+metadata:
+  name: runner-disabled
+  namespace: test-clowder-jobs
+spec:
+  appName: puptoo
+  jobs:
+    - hello-cji-disabled


### PR DESCRIPTION
Currently there is no way to disable jobs. This PR gives the ability for jobs to be disabled if they are not required to run or need to be disabled for some time.

Also includes documentation and test updates.