### PR TITLE
Fix selenium image tag override

### DIFF
--- a/controllers/cloud.redhat.com/providers/iqe/impl.go
+++ b/controllers/cloud.redhat.com/providers/iqe/impl.go
@@ -114,9 +114,9 @@ func createSeleniumContainer(j *batchv1.Job, cji *crd.ClowdJobInvocation, env *c
 		tag = "ff_102.9.0esr_chrome_112.0.5615.121"
 	}
 
-	// check if this CJI has specified an image tag override
+	// check if this CJI has specified a selenium image tag override
 	if cji.Spec.Testing.Iqe.UI.Selenium.ImageTag != "" {
-		tag = cji.Spec.Testing.Iqe.ImageTag
+		tag = cji.Spec.Testing.Iqe.UI.Selenium.ImageTag
 	}
 
 	// create pod container


### PR DESCRIPTION
I noticed a typo in the logic for overriding the selenium image tag via a CJI. (probably a copy-paste error)

The logic is currently written as: "if the selenium image tag is non-empty, then set the pod to use the IQE image tag"

That's wrong and it should read more like: "if the selenium image tag is non-empty, then set the pod to use the selenium image tag"