### PR TITLE
Adds IQE_RP_ARGS reportportal and IQE_IBUTSU_SOURCE args to CJIs

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdjobinvocation_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdjobinvocation_types.go
@@ -89,6 +89,12 @@ type IqeJobSpec struct {
 
 	// sets value passed to IQE 'IQE_PARALLEL_WORKER_COUNT' arg
 	ParallelWorkerCount string `json:"parallelWorkerCount,omitempty"`
+
+	// sets value passed to IQE 'IQE_RP_ARGS' report portal args
+	RpArgs string `json:"rpArgs,omitempty"`
+
+	// sets value passed to IQE 'IQE_IBUTSU_SOURCE' args
+	IbutsuSource string `json:"ibutsuSource,omitempty"`
 }
 
 type IqeUISpec struct {

--- a/config/crd/bases/cloud.redhat.com_clowdjobinvocations.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdjobinvocations.yaml
@@ -67,6 +67,10 @@ spec:
                       filter:
                         description: sets pytest -k args
                         type: string
+                      ibutsuSource:
+                        description: sets value passed to IQE 'IQE_IBUTSU_SOURCE'
+                          args
+                        type: string
                       imageTag:
                         description: By default, Clowder will set the image on the
                           ClowdJob to be the baseImage:name-of-iqe-plugin, but only
@@ -112,6 +116,10 @@ spec:
                         items:
                           type: string
                         type: array
+                      rpArgs:
+                        description: sets value passed to IQE 'IQE_RP_ARGS' report
+                          portal args
+                        type: string
                       testImportance:
                         description: sets values passed to IQE '--test-importance'
                           arg

--- a/controllers/cloud.redhat.com/providers/iqe/impl.go
+++ b/controllers/cloud.redhat.com/providers/iqe/impl.go
@@ -63,6 +63,8 @@ func createIqeContainer(j *batchv1.Job, nn types.NamespacedName, cji *crd.ClowdJ
 		{Name: "IQE_TEST_IMPORTANCE", Value: joinNullableSlice(cji.Spec.Testing.Iqe.TestImportance)},
 		{Name: "IQE_PARALLEL_ENABLED", Value: cji.Spec.Testing.Iqe.ParallelEnabled},
 		{Name: "IQE_PARALLEL_WORKER_COUNT", Value: cji.Spec.Testing.Iqe.ParallelWorkerCount},
+		{Name: "IQE_RP_ARGS", Value: cji.Spec.Testing.Iqe.RpArgs},
+		{Name: "IQE_IBUTSU_SOURCE", Value: cji.Spec.Testing.Iqe.IbutsuSource},
 	}
 
 	// set image tag

--- a/deploy-mutate.yml
+++ b/deploy-mutate.yml
@@ -6792,6 +6792,10 @@ objects:
                         filter:
                           description: sets pytest -k args
                           type: string
+                        ibutsuSource:
+                          description: sets value passed to IQE 'IQE_IBUTSU_SOURCE'
+                            args
+                          type: string
                         imageTag:
                           description: By default, Clowder will set the image on the
                             ClowdJob to be the baseImage:name-of-iqe-plugin, but only
@@ -6838,6 +6842,10 @@ objects:
                           items:
                             type: string
                           type: array
+                        rpArgs:
+                          description: sets value passed to IQE 'IQE_RP_ARGS' report
+                            portal args
+                          type: string
                         testImportance:
                           description: sets values passed to IQE '--test-importance'
                             arg

--- a/deploy.yml
+++ b/deploy.yml
@@ -6792,6 +6792,10 @@ objects:
                         filter:
                           description: sets pytest -k args
                           type: string
+                        ibutsuSource:
+                          description: sets value passed to IQE 'IQE_IBUTSU_SOURCE'
+                            args
+                          type: string
                         imageTag:
                           description: By default, Clowder will set the image on the
                             ClowdJob to be the baseImage:name-of-iqe-plugin, but only
@@ -6838,6 +6842,10 @@ objects:
                           items:
                             type: string
                           type: array
+                        rpArgs:
+                          description: sets value passed to IQE 'IQE_RP_ARGS' report
+                            portal args
+                          type: string
                         testImportance:
                           description: sets values passed to IQE '--test-importance'
                             arg

--- a/docs/antora/modules/ROOT/pages/api_reference.adoc
+++ b/docs/antora/modules/ROOT/pages/api_reference.adoc
@@ -595,6 +595,8 @@ InitContainer is a struct defining a k8s init container. This will be deployed a
 | *`logLevel`* __string__ | sets value for IQE_LOG_LEVEL (default if empty: "info")
 | *`parallelEnabled`* __string__ | sets value passed to IQE 'IQE_PARALLEL_ENABLED' arg
 | *`parallelWorkerCount`* __string__ | sets value passed to IQE 'IQE_PARALLEL_WORKER_COUNT' arg
+| *`rpArgs`* __string__ | sets value passed to IQE 'IQE_RP_ARGS' report portal args
+| *`ibutsuSource`* __string__ | sets value passed to IQE 'IQE_IBUTSU_SOURCE' args
 |===
 
 
@@ -844,7 +846,7 @@ MetricsConfig configures the Clowder provider controlling the creation of metric
 | Field | Description
 | *`port`* __integer__ | The port that metrics services inside ClowdApp pods should be served on.
 | *`path`* __string__ | A prefix path that pods will be instructed to use when setting up their metrics server.
-| *`mode`* __MetricsMode__ | The mode of operation of the Metrics provider. The allowed modes are  (*_none_*), which disables metrics service generation, or (*_operator_*) where services and probes are generated. (*_app-interface_*) where services and probes are generated for app-interface.
+| *`mode`* __MetricsMode__ | The mode of operation of the Metrics provider. The allowed modes are (*_none_*), which disables metrics service generation, or (*_operator_*) where services and probes are generated. (*_app-interface_*) where services and probes are generated for app-interface.
 | *`prometheus`* __xref:{anchor_prefix}-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-prometheusconfig[$$PrometheusConfig$$]__ | Prometheus specific configuration
 |===
 

--- a/tests/kuttl/test-iqe-jobs-selenium/01-assert.yaml
+++ b/tests/kuttl/test-iqe-jobs-selenium/01-assert.yaml
@@ -66,6 +66,10 @@ spec:
               value: "true"
             - name: IQE_PARALLEL_WORKER_COUNT
               value: "4"
+            - name: IQE_RP_ARGS
+              value: "true"
+            - name: IQE_IBUTSU_SOURCE
+              value: "post_stage_deploy"
           image: quay.io/psav/clowder-hello:latest
           resources:
             limits:

--- a/tests/kuttl/test-iqe-jobs-selenium/01-pods.yaml
+++ b/tests/kuttl/test-iqe-jobs-selenium/01-pods.yaml
@@ -91,3 +91,5 @@ spec:
       filter: "test_plugin_accessible"
       parallelEnabled: "true"
       parallelWorkerCount: "4"
+      rpArgs: "true"
+      ibutsuSource: "post_stage_deploy"

--- a/tests/kuttl/test-iqe-jobs-vault/01-assert.yaml
+++ b/tests/kuttl/test-iqe-jobs-vault/01-assert.yaml
@@ -69,6 +69,10 @@ spec:
               value: "true"
             - name: IQE_PARALLEL_WORKER_COUNT
               value: "4"
+            - name: IQE_RP_ARGS
+              value: "true"
+            - name: IQE_IBUTSU_SOURCE
+              value: "post_stage_deploy"
             - name: DYNACONF_IQE_VAULT_LOADER_ENABLED
               value: "true"
             - name: DYNACONF_IQE_VAULT_VERIFY

--- a/tests/kuttl/test-iqe-jobs-vault/01-pods.yaml
+++ b/tests/kuttl/test-iqe-jobs-vault/01-pods.yaml
@@ -95,3 +95,5 @@ spec:
       filter: "test_plugin_accessible"
       parallelEnabled: "true"
       parallelWorkerCount: "4"
+      rpArgs: "true"
+      ibutsuSource: "post_stage_deploy"

--- a/tests/kuttl/test-iqe-jobs/01-assert.yaml
+++ b/tests/kuttl/test-iqe-jobs/01-assert.yaml
@@ -62,6 +62,10 @@ spec:
               value: "true"
             - name: IQE_PARALLEL_WORKER_COUNT
               value: "4"
+            - name: IQE_RP_ARGS
+              value: "true"
+            - name: IQE_IBUTSU_SOURCE
+              value: "post_stage_deploy"
           resources:
             limits:
               cpu: "2"

--- a/tests/kuttl/test-iqe-jobs/01-pods.yaml
+++ b/tests/kuttl/test-iqe-jobs/01-pods.yaml
@@ -89,3 +89,5 @@ spec:
       - "high"
       parallelEnabled: "true"
       parallelWorkerCount: "4"
+      rpArgs: "true"
+      ibutsuSource: "post_stage_deploy"

--- a/tests/kuttl/test-iqe-jobs/03-assert-with-view.yaml
+++ b/tests/kuttl/test-iqe-jobs/03-assert-with-view.yaml
@@ -55,6 +55,10 @@ spec:
               value: "true"
             - name: IQE_PARALLEL_WORKER_COUNT
               value: "4"
+            - name: IQE_RP_ARGS
+              value: "true"
+            - name: IQE_IBUTSU_SOURCE
+              value: "post_stage_deploy"
           resources:
             limits:
               cpu: "2"

--- a/tests/kuttl/test-iqe-jobs/03-pods-with-view.yaml
+++ b/tests/kuttl/test-iqe-jobs/03-pods-with-view.yaml
@@ -79,3 +79,5 @@ spec:
       filter: "test_plugin_accessible"
       parallelEnabled: "true"
       parallelWorkerCount: "4"
+      rpArgs: "true"
+      ibutsuSource: "post_stage_deploy"

--- a/tests/kuttl/test-iqe-jobs/05-assert-with-default.yaml
+++ b/tests/kuttl/test-iqe-jobs/05-assert-with-default.yaml
@@ -53,6 +53,8 @@ spec:
             - name: IQE_TEST_IMPORTANCE
             - name: IQE_PARALLEL_ENABLED
             - name: IQE_PARALLEL_WORKER_COUNT
+            - name: IQE_RP_ARGS
+            - name: IQE_IBUTSU_SOURCE
           resources:
             limits:
               cpu: "2"


### PR DESCRIPTION
There are two variables those were added to iqecore to integrate with report-portal and also specify ibutsu-source for the test run