### PR TITLE
Fix rhfull location for correct client

### DIFF
--- a/jsons/redhat-external-realm.json
+++ b/jsons/redhat-external-realm.json
@@ -491,8 +491,7 @@
         "web-origins",
         "roles",
         "profile",
-        "email",
-        "rhfull"
+        "email"
       ],
       "optionalClientScopes": [
         "address",
@@ -855,7 +854,8 @@
         "roles",
         "profile",
         "email",
-        "nameandterms"
+        "nameandterms",
+        "rhfull"
       ],
       "optionalClientScopes": [
         "address",


### PR DESCRIPTION
This patch puts the rhfull scope in the right client