### PR TITLE
Add parallelEnabled and parallelWorkerCount to CJI spec which sets corresponding IQE vars.

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdjobinvocation_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdjobinvocation_types.go
@@ -83,6 +83,12 @@ type IqeJobSpec struct {
 	// sets value for IQE_LOG_LEVEL (default if empty: "info")
 	//+kubebuilder:validation:Enum={"", "critical", "error", "warning", "info", "debug", "notset"}
 	LogLevel string `json:"logLevel,omitempty"`
+
+	// sets value passed to IQE 'IQE_PARALLEL_ENABLED' arg
+	ParallelEnabled string `json:"parallelEnabled,omitempty"`
+
+	// sets value passed to IQE 'IQE_PARALLEL_WORKER_COUNT' arg
+	ParallelWorkerCount string `json:"parallelWorkerCount,omitempty"`
 }
 
 type IqeUISpec struct {

--- a/config/crd/bases/cloud.redhat.com_clowdjobinvocations.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdjobinvocations.yaml
@@ -87,6 +87,14 @@ spec:
                       marker:
                         description: sets the pytest -m args
                         type: string
+                      parallelEnabled:
+                        description: sets value passed to IQE 'IQE_PARALLEL_ENABLED'
+                          arg
+                        type: string
+                      parallelWorkerCount:
+                        description: sets value passed to IQE 'IQE_PARALLEL_WORKER_COUNT'
+                          arg
+                        type: string
                       plugins:
                         description: By default, Clowder will use the plugin name
                           indicated in the ClowdApp's spec.testing.iqePlugin field.

--- a/controllers/cloud.redhat.com/providers/iqe/impl.go
+++ b/controllers/cloud.redhat.com/providers/iqe/impl.go
@@ -61,6 +61,8 @@ func createIqeContainer(j *batchv1.Job, nn types.NamespacedName, cji *crd.ClowdJ
 		{Name: "IQE_REQUIREMENTS", Value: joinNullableSlice(cji.Spec.Testing.Iqe.Requirements)},
 		{Name: "IQE_REQUIREMENTS_PRIORITY", Value: joinNullableSlice(cji.Spec.Testing.Iqe.RequirementsPriority)},
 		{Name: "IQE_TEST_IMPORTANCE", Value: joinNullableSlice(cji.Spec.Testing.Iqe.TestImportance)},
+		{Name: "IQE_PARALLEL_ENABLED", Value: cji.Spec.Testing.Iqe.ParallelEnabled},
+		{Name: "IQE_PARALLEL_WORKER_COUNT", Value: cji.Spec.Testing.Iqe.ParallelWorkerCount},
 	}
 
 	// set image tag

--- a/deploy-mutate.yml
+++ b/deploy-mutate.yml
@@ -6608,6 +6608,14 @@ objects:
                         marker:
                           description: sets the pytest -m args
                           type: string
+                        parallelEnabled:
+                          description: sets value passed to IQE 'IQE_PARALLEL_ENABLED'
+                            arg
+                          type: string
+                        parallelWorkerCount:
+                          description: sets value passed to IQE 'IQE_PARALLEL_WORKER_COUNT'
+                            arg
+                          type: string
                         plugins:
                           description: By default, Clowder will use the plugin name
                             indicated in the ClowdApp's spec.testing.iqePlugin field.

--- a/deploy.yml
+++ b/deploy.yml
@@ -6608,6 +6608,14 @@ objects:
                         marker:
                           description: sets the pytest -m args
                           type: string
+                        parallelEnabled:
+                          description: sets value passed to IQE 'IQE_PARALLEL_ENABLED'
+                            arg
+                          type: string
+                        parallelWorkerCount:
+                          description: sets value passed to IQE 'IQE_PARALLEL_WORKER_COUNT'
+                            arg
+                          type: string
                         plugins:
                           description: By default, Clowder will use the plugin name
                             indicated in the ClowdApp's spec.testing.iqePlugin field.

--- a/docs/antora/modules/ROOT/pages/api_reference.adoc
+++ b/docs/antora/modules/ROOT/pages/api_reference.adoc
@@ -593,6 +593,8 @@ InitContainer is a struct defining a k8s init container. This will be deployed a
 | *`requirementsPriority`* __string__ | sets values passed to IQE '--requirements-priority' arg
 | *`testImportance`* __string__ | sets values passed to IQE '--test-importance' arg
 | *`logLevel`* __string__ | sets value for IQE_LOG_LEVEL (default if empty: "info")
+| *`parallelEnabled`* __string__ | Whether tests should run in parallel or not
+| *`parallelWorkerCount`* __string__ | sets value for IQE '--parallel-worker-count'
 |===
 
 

--- a/tests/kuttl/test-iqe-jobs-selenium/01-assert.yaml
+++ b/tests/kuttl/test-iqe-jobs-selenium/01-assert.yaml
@@ -62,6 +62,10 @@ spec:
             - name: IQE_REQUIREMENTS
             - name: IQE_REQUIREMENTS_PRIORITY
             - name: IQE_TEST_IMPORTANCE
+            - name: IQE_PARALLEL_ENABLED
+              value: "true"
+            - name: IQE_PARALLEL_WORKER_COUNT
+              value: "4"
           image: quay.io/psav/clowder-hello:latest
           resources:
             limits:

--- a/tests/kuttl/test-iqe-jobs-selenium/01-pods.yaml
+++ b/tests/kuttl/test-iqe-jobs-selenium/01-pods.yaml
@@ -89,3 +89,5 @@ spec:
       marker: "smoke"
       dynaconfEnvName: "clowder_smoke"
       filter: "test_plugin_accessible"
+      parallelEnabled: "true"
+      parallelWorkerCount: "4"

--- a/tests/kuttl/test-iqe-jobs-vault/01-assert.yaml
+++ b/tests/kuttl/test-iqe-jobs-vault/01-assert.yaml
@@ -65,6 +65,10 @@ spec:
             - name: IQE_REQUIREMENTS
             - name: IQE_REQUIREMENTS_PRIORITY
             - name: IQE_TEST_IMPORTANCE
+            - name: IQE_PARALLEL_ENABLED
+              value: "true"
+            - name: IQE_PARALLEL_WORKER_COUNT
+              value: "4"
             - name: DYNACONF_IQE_VAULT_LOADER_ENABLED
               value: "true"
             - name: DYNACONF_IQE_VAULT_VERIFY

--- a/tests/kuttl/test-iqe-jobs-vault/01-pods.yaml
+++ b/tests/kuttl/test-iqe-jobs-vault/01-pods.yaml
@@ -93,3 +93,5 @@ spec:
       marker: "smoke"
       dynaconfEnvName: "clowder_smoke"
       filter: "test_plugin_accessible"
+      parallelEnabled: "true"
+      parallelWorkerCount: "4"

--- a/tests/kuttl/test-iqe-jobs/01-assert.yaml
+++ b/tests/kuttl/test-iqe-jobs/01-assert.yaml
@@ -58,6 +58,10 @@ spec:
               value: "some-priority"
             - name: IQE_TEST_IMPORTANCE
               value: "critical,high"
+            - name: IQE_PARALLEL_ENABLED
+              value: "true"
+            - name: IQE_PARALLEL_WORKER_COUNT
+              value: "4"
           resources:
             limits:
               cpu: "2"

--- a/tests/kuttl/test-iqe-jobs/01-pods.yaml
+++ b/tests/kuttl/test-iqe-jobs/01-pods.yaml
@@ -87,3 +87,5 @@ spec:
       testImportance:
       - "critical"
       - "high"
+      parallelEnabled: "true"
+      parallelWorkerCount: "4"

--- a/tests/kuttl/test-iqe-jobs/03-assert-with-view.yaml
+++ b/tests/kuttl/test-iqe-jobs/03-assert-with-view.yaml
@@ -51,6 +51,10 @@ spec:
             - name: IQE_REQUIREMENTS
             - name: IQE_REQUIREMENTS_PRIORITY
             - name: IQE_TEST_IMPORTANCE
+            - name: IQE_PARALLEL_ENABLED
+              value: "true"
+            - name: IQE_PARALLEL_WORKER_COUNT
+              value: "4"
           resources:
             limits:
               cpu: "2"

--- a/tests/kuttl/test-iqe-jobs/03-pods-with-view.yaml
+++ b/tests/kuttl/test-iqe-jobs/03-pods-with-view.yaml
@@ -77,3 +77,5 @@ spec:
       marker: "smoke"
       dynaconfEnvName: "clowder_smoke"
       filter: "test_plugin_accessible"
+      parallelEnabled: "true"
+      parallelWorkerCount: "4"

--- a/tests/kuttl/test-iqe-jobs/05-assert-with-default.yaml
+++ b/tests/kuttl/test-iqe-jobs/05-assert-with-default.yaml
@@ -51,6 +51,8 @@ spec:
             - name: IQE_REQUIREMENTS
             - name: IQE_REQUIREMENTS_PRIORITY
             - name: IQE_TEST_IMPORTANCE
+            - name: IQE_PARALLEL_ENABLED
+            - name: IQE_PARALLEL_WORKER_COUNT
           resources:
             limits:
               cpu: "2"


### PR DESCRIPTION
There are two variables those were added to iqecore to handle the way we trigger tests in parallel, this would benefit the most with resource and time consuming UI tests.