### PR TITLE
[RHCLOUD-28443] - Add scope to token-refresher sidecar

### DIFF
--- a/controllers/cloud.redhat.com/providers/sidecar/default.go
+++ b/controllers/cloud.redhat.com/providers/sidecar/default.go
@@ -99,6 +99,7 @@ func getTokenRefresher(appName string) *core.Container {
 		"--oidc.issuer-url=$(ISSUER_URL)",
 		"--url=$(URL)",
 		"--web.listen=:8082",
+		"--scope=$(SCOPE)",
 	}
 	cont.TerminationMessagePath = "/dev/termination-log"
 	cont.TerminationMessagePolicy = core.TerminationMessageReadFile
@@ -155,6 +156,17 @@ func getTokenRefresher(appName string) *core.Container {
 						Name: fmt.Sprintf("%s-token-refresher", appName),
 					},
 					Key: "URL",
+				},
+			},
+		},
+		{
+			Name: "SCOPE",
+			ValueFrom: &core.EnvVarSource{
+				SecretKeyRef: &core.SecretKeySelector{
+					LocalObjectReference: core.LocalObjectReference{
+						Name: fmt.Sprintf("%s-token-refresher", appName),
+					},
+					Key: "SCOPE",
 				},
 			},
 		},

--- a/controllers/cloud.redhat.com/providers/sidecar/provider.go
+++ b/controllers/cloud.redhat.com/providers/sidecar/provider.go
@@ -4,7 +4,7 @@ import (
 	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/providers"
 )
 
-var DefaultImageSideCarTokenRefresher = "quay.io/observatorium/token-refresher:master-2022-10-21-a99ce82" // nolint:gosec
+var DefaultImageSideCarTokenRefresher = "quay.io/observatorium/token-refresher:master-2023-09-20-f5e3403" // nolint:gosec
 
 // ProvName sets the provider name identifier
 var ProvName = "sidecar"

--- a/tests/kuttl/test-sidecars/01-pods.yaml
+++ b/tests/kuttl/test-sidecars/01-pods.yaml
@@ -63,6 +63,7 @@ data:
   CLIENT_SECRET: Y2xpZW50X3NlY3JldA== #client_secret
   ISSUER_URL: aHR0cDovLzEyNy4wLjAuMQ== #http://127.0.0.1
   URL: aHR0cDovLzEyNy4wLjAuMQ== #http://127.0.0.1
+  SCOPE: b3BlbmlkIG9mZmxpbmVfYWNjZXNz #openid offline_access
 kind: Secret
 metadata:
   name: puptoo-token-refresher


### PR DESCRIPTION
This patch adds scope as an option to token-refresher sidecar. Also bumps the version of the token-refresher sidecar. Related to https://github.com/observatorium/token-refresher/pull/32