### PR TITLE
Update UBI8-Minimal Base-Image & Update Build-Deploy Script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o manager mai
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1085
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1107
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/manifest.yaml .

--- a/tests/kuttl/test-kafka-managed/02-json-asserts.yaml
+++ b/tests/kuttl/test-kafka-managed/02-json-asserts.yaml
@@ -15,3 +15,4 @@ commands:
 - script: jq -r '.kafka.brokers[].sasl.password == "kafka-password"' -e < /tmp/test-kafka-managed-json
 - script: jq -r '.kafka.brokers[].sasl.securityProtocol == "SASL_SSL"' -e < /tmp/test-kafka-managed-json
 - script: jq -r '.kafka.brokers[].sasl.saslMechanism == "PLAIN"' -e < /tmp/test-kafka-managed-json
+- script: jq -r '.kafka.brokers[].securityProtocol == "SASL_SSL"' -e < /tmp/test-kafka-managed-json


### PR DESCRIPTION
This PR is to update the `UBI8-Minimal` Base-Image used for Clowder to patch vulnerabilities. Additionally, the `build_deploy.sh` script has been updated to support conditional image tagging based on whether the `security-compliance` branch is being used during the automated build pipeline.  