### PR TITLE
[RHCLOUD-28457] - Fix bucket issue

### DIFF
--- a/controllers/cloud.redhat.com/config/schema.json
+++ b/controllers/cloud.redhat.com/config/schema.json
@@ -342,6 +342,14 @@
                 "name": {
                     "description": "The actual name of the bucket being accessed.",
                     "type": "string"
+                },
+                "tls": {
+                    "description": "Details if the Object Server uses TLS.",
+                    "type": "boolean"
+                },
+                "endpoint": {
+                    "description": "Defines the endpoint for the Object Storage server configuration.",
+                    "type": "string"
                 }
             },
             "required": [

--- a/controllers/cloud.redhat.com/config/types.go
+++ b/controllers/cloud.redhat.com/config/types.go
@@ -2,68 +2,126 @@
 
 package config
 
-import "encoding/json"
 import "fmt"
+import "encoding/json"
 import "reflect"
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *BrokerConfig) UnmarshalJSON(b []byte) error {
+func (j *TopicConfig) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname in BrokerConfig: required")
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name: required")
 	}
-	type Plain BrokerConfig
+	if v, ok := raw["requestedName"]; !ok || v == nil {
+		return fmt.Errorf("field requestedName: required")
+	}
+	type Plain TopicConfig
 	var plain Plain
 	if err := json.Unmarshal(b, &plain); err != nil {
 		return err
 	}
-	*j = BrokerConfig(plain)
+	*j = TopicConfig(plain)
 	return nil
 }
 
-// Object Storage Configuration
-type ObjectStoreConfig struct {
-	// Defines the access key for the Object Storage server configuration.
-	AccessKey *string `json:"accessKey,omitempty" yaml:"accessKey,omitempty" mapstructure:"accessKey,omitempty"`
-
-	// Buckets corresponds to the JSON schema field "buckets".
-	Buckets []ObjectStoreBucket `json:"buckets,omitempty" yaml:"buckets,omitempty" mapstructure:"buckets,omitempty"`
-
-	// Defines the hostname for the Object Storage server configuration.
-	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
-
-	// Defines the port for the Object Storage server configuration.
-	Port int `json:"port" yaml:"port" mapstructure:"port"`
-
-	// Defines the secret key for the Object Storage server configuration.
-	SecretKey *string `json:"secretKey,omitempty" yaml:"secretKey,omitempty" mapstructure:"secretKey,omitempty"`
-
-	// Details if the Object Server uses TLS.
-	Tls bool `json:"tls" yaml:"tls" mapstructure:"tls"`
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *DatabaseConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["adminPassword"]; !ok || v == nil {
+		return fmt.Errorf("field adminPassword: required")
+	}
+	if v, ok := raw["adminUsername"]; !ok || v == nil {
+		return fmt.Errorf("field adminUsername: required")
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname: required")
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name: required")
+	}
+	if v, ok := raw["password"]; !ok || v == nil {
+		return fmt.Errorf("field password: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port: required")
+	}
+	if v, ok := raw["sslMode"]; !ok || v == nil {
+		return fmt.Errorf("field sslMode: required")
+	}
+	if v, ok := raw["username"]; !ok || v == nil {
+		return fmt.Errorf("field username: required")
+	}
+	type Plain DatabaseConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = DatabaseConfig(plain)
+	return nil
 }
 
-// Dependent service connection info
-type DependencyEndpoint struct {
-	// The top level api path that the app should serve from /api/<apiPath>
-	ApiPath interface{} `json:"apiPath" yaml:"apiPath" mapstructure:"apiPath"`
+// ClowdApp deployment configuration for Clowder enabled apps.
+type AppConfig struct {
+	// Defines the path to the BOPURL.
+	BOPURL *string `json:"BOPURL,omitempty"`
 
-	// The app name of the ClowdApp hosting the service.
-	App string `json:"app" yaml:"app" mapstructure:"app"`
+	// Database corresponds to the JSON schema field "database".
+	Database *DatabaseConfig `json:"database,omitempty"`
 
-	// The hostname of the dependent service.
-	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
+	// Endpoints corresponds to the JSON schema field "endpoints".
+	Endpoints []DependencyEndpoint `json:"endpoints,omitempty"`
 
-	// The PodSpec name of the dependent service inside the ClowdApp.
-	Name string `json:"name" yaml:"name" mapstructure:"name"`
+	// FeatureFlags corresponds to the JSON schema field "featureFlags".
+	FeatureFlags *FeatureFlagsConfig `json:"featureFlags,omitempty"`
 
-	// The port of the dependent service.
-	Port int `json:"port" yaml:"port" mapstructure:"port"`
+	// A set of configMap/secret hashes
+	HashCache *string `json:"hashCache,omitempty"`
 
-	// The TLS port of the dependent service.
-	TlsPort *int `json:"tlsPort,omitempty" yaml:"tlsPort,omitempty" mapstructure:"tlsPort,omitempty"`
+	// InMemoryDb corresponds to the JSON schema field "inMemoryDb".
+	InMemoryDb *InMemoryDBConfig `json:"inMemoryDb,omitempty"`
+
+	// Kafka corresponds to the JSON schema field "kafka".
+	Kafka *KafkaConfig `json:"kafka,omitempty"`
+
+	// Logging corresponds to the JSON schema field "logging".
+	Logging LoggingConfig `json:"logging"`
+
+	// Metadata corresponds to the JSON schema field "metadata".
+	Metadata *AppMetadata `json:"metadata,omitempty"`
+
+	// Defines the path to the metrics server that the app should be configured to
+	// listen on for metric traffic.
+	MetricsPath string `json:"metricsPath"`
+
+	// Defines the metrics port that the app should be configured to listen on for
+	// metric traffic.
+	MetricsPort int `json:"metricsPort"`
+
+	// ObjectStore corresponds to the JSON schema field "objectStore".
+	ObjectStore *ObjectStoreConfig `json:"objectStore,omitempty"`
+
+	// PrivateEndpoints corresponds to the JSON schema field "privateEndpoints".
+	PrivateEndpoints []PrivateDependencyEndpoint `json:"privateEndpoints,omitempty"`
+
+	// Defines the private port that the app should be configured to listen on for API
+	// traffic.
+	PrivatePort *int `json:"privatePort,omitempty"`
+
+	// Defines the public port that the app should be configured to listen on for API
+	// traffic.
+	PublicPort *int `json:"publicPort,omitempty"`
+
+	// Defines the port CA path
+	TlsCAPath *string `json:"tlsCAPath,omitempty"`
+
+	// Deprecated: Use 'publicPort' instead.
+	WebPort *int `json:"webPort,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -73,19 +131,19 @@ func (j *DependencyEndpoint) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if v, ok := raw["apiPath"]; !ok || v == nil {
-		return fmt.Errorf("field apiPath in DependencyEndpoint: required")
+		return fmt.Errorf("field apiPath: required")
 	}
 	if v, ok := raw["app"]; !ok || v == nil {
-		return fmt.Errorf("field app in DependencyEndpoint: required")
+		return fmt.Errorf("field app: required")
 	}
 	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname in DependencyEndpoint: required")
+		return fmt.Errorf("field hostname: required")
 	}
 	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name in DependencyEndpoint: required")
+		return fmt.Errorf("field name: required")
 	}
 	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port in DependencyEndpoint: required")
+		return fmt.Errorf("field port: required")
 	}
 	type Plain DependencyEndpoint
 	var plain Plain
@@ -96,238 +154,55 @@ func (j *DependencyEndpoint) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-type FeatureFlagsConfigScheme string
-
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *AppConfig) UnmarshalJSON(b []byte) error {
+func (j *PrivateDependencyEndpoint) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
-	if v, ok := raw["logging"]; !ok || v == nil {
-		return fmt.Errorf("field logging in AppConfig: required")
+	if v, ok := raw["app"]; !ok || v == nil {
+		return fmt.Errorf("field app: required")
 	}
-	if v, ok := raw["metricsPath"]; !ok || v == nil {
-		return fmt.Errorf("field metricsPath in AppConfig: required")
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname: required")
 	}
-	if v, ok := raw["metricsPort"]; !ok || v == nil {
-		return fmt.Errorf("field metricsPort in AppConfig: required")
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name: required")
 	}
-	type Plain AppConfig
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port: required")
+	}
+	type Plain PrivateDependencyEndpoint
 	var plain Plain
 	if err := json.Unmarshal(b, &plain); err != nil {
 		return err
 	}
-	*j = AppConfig(plain)
+	*j = PrivateDependencyEndpoint(plain)
 	return nil
 }
 
-// SASL Configuration for Kafka
-type KafkaSASLConfig struct {
-	// Password corresponds to the JSON schema field "password".
-	Password *string `json:"password,omitempty" yaml:"password,omitempty" mapstructure:"password,omitempty"`
-
-	// SaslMechanism corresponds to the JSON schema field "saslMechanism".
-	SaslMechanism *string `json:"saslMechanism,omitempty" yaml:"saslMechanism,omitempty" mapstructure:"saslMechanism,omitempty"`
-
-	// Deprecated: Use the top level securityProtocol field instead
-	SecurityProtocol *string `json:"securityProtocol,omitempty" yaml:"securityProtocol,omitempty" mapstructure:"securityProtocol,omitempty"`
-
-	// Username corresponds to the JSON schema field "username".
-	Username *string `json:"username,omitempty" yaml:"username,omitempty" mapstructure:"username,omitempty"`
-}
-
-const FeatureFlagsConfigSchemeHttp FeatureFlagsConfigScheme = "http"
-const FeatureFlagsConfigSchemeHttps FeatureFlagsConfigScheme = "https"
-
-// Feature Flags Configuration
-type FeatureFlagsConfig struct {
-	// Defines the client access token to use when connect to the FeatureFlags server
-	ClientAccessToken *string `json:"clientAccessToken,omitempty" yaml:"clientAccessToken,omitempty" mapstructure:"clientAccessToken,omitempty"`
-
-	// Defines the hostname for the FeatureFlags server
-	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
-
-	// Defines the port for the FeatureFlags server
-	Port int `json:"port" yaml:"port" mapstructure:"port"`
-
-	// Details the scheme to use for FeatureFlags http/https
-	Scheme FeatureFlagsConfigScheme `json:"scheme" yaml:"scheme" mapstructure:"scheme"`
-}
-
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *FeatureFlagsConfig) UnmarshalJSON(b []byte) error {
+func (j *ObjectStoreConfig) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
 	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname in FeatureFlagsConfig: required")
+		return fmt.Errorf("field hostname: required")
 	}
 	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port in FeatureFlagsConfig: required")
+		return fmt.Errorf("field port: required")
 	}
-	if v, ok := raw["scheme"]; !ok || v == nil {
-		return fmt.Errorf("field scheme in FeatureFlagsConfig: required")
+	if v, ok := raw["tls"]; !ok || v == nil {
+		return fmt.Errorf("field tls: required")
 	}
-	type Plain FeatureFlagsConfig
+	type Plain ObjectStoreConfig
 	var plain Plain
 	if err := json.Unmarshal(b, &plain); err != nil {
 		return err
 	}
-	*j = FeatureFlagsConfig(plain)
+	*j = ObjectStoreConfig(plain)
 	return nil
-}
-
-// In Memory DB Configuration
-type InMemoryDBConfig struct {
-	// Defines the hostname for the In Memory DB server configuration.
-	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
-
-	// Defines the password for the In Memory DB server configuration.
-	Password *string `json:"password,omitempty" yaml:"password,omitempty" mapstructure:"password,omitempty"`
-
-	// Defines the port for the In Memory DB server configuration.
-	Port int `json:"port" yaml:"port" mapstructure:"port"`
-
-	// Defines the sslMode used by the In Memory DB server coniguration
-	SslMode *bool `json:"sslMode,omitempty" yaml:"sslMode,omitempty" mapstructure:"sslMode,omitempty"`
-
-	// Defines the username for the In Memory DB server configuration.
-	Username *string `json:"username,omitempty" yaml:"username,omitempty" mapstructure:"username,omitempty"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *InMemoryDBConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname in InMemoryDBConfig: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port in InMemoryDBConfig: required")
-	}
-	type Plain InMemoryDBConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = InMemoryDBConfig(plain)
-	return nil
-}
-
-type BrokerConfigAuthtype string
-
-// ClowdApp deployment configuration for Clowder enabled apps.
-type AppConfig struct {
-	// Defines the path to the BOPURL.
-	BOPURL *string `json:"BOPURL,omitempty" yaml:"BOPURL,omitempty" mapstructure:"BOPURL,omitempty"`
-
-	// Database corresponds to the JSON schema field "database".
-	Database *DatabaseConfig `json:"database,omitempty" yaml:"database,omitempty" mapstructure:"database,omitempty"`
-
-	// Endpoints corresponds to the JSON schema field "endpoints".
-	Endpoints []DependencyEndpoint `json:"endpoints,omitempty" yaml:"endpoints,omitempty" mapstructure:"endpoints,omitempty"`
-
-	// FeatureFlags corresponds to the JSON schema field "featureFlags".
-	FeatureFlags *FeatureFlagsConfig `json:"featureFlags,omitempty" yaml:"featureFlags,omitempty" mapstructure:"featureFlags,omitempty"`
-
-	// A set of configMap/secret hashes
-	HashCache *string `json:"hashCache,omitempty" yaml:"hashCache,omitempty" mapstructure:"hashCache,omitempty"`
-
-	// InMemoryDb corresponds to the JSON schema field "inMemoryDb".
-	InMemoryDb *InMemoryDBConfig `json:"inMemoryDb,omitempty" yaml:"inMemoryDb,omitempty" mapstructure:"inMemoryDb,omitempty"`
-
-	// Kafka corresponds to the JSON schema field "kafka".
-	Kafka *KafkaConfig `json:"kafka,omitempty" yaml:"kafka,omitempty" mapstructure:"kafka,omitempty"`
-
-	// Logging corresponds to the JSON schema field "logging".
-	Logging LoggingConfig `json:"logging" yaml:"logging" mapstructure:"logging"`
-
-	// Metadata corresponds to the JSON schema field "metadata".
-	Metadata *AppMetadata `json:"metadata,omitempty" yaml:"metadata,omitempty" mapstructure:"metadata,omitempty"`
-
-	// Defines the path to the metrics server that the app should be configured to
-	// listen on for metric traffic.
-	MetricsPath string `json:"metricsPath" yaml:"metricsPath" mapstructure:"metricsPath"`
-
-	// Defines the metrics port that the app should be configured to listen on for
-	// metric traffic.
-	MetricsPort int `json:"metricsPort" yaml:"metricsPort" mapstructure:"metricsPort"`
-
-	// ObjectStore corresponds to the JSON schema field "objectStore".
-	ObjectStore *ObjectStoreConfig `json:"objectStore,omitempty" yaml:"objectStore,omitempty" mapstructure:"objectStore,omitempty"`
-
-	// PrivateEndpoints corresponds to the JSON schema field "privateEndpoints".
-	PrivateEndpoints []PrivateDependencyEndpoint `json:"privateEndpoints,omitempty" yaml:"privateEndpoints,omitempty" mapstructure:"privateEndpoints,omitempty"`
-
-	// Defines the private port that the app should be configured to listen on for API
-	// traffic.
-	PrivatePort *int `json:"privatePort,omitempty" yaml:"privatePort,omitempty" mapstructure:"privatePort,omitempty"`
-
-	// Defines the public port that the app should be configured to listen on for API
-	// traffic.
-	PublicPort *int `json:"publicPort,omitempty" yaml:"publicPort,omitempty" mapstructure:"publicPort,omitempty"`
-
-	// Defines the port CA path
-	TlsCAPath *string `json:"tlsCAPath,omitempty" yaml:"tlsCAPath,omitempty" mapstructure:"tlsCAPath,omitempty"`
-
-	// Deprecated: Use 'publicPort' instead.
-	WebPort *int `json:"webPort,omitempty" yaml:"webPort,omitempty" mapstructure:"webPort,omitempty"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *BrokerConfigAuthtype) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_BrokerConfigAuthtype {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_BrokerConfigAuthtype, v)
-	}
-	*j = BrokerConfigAuthtype(v)
-	return nil
-}
-
-const BrokerConfigAuthtypeMtls BrokerConfigAuthtype = "mtls"
-
-// Database Configuration
-type DatabaseConfig struct {
-	// Defines the pgAdmin password.
-	AdminPassword string `json:"adminPassword" yaml:"adminPassword" mapstructure:"adminPassword"`
-
-	// Defines the pgAdmin username.
-	AdminUsername string `json:"adminUsername" yaml:"adminUsername" mapstructure:"adminUsername"`
-
-	// Defines the hostname of the database configured for the ClowdApp.
-	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
-
-	// Defines the database name.
-	Name string `json:"name" yaml:"name" mapstructure:"name"`
-
-	// Defines the password for the standard user.
-	Password string `json:"password" yaml:"password" mapstructure:"password"`
-
-	// Defines the port of the database configured for the ClowdApp.
-	Port int `json:"port" yaml:"port" mapstructure:"port"`
-
-	// Defines the CA used to access the database.
-	RdsCa *string `json:"rdsCa,omitempty" yaml:"rdsCa,omitempty" mapstructure:"rdsCa,omitempty"`
-
-	// Defines the postgres SSL mode that should be used.
-	SslMode string `json:"sslMode" yaml:"sslMode" mapstructure:"sslMode"`
-
-	// Defines a username with standard access to the database.
-	Username string `json:"username" yaml:"username" mapstructure:"username"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -351,264 +226,16 @@ func (j *FeatureFlagsConfigScheme) UnmarshalJSON(b []byte) error {
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *DatabaseConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["adminPassword"]; !ok || v == nil {
-		return fmt.Errorf("field adminPassword in DatabaseConfig: required")
-	}
-	if v, ok := raw["adminUsername"]; !ok || v == nil {
-		return fmt.Errorf("field adminUsername in DatabaseConfig: required")
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname in DatabaseConfig: required")
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name in DatabaseConfig: required")
-	}
-	if v, ok := raw["password"]; !ok || v == nil {
-		return fmt.Errorf("field password in DatabaseConfig: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port in DatabaseConfig: required")
-	}
-	if v, ok := raw["sslMode"]; !ok || v == nil {
-		return fmt.Errorf("field sslMode in DatabaseConfig: required")
-	}
-	if v, ok := raw["username"]; !ok || v == nil {
-		return fmt.Errorf("field username in DatabaseConfig: required")
-	}
-	type Plain DatabaseConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = DatabaseConfig(plain)
-	return nil
-}
-
-const BrokerConfigAuthtypeSasl BrokerConfigAuthtype = "sasl"
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *PrivateDependencyEndpoint) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["app"]; !ok || v == nil {
-		return fmt.Errorf("field app in PrivateDependencyEndpoint: required")
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname in PrivateDependencyEndpoint: required")
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name in PrivateDependencyEndpoint: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port in PrivateDependencyEndpoint: required")
-	}
-	type Plain PrivateDependencyEndpoint
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = PrivateDependencyEndpoint(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *TopicConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name in TopicConfig: required")
-	}
-	if v, ok := raw["requestedName"]; !ok || v == nil {
-		return fmt.Errorf("field requestedName in TopicConfig: required")
-	}
-	type Plain TopicConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = TopicConfig(plain)
-	return nil
-}
-
-// Kafka Configuration
-type KafkaConfig struct {
-	// Defines the brokers the app should connect to for Kafka services.
-	Brokers []BrokerConfig `json:"brokers" yaml:"brokers" mapstructure:"brokers"`
-
-	// Defines a list of the topic configurations available to the application.
-	Topics []TopicConfig `json:"topics" yaml:"topics" mapstructure:"topics"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *KafkaConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["brokers"]; !ok || v == nil {
-		return fmt.Errorf("field brokers in KafkaConfig: required")
-	}
-	if v, ok := raw["topics"]; !ok || v == nil {
-		return fmt.Errorf("field topics in KafkaConfig: required")
-	}
-	type Plain KafkaConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = KafkaConfig(plain)
-	return nil
-}
-
-// Cloud Watch configuration
-type CloudWatchConfig struct {
-	// Defines the access key that the app should use for configuring CloudWatch.
-	AccessKeyId string `json:"accessKeyId" yaml:"accessKeyId" mapstructure:"accessKeyId"`
-
-	// Defines the logGroup that the app should use for configuring CloudWatch.
-	LogGroup string `json:"logGroup" yaml:"logGroup" mapstructure:"logGroup"`
-
-	// Defines the region that the app should use for configuring CloudWatch.
-	Region string `json:"region" yaml:"region" mapstructure:"region"`
-
-	// Defines the secret key that the app should use for configuring CloudWatch.
-	SecretAccessKey string `json:"secretAccessKey" yaml:"secretAccessKey" mapstructure:"secretAccessKey"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *CloudWatchConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["accessKeyId"]; !ok || v == nil {
-		return fmt.Errorf("field accessKeyId in CloudWatchConfig: required")
-	}
-	if v, ok := raw["logGroup"]; !ok || v == nil {
-		return fmt.Errorf("field logGroup in CloudWatchConfig: required")
-	}
-	if v, ok := raw["region"]; !ok || v == nil {
-		return fmt.Errorf("field region in CloudWatchConfig: required")
-	}
-	if v, ok := raw["secretAccessKey"]; !ok || v == nil {
-		return fmt.Errorf("field secretAccessKey in CloudWatchConfig: required")
-	}
-	type Plain CloudWatchConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = CloudWatchConfig(plain)
-	return nil
-}
-
-// Logging Configuration
-type LoggingConfig struct {
-	// Cloudwatch corresponds to the JSON schema field "cloudwatch".
-	Cloudwatch *CloudWatchConfig `json:"cloudwatch,omitempty" yaml:"cloudwatch,omitempty" mapstructure:"cloudwatch,omitempty"`
-
-	// Defines the type of logging configuration
-	Type string `json:"type" yaml:"type" mapstructure:"type"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *LoggingConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["type"]; !ok || v == nil {
-		return fmt.Errorf("field type in LoggingConfig: required")
-	}
-	type Plain LoggingConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = LoggingConfig(plain)
-	return nil
-}
-
-// Deployment Metadata
-type DeploymentMetadata struct {
-	// Image used by deployment
-	Image string `json:"image" yaml:"image" mapstructure:"image"`
-
-	// Name of deployment
-	Name string `json:"name" yaml:"name" mapstructure:"name"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *DeploymentMetadata) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["image"]; !ok || v == nil {
-		return fmt.Errorf("field image in DeploymentMetadata: required")
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name in DeploymentMetadata: required")
-	}
-	type Plain DeploymentMetadata
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = DeploymentMetadata(plain)
-	return nil
-}
-
-// Arbitrary metadata pertaining to the application application
-type AppMetadata struct {
-	// Metadata pertaining to an application's deployments
-	Deployments []DeploymentMetadata `json:"deployments,omitempty" yaml:"deployments,omitempty" mapstructure:"deployments,omitempty"`
-
-	// Name of the ClowdEnvironment this ClowdApp runs in
-	EnvName *string `json:"envName,omitempty" yaml:"envName,omitempty" mapstructure:"envName,omitempty"`
-
-	// Name of the ClowdApp
-	Name *string `json:"name,omitempty" yaml:"name,omitempty" mapstructure:"name,omitempty"`
-}
-
-// Object Storage Bucket
-type ObjectStoreBucket struct {
-	// Defines the access key for specificed bucket.
-	AccessKey *string `json:"accessKey,omitempty" yaml:"accessKey,omitempty" mapstructure:"accessKey,omitempty"`
-
-	// The actual name of the bucket being accessed.
-	Name string `json:"name" yaml:"name" mapstructure:"name"`
-
-	// Defines the region for the specified bucket.
-	Region *string `json:"region,omitempty" yaml:"region,omitempty" mapstructure:"region,omitempty"`
-
-	// The name that was requested for the bucket in the ClowdApp.
-	RequestedName string `json:"requestedName" yaml:"requestedName" mapstructure:"requestedName"`
-
-	// Defines the secret key for the specified bucket.
-	SecretKey *string `json:"secretKey,omitempty" yaml:"secretKey,omitempty" mapstructure:"secretKey,omitempty"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
 func (j *ObjectStoreBucket) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
 	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name in ObjectStoreBucket: required")
+		return fmt.Errorf("field name: required")
 	}
 	if v, ok := raw["requestedName"]; !ok || v == nil {
-		return fmt.Errorf("field requestedName in ObjectStoreBucket: required")
+		return fmt.Errorf("field requestedName: required")
 	}
 	type Plain ObjectStoreBucket
 	var plain Plain
@@ -619,76 +246,430 @@ func (j *ObjectStoreBucket) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// Broker Configuration
-type BrokerConfig struct {
-	// Authtype corresponds to the JSON schema field "authtype".
-	Authtype *BrokerConfigAuthtype `json:"authtype,omitempty" yaml:"authtype,omitempty" mapstructure:"authtype,omitempty"`
+// Arbitrary metadata pertaining to the application application
+type AppMetadata struct {
+	// Metadata pertaining to an application's deployments
+	Deployments []DeploymentMetadata `json:"deployments,omitempty"`
 
-	// Cacert corresponds to the JSON schema field "cacert".
-	Cacert *string `json:"cacert,omitempty" yaml:"cacert,omitempty" mapstructure:"cacert,omitempty"`
+	// Name of the ClowdEnvironment this ClowdApp runs in
+	EnvName *string `json:"envName,omitempty"`
 
-	// Hostname corresponds to the JSON schema field "hostname".
-	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
-
-	// Port corresponds to the JSON schema field "port".
-	Port *int `json:"port,omitempty" yaml:"port,omitempty" mapstructure:"port,omitempty"`
-
-	// Sasl corresponds to the JSON schema field "sasl".
-	Sasl *KafkaSASLConfig `json:"sasl,omitempty" yaml:"sasl,omitempty" mapstructure:"sasl,omitempty"`
-
-	// SecurityProtocol corresponds to the JSON schema field "securityProtocol".
-	SecurityProtocol *string `json:"securityProtocol,omitempty" yaml:"securityProtocol,omitempty" mapstructure:"securityProtocol,omitempty"`
+	// Name of the ClowdApp
+	Name *string `json:"name,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *ObjectStoreConfig) UnmarshalJSON(b []byte) error {
+func (j *DeploymentMetadata) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["image"]; !ok || v == nil {
+		return fmt.Errorf("field image: required")
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name: required")
+	}
+	type Plain DeploymentMetadata
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = DeploymentMetadata(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *FeatureFlagsConfig) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
 	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname in ObjectStoreConfig: required")
+		return fmt.Errorf("field hostname: required")
 	}
 	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port in ObjectStoreConfig: required")
+		return fmt.Errorf("field port: required")
 	}
-	if v, ok := raw["tls"]; !ok || v == nil {
-		return fmt.Errorf("field tls in ObjectStoreConfig: required")
+	if v, ok := raw["scheme"]; !ok || v == nil {
+		return fmt.Errorf("field scheme: required")
 	}
-	type Plain ObjectStoreConfig
+	type Plain FeatureFlagsConfig
 	var plain Plain
 	if err := json.Unmarshal(b, &plain); err != nil {
 		return err
 	}
-	*j = ObjectStoreConfig(plain)
+	*j = FeatureFlagsConfig(plain)
 	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *LoggingConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["type"]; !ok || v == nil {
+		return fmt.Errorf("field type: required")
+	}
+	type Plain LoggingConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = LoggingConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *InMemoryDBConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port: required")
+	}
+	type Plain InMemoryDBConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = InMemoryDBConfig(plain)
+	return nil
+}
+
+type BrokerConfigAuthtype string
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *CloudWatchConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["accessKeyId"]; !ok || v == nil {
+		return fmt.Errorf("field accessKeyId: required")
+	}
+	if v, ok := raw["logGroup"]; !ok || v == nil {
+		return fmt.Errorf("field logGroup: required")
+	}
+	if v, ok := raw["region"]; !ok || v == nil {
+		return fmt.Errorf("field region: required")
+	}
+	if v, ok := raw["secretAccessKey"]; !ok || v == nil {
+		return fmt.Errorf("field secretAccessKey: required")
+	}
+	type Plain CloudWatchConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = CloudWatchConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *BrokerConfigAuthtype) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_BrokerConfigAuthtype {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_BrokerConfigAuthtype, v)
+	}
+	*j = BrokerConfigAuthtype(v)
+	return nil
+}
+
+const BrokerConfigAuthtypeMtls BrokerConfigAuthtype = "mtls"
+const BrokerConfigAuthtypeSasl BrokerConfigAuthtype = "sasl"
+
+// Cloud Watch configuration
+type CloudWatchConfig struct {
+	// Defines the access key that the app should use for configuring CloudWatch.
+	AccessKeyId string `json:"accessKeyId"`
+
+	// Defines the logGroup that the app should use for configuring CloudWatch.
+	LogGroup string `json:"logGroup"`
+
+	// Defines the region that the app should use for configuring CloudWatch.
+	Region string `json:"region"`
+
+	// Defines the secret key that the app should use for configuring CloudWatch.
+	SecretAccessKey string `json:"secretAccessKey"`
+}
+
+// Broker Configuration
+type BrokerConfig struct {
+	// Authtype corresponds to the JSON schema field "authtype".
+	Authtype *BrokerConfigAuthtype `json:"authtype,omitempty"`
+
+	// Cacert corresponds to the JSON schema field "cacert".
+	Cacert *string `json:"cacert,omitempty"`
+
+	// Hostname corresponds to the JSON schema field "hostname".
+	Hostname string `json:"hostname"`
+
+	// Port corresponds to the JSON schema field "port".
+	Port *int `json:"port,omitempty"`
+
+	// Sasl corresponds to the JSON schema field "sasl".
+	Sasl *KafkaSASLConfig `json:"sasl,omitempty"`
+
+	// SecurityProtocol corresponds to the JSON schema field "securityProtocol".
+	SecurityProtocol *string `json:"securityProtocol,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *BrokerConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname: required")
+	}
+	type Plain BrokerConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = BrokerConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *KafkaConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["brokers"]; !ok || v == nil {
+		return fmt.Errorf("field brokers: required")
+	}
+	if v, ok := raw["topics"]; !ok || v == nil {
+		return fmt.Errorf("field topics: required")
+	}
+	type Plain KafkaConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = KafkaConfig(plain)
+	return nil
+}
+
+// Database Configuration
+type DatabaseConfig struct {
+	// Defines the pgAdmin password.
+	AdminPassword string `json:"adminPassword"`
+
+	// Defines the pgAdmin username.
+	AdminUsername string `json:"adminUsername"`
+
+	// Defines the hostname of the database configured for the ClowdApp.
+	Hostname string `json:"hostname"`
+
+	// Defines the database name.
+	Name string `json:"name"`
+
+	// Defines the password for the standard user.
+	Password string `json:"password"`
+
+	// Defines the port of the database configured for the ClowdApp.
+	Port int `json:"port"`
+
+	// Defines the CA used to access the database.
+	RdsCa *string `json:"rdsCa,omitempty"`
+
+	// Defines the postgres SSL mode that should be used.
+	SslMode string `json:"sslMode"`
+
+	// Defines a username with standard access to the database.
+	Username string `json:"username"`
+}
+
+// Dependent service connection info
+type DependencyEndpoint struct {
+	// The top level api path that the app should serve from /api/<apiPath>
+	ApiPath interface{} `json:"apiPath"`
+
+	// The app name of the ClowdApp hosting the service.
+	App string `json:"app"`
+
+	// The hostname of the dependent service.
+	Hostname string `json:"hostname"`
+
+	// The PodSpec name of the dependent service inside the ClowdApp.
+	Name string `json:"name"`
+
+	// The port of the dependent service.
+	Port int `json:"port"`
+
+	// The TLS port of the dependent service.
+	TlsPort *int `json:"tlsPort,omitempty"`
+}
+
+// Deployment Metadata
+type DeploymentMetadata struct {
+	// Image used by deployment
+	Image string `json:"image"`
+
+	// Name of deployment
+	Name string `json:"name"`
+}
+
+// Feature Flags Configuration
+type FeatureFlagsConfig struct {
+	// Defines the client access token to use when connect to the FeatureFlags server
+	ClientAccessToken *string `json:"clientAccessToken,omitempty"`
+
+	// Defines the hostname for the FeatureFlags server
+	Hostname string `json:"hostname"`
+
+	// Defines the port for the FeatureFlags server
+	Port int `json:"port"`
+
+	// Details the scheme to use for FeatureFlags http/https
+	Scheme FeatureFlagsConfigScheme `json:"scheme"`
+}
+
+type FeatureFlagsConfigScheme string
+
+const FeatureFlagsConfigSchemeHttp FeatureFlagsConfigScheme = "http"
+const FeatureFlagsConfigSchemeHttps FeatureFlagsConfigScheme = "https"
+
+// In Memory DB Configuration
+type InMemoryDBConfig struct {
+	// Defines the hostname for the In Memory DB server configuration.
+	Hostname string `json:"hostname"`
+
+	// Defines the password for the In Memory DB server configuration.
+	Password *string `json:"password,omitempty"`
+
+	// Defines the port for the In Memory DB server configuration.
+	Port int `json:"port"`
+
+	// Defines the sslMode used by the In Memory DB server coniguration
+	SslMode *bool `json:"sslMode,omitempty"`
+
+	// Defines the username for the In Memory DB server configuration.
+	Username *string `json:"username,omitempty"`
+}
+
+// Kafka Configuration
+type KafkaConfig struct {
+	// Defines the brokers the app should connect to for Kafka services.
+	Brokers []BrokerConfig `json:"brokers"`
+
+	// Defines a list of the topic configurations available to the application.
+	Topics []TopicConfig `json:"topics"`
+}
+
+// SASL Configuration for Kafka
+type KafkaSASLConfig struct {
+	// Password corresponds to the JSON schema field "password".
+	Password *string `json:"password,omitempty"`
+
+	// SaslMechanism corresponds to the JSON schema field "saslMechanism".
+	SaslMechanism *string `json:"saslMechanism,omitempty"`
+
+	// Deprecated: Use the top level securityProtocol field instead
+	SecurityProtocol *string `json:"securityProtocol,omitempty"`
+
+	// Username corresponds to the JSON schema field "username".
+	Username *string `json:"username,omitempty"`
+}
+
+// Logging Configuration
+type LoggingConfig struct {
+	// Cloudwatch corresponds to the JSON schema field "cloudwatch".
+	Cloudwatch *CloudWatchConfig `json:"cloudwatch,omitempty"`
+
+	// Defines the type of logging configuration
+	Type string `json:"type"`
+}
+
+// Object Storage Bucket
+type ObjectStoreBucket struct {
+	// Defines the access key for specificed bucket.
+	AccessKey *string `json:"accessKey,omitempty"`
+
+	// Defines the endpoint for the Object Storage server configuration.
+	Endpoint *string `json:"endpoint,omitempty"`
+
+	// The actual name of the bucket being accessed.
+	Name string `json:"name"`
+
+	// Defines the region for the specified bucket.
+	Region *string `json:"region,omitempty"`
+
+	// The name that was requested for the bucket in the ClowdApp.
+	RequestedName string `json:"requestedName"`
+
+	// Defines the secret key for the specified bucket.
+	SecretKey *string `json:"secretKey,omitempty"`
+
+	// Details if the Object Server uses TLS.
+	Tls *bool `json:"tls,omitempty"`
+}
+
+// Object Storage Configuration
+type ObjectStoreConfig struct {
+	// Defines the access key for the Object Storage server configuration.
+	AccessKey *string `json:"accessKey,omitempty"`
+
+	// Buckets corresponds to the JSON schema field "buckets".
+	Buckets []ObjectStoreBucket `json:"buckets,omitempty"`
+
+	// Defines the hostname for the Object Storage server configuration.
+	Hostname string `json:"hostname"`
+
+	// Defines the port for the Object Storage server configuration.
+	Port int `json:"port"`
+
+	// Defines the secret key for the Object Storage server configuration.
+	SecretKey *string `json:"secretKey,omitempty"`
+
+	// Details if the Object Server uses TLS.
+	Tls bool `json:"tls"`
 }
 
 // Dependent service connection info
 type PrivateDependencyEndpoint struct {
 	// The app name of the ClowdApp hosting the service.
-	App string `json:"app" yaml:"app" mapstructure:"app"`
+	App string `json:"app"`
 
 	// The hostname of the dependent service.
-	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
+	Hostname string `json:"hostname"`
 
 	// The PodSpec name of the dependent service inside the ClowdApp.
-	Name string `json:"name" yaml:"name" mapstructure:"name"`
+	Name string `json:"name"`
 
 	// The port of the dependent service.
-	Port int `json:"port" yaml:"port" mapstructure:"port"`
+	Port int `json:"port"`
 
 	// The TLS port of the dependent service.
-	TlsPort *int `json:"tlsPort,omitempty" yaml:"tlsPort,omitempty" mapstructure:"tlsPort,omitempty"`
+	TlsPort *int `json:"tlsPort,omitempty"`
 }
 
 // Topic Configuration
 type TopicConfig struct {
 	// The name of the actual topic on the Kafka server.
-	Name string `json:"name" yaml:"name" mapstructure:"name"`
+	Name string `json:"name"`
 
 	// The name that the app requested in the ClowdApp definition.
-	RequestedName string `json:"requestedName" yaml:"requestedName" mapstructure:"requestedName"`
+	RequestedName string `json:"requestedName"`
 }
 
 var enumValues_BrokerConfigAuthtype = []interface{}{
@@ -698,4 +679,28 @@ var enumValues_BrokerConfigAuthtype = []interface{}{
 var enumValues_FeatureFlagsConfigScheme = []interface{}{
 	"http",
 	"https",
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *AppConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["logging"]; !ok || v == nil {
+		return fmt.Errorf("field logging: required")
+	}
+	if v, ok := raw["metricsPath"]; !ok || v == nil {
+		return fmt.Errorf("field metricsPath: required")
+	}
+	if v, ok := raw["metricsPort"]; !ok || v == nil {
+		return fmt.Errorf("field metricsPort: required")
+	}
+	type Plain AppConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = AppConfig(plain)
+	return nil
 }

--- a/controllers/cloud.redhat.com/providers/objectstore/appinterface.go
+++ b/controllers/cloud.redhat.com/providers/objectstore/appinterface.go
@@ -8,6 +8,7 @@ import (
 	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/config"
 	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/errors"
 	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/providers"
+	"github.com/RedHatInsights/rhc-osdk-utils/utils"
 	core "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -89,10 +90,12 @@ func genObjStoreConfig(secrets []core.Secret) (*config.ObjectStoreConfig, error)
 
 	extractFn := func(secret *core.Secret, bucket string) {
 		bucketConfig := config.ObjectStoreBucket{
-			AccessKey: providers.StrPtr(string(secret.Data["aws_access_key_id"])),
-			SecretKey: providers.StrPtr(string(secret.Data["aws_secret_access_key"])),
+			AccessKey: utils.StringPtr(string(secret.Data["aws_access_key_id"])),
+			SecretKey: utils.StringPtr(string(secret.Data["aws_secret_access_key"])),
 			Name:      bucket,
-			Region:    providers.StrPtr(string(secret.Data["aws_region"])),
+			Region:    utils.StringPtr(string(secret.Data["aws_region"])),
+			Endpoint:  utils.StringPtr(string(secret.Data["endpoint"])),
+			Tls:       utils.TruePtr(),
 		}
 
 		if endpoint, ok := secret.Data["endpoint"]; ok {

--- a/controllers/cloud.redhat.com/providers/objectstore/appinterface_test.go
+++ b/controllers/cloud.redhat.com/providers/objectstore/appinterface_test.go
@@ -66,16 +66,21 @@ func TestAppInterfaceObjectStore(t *testing.T) {
 
 	assert.NoError(t, err, "error calling genObjStoreConfig")
 
+	err = resolveBucketDeps([]string{"test-bucket"}, c)
+
+	assert.NoError(t, err, "error calling resolveBucketDeps")
+
 	expected := config.ObjectStoreConfig{
 		Port:     443,
 		Hostname: testSecretSpecs.ExactKeys["endpoint"],
 		Buckets: []config.ObjectStoreBucket{{
-			Region:    utils.StringPtr("us-east-1"),
-			AccessKey: utils.StringPtr(testSecretSpecs.ExactKeys["aws_access_key_id"]),
-			SecretKey: utils.StringPtr(testSecretSpecs.ExactKeys["aws_secret_access_key"]),
-			Name:      testSecretSpecs.ExactKeys["bucket"],
-			Endpoint:  utils.StringPtr("s3.us-east-1.aws.amazon.com"),
-			Tls:       utils.TruePtr(),
+			Region:        utils.StringPtr("us-east-1"),
+			AccessKey:     utils.StringPtr(testSecretSpecs.ExactKeys["aws_access_key_id"]),
+			SecretKey:     utils.StringPtr(testSecretSpecs.ExactKeys["aws_secret_access_key"]),
+			Name:          testSecretSpecs.ExactKeys["bucket"],
+			Endpoint:      utils.StringPtr(testSecretSpecs.ExactKeys["endpoint"]),
+			Tls:           utils.TruePtr(),
+			RequestedName: testSecretSpecs.ExactKeys["bucket"],
 		}},
 		Tls: true,
 	}

--- a/controllers/cloud.redhat.com/providers/objectstore/appinterface_test.go
+++ b/controllers/cloud.redhat.com/providers/objectstore/appinterface_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/config"
-	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/providers"
 	"github.com/stretchr/testify/assert"
 	core "k8s.io/api/core/v1"
 
@@ -72,9 +71,11 @@ func TestAppInterfaceObjectStore(t *testing.T) {
 		Hostname: testSecretSpecs.ExactKeys["endpoint"],
 		Buckets: []config.ObjectStoreBucket{{
 			Region:    utils.StringPtr("us-east-1"),
-			AccessKey: providers.StrPtr(testSecretSpecs.ExactKeys["aws_access_key_id"]),
-			SecretKey: providers.StrPtr(testSecretSpecs.ExactKeys["aws_secret_access_key"]),
+			AccessKey: utils.StringPtr(testSecretSpecs.ExactKeys["aws_access_key_id"]),
+			SecretKey: utils.StringPtr(testSecretSpecs.ExactKeys["aws_secret_access_key"]),
 			Name:      testSecretSpecs.ExactKeys["bucket"],
+			Endpoint:  utils.StringPtr("s3.us-east-1.aws.amazon.com"),
+			Tls:       utils.TruePtr(),
 		}},
 		Tls: true,
 	}

--- a/controllers/cloud.redhat.com/providers/objectstore/minio.go
+++ b/controllers/cloud.redhat.com/providers/objectstore/minio.go
@@ -144,6 +144,7 @@ func (m *minioProvider) Provide(app *crd.ClowdApp) error {
 		newBucket := config.ObjectStoreBucket{
 			Name:          bucket,
 			RequestedName: bucket,
+			Endpoint:      utils.StringPtr(string(secret.Data["hostname"])),
 		}
 
 		if string(secret.Data["accessKey"]) != "" {
@@ -222,8 +223,8 @@ func createMinioProvider(
 	err = mp.BucketHandler.CreateClient(
 		secMap["hostname"],
 		int(port),
-		providers.StrPtr(secMap["accessKey"]),
-		providers.StrPtr(secMap["secretKey"]),
+		utils.StringPtr(secMap["accessKey"]),
+		utils.StringPtr(secMap["secretKey"]),
 	)
 
 	if err != nil {

--- a/controllers/cloud.redhat.com/providers/objectstore/minio_test.go
+++ b/controllers/cloud.redhat.com/providers/objectstore/minio_test.go
@@ -260,7 +260,7 @@ func TestMinio(t *testing.T) {
 		assert.Len(handler.MakeCalls, 0)
 		assert.Contains(handler.ExistsCalls, bucketName)
 
-		wantBucketConfig := config.ObjectStoreBucket{Name: bucketName, RequestedName: bucketName}
+		wantBucketConfig := config.ObjectStoreBucket{Name: bucketName, RequestedName: bucketName, Endpoint: &mp.Config.ObjectStore.Hostname}
 		assert.Contains(mp.Config.ObjectStore.Buckets, wantBucketConfig)
 		assert.Len(mp.Config.ObjectStore.Buckets, 1)
 	})
@@ -288,7 +288,7 @@ func TestMinio(t *testing.T) {
 		assert.Contains(handler.ExistsCalls, bucketName)
 		assert.Contains(handler.MakeCalls, bucketName)
 
-		wantBucketConfig := config.ObjectStoreBucket{Name: bucketName, RequestedName: bucketName}
+		wantBucketConfig := config.ObjectStoreBucket{Name: bucketName, RequestedName: bucketName, Endpoint: &mp.Config.ObjectStore.Hostname}
 		assert.Contains(mp.Config.ObjectStore.Buckets, wantBucketConfig)
 		assert.Len(mp.Config.ObjectStore.Buckets, 1)
 	})
@@ -318,7 +318,7 @@ func TestMinio(t *testing.T) {
 		assert.Len(handler.MakeCalls, 3)
 		assert.Len(mp.Config.ObjectStore.Buckets, 3)
 		for _, b := range []string{b1, b2, b3} {
-			wantBucketConfig := config.ObjectStoreBucket{Name: b, RequestedName: b}
+			wantBucketConfig := config.ObjectStoreBucket{Name: b, RequestedName: b, Endpoint: &mp.Config.ObjectStore.Hostname}
 			assert.Contains(mp.Config.ObjectStore.Buckets, wantBucketConfig)
 			assert.Contains(handler.ExistsCalls, b)
 			assert.Contains(handler.MakeCalls, b)
@@ -350,7 +350,7 @@ func TestMinio(t *testing.T) {
 		assert.Len(mp.Config.ObjectStore.Buckets, 3)
 		for _, b := range []string{b1, b2, b3} {
 			assert.Contains(handler.ExistsCalls, b)
-			wantBucketConfig := config.ObjectStoreBucket{Name: b, RequestedName: b}
+			wantBucketConfig := config.ObjectStoreBucket{Name: b, RequestedName: b, Endpoint: &mp.Config.ObjectStore.Hostname}
 			assert.Contains(mp.Config.ObjectStore.Buckets, wantBucketConfig)
 		}
 		assert.Contains(handler.MakeCalls, b3)
@@ -383,7 +383,7 @@ func TestMinio(t *testing.T) {
 		assert.Len(handler.ExistsCalls, 2)
 		assert.Len(handler.MakeCalls, 1)
 		assert.Len(mp.Config.ObjectStore.Buckets, 1)
-		wantBucketConfig := config.ObjectStoreBucket{Name: b1, RequestedName: b1}
+		wantBucketConfig := config.ObjectStoreBucket{Name: b1, RequestedName: b1, Endpoint: &mp.Config.ObjectStore.Hostname}
 		assert.Contains(mp.Config.ObjectStore.Buckets, wantBucketConfig)
 	})
 
@@ -414,7 +414,7 @@ func TestMinio(t *testing.T) {
 		assert.Len(handler.ExistsCalls, 2)
 		assert.Len(handler.MakeCalls, 2)
 		assert.Len(mp.Config.ObjectStore.Buckets, 1)
-		wantBucketConfig := config.ObjectStoreBucket{Name: b1, RequestedName: b1}
+		wantBucketConfig := config.ObjectStoreBucket{Name: b1, RequestedName: b1, Endpoint: &mp.Config.ObjectStore.Hostname}
 		assert.Contains(mp.Config.ObjectStore.Buckets, wantBucketConfig)
 	})
 }

--- a/controllers/cloud.redhat.com/providers/providers.go
+++ b/controllers/cloud.redhat.com/providers/providers.go
@@ -127,11 +127,6 @@ type ClowderProvider interface {
 	GetConfig() *config.AppConfig
 }
 
-// StrPtr returns a pointer to a string.
-func StrPtr(s string) *string {
-	return &s
-}
-
 type makeFnCache func(o obj.ClowdObject, objMap ObjectMap, usePVC bool, nodePort bool)
 
 func createResource(cache *rc.ObjectCache, resourceIdent rc.ResourceIdent, nn types.NamespacedName) (client.Object, error) {

--- a/docs/appconfig/schema-definitions-objectstorebucket-properties-endpoint.md
+++ b/docs/appconfig/schema-definitions-objectstorebucket-properties-endpoint.md
@@ -1,0 +1,16 @@
+# Untitled string in AppConfig Schema
+
+```txt
+https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/endpoint
+```
+
+Defines the endpoint for the Object Storage server configuration.
+
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                    |
+| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | ------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [schema.json\*](../../out/schema.json "open original schema") |
+
+## endpoint Type
+
+`string`

--- a/docs/appconfig/schema-definitions-objectstorebucket-properties-tls.md
+++ b/docs/appconfig/schema-definitions-objectstorebucket-properties-tls.md
@@ -1,0 +1,16 @@
+# Untitled boolean in AppConfig Schema
+
+```txt
+https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/tls
+```
+
+Details if the Object Server uses TLS.
+
+
+| Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                    |
+| :------------------ | ---------- | -------------- | ----------------------- | :---------------- | --------------------- | ------------------- | ------------------------------------------------------------- |
+| Can be instantiated | No         | Unknown status | Unknown identifiability | Forbidden         | Allowed               | none                | [schema.json\*](../../out/schema.json "open original schema") |
+
+## tls Type
+
+`boolean`

--- a/docs/appconfig/schema-definitions-objectstorebucket.md
+++ b/docs/appconfig/schema-definitions-objectstorebucket.md
@@ -17,13 +17,15 @@ Object Storage Bucket
 
 # undefined Properties
 
-| Property                        | Type     | Required | Nullable       | Defined by                                                                                                                                                                                      |
-| :------------------------------ | -------- | -------- | -------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [accessKey](#accesskey)         | `string` | Optional | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-accesskey.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/accessKey")         |
-| [secretKey](#secretkey)         | `string` | Optional | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-secretkey.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/secretKey")         |
-| [region](#region)               | `string` | Optional | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-region.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/region")               |
-| [requestedName](#requestedname) | `string` | Required | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-requestedname.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/requestedName") |
-| [name](#name)                   | `string` | Required | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-name.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/name")                   |
+| Property                        | Type      | Required | Nullable       | Defined by                                                                                                                                                                                      |
+| :------------------------------ | --------- | -------- | -------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [accessKey](#accesskey)         | `string`  | Optional | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-accesskey.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/accessKey")         |
+| [secretKey](#secretkey)         | `string`  | Optional | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-secretkey.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/secretKey")         |
+| [region](#region)               | `string`  | Optional | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-region.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/region")               |
+| [requestedName](#requestedname) | `string`  | Required | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-requestedname.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/requestedName") |
+| [name](#name)                   | `string`  | Required | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-name.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/name")                   |
+| [tls](#tls)                     | `boolean` | Optional | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-tls.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/tls")                     |
+| [endpoint](#endpoint)           | `string`  | Optional | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-endpoint.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/endpoint")           |
 
 ## accessKey
 
@@ -102,5 +104,37 @@ The actual name of the bucket being accessed.
 -   defined in: [AppConfig](schema-definitions-objectstorebucket-properties-name.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/name")
 
 ### name Type
+
+`string`
+
+## tls
+
+Details if the Object Server uses TLS.
+
+
+`tls`
+
+-   is optional
+-   Type: `boolean`
+-   cannot be null
+-   defined in: [AppConfig](schema-definitions-objectstorebucket-properties-tls.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/tls")
+
+### tls Type
+
+`boolean`
+
+## endpoint
+
+Defines the endpoint for the Object Storage server configuration.
+
+
+`endpoint`
+
+-   is optional
+-   Type: `string`
+-   cannot be null
+-   defined in: [AppConfig](schema-definitions-objectstorebucket-properties-endpoint.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/endpoint")
+
+### endpoint Type
 
 `string`

--- a/docs/appconfig/schema.md
+++ b/docs/appconfig/schema.md
@@ -1011,13 +1011,15 @@ Reference this group by using
 {"$ref":"https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket"}
 ```
 
-| Property                          | Type     | Required | Nullable       | Defined by                                                                                                                                                                                      |
-| :-------------------------------- | -------- | -------- | -------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [accessKey](#accesskey)           | `string` | Optional | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-accesskey.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/accessKey")         |
-| [secretKey](#secretkey)           | `string` | Optional | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-secretkey.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/secretKey")         |
-| [region](#region-1)               | `string` | Optional | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-region.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/region")               |
-| [requestedName](#requestedname-1) | `string` | Required | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-requestedname.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/requestedName") |
-| [name](#name-4)                   | `string` | Required | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-name.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/name")                   |
+| Property                          | Type      | Required | Nullable       | Defined by                                                                                                                                                                                      |
+| :-------------------------------- | --------- | -------- | -------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [accessKey](#accesskey)           | `string`  | Optional | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-accesskey.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/accessKey")         |
+| [secretKey](#secretkey)           | `string`  | Optional | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-secretkey.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/secretKey")         |
+| [region](#region-1)               | `string`  | Optional | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-region.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/region")               |
+| [requestedName](#requestedname-1) | `string`  | Required | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-requestedname.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/requestedName") |
+| [name](#name-4)                   | `string`  | Required | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-name.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/name")                   |
+| [tls](#tls)                       | `boolean` | Optional | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-tls.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/tls")                     |
+| [endpoint](#endpoint)             | `string`  | Optional | cannot be null | [AppConfig](schema-definitions-objectstorebucket-properties-endpoint.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/endpoint")           |
 
 ### accessKey
 
@@ -1099,6 +1101,38 @@ The actual name of the bucket being accessed.
 
 `string`
 
+### tls
+
+Details if the Object Server uses TLS.
+
+
+`tls`
+
+-   is optional
+-   Type: `boolean`
+-   cannot be null
+-   defined in: [AppConfig](schema-definitions-objectstorebucket-properties-tls.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/tls")
+
+#### tls Type
+
+`boolean`
+
+### endpoint
+
+Defines the endpoint for the Object Storage server configuration.
+
+
+`endpoint`
+
+-   is optional
+-   Type: `string`
+-   cannot be null
+-   defined in: [AppConfig](schema-definitions-objectstorebucket-properties-endpoint.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreBucket/properties/endpoint")
+
+#### endpoint Type
+
+`string`
+
 ## Definitions group ObjectStoreConfig
 
 Reference this group by using
@@ -1114,7 +1148,7 @@ Reference this group by using
 | [secretKey](#secretkey-1) | `string`  | Optional | cannot be null | [AppConfig](schema-definitions-objectstoreconfig-properties-secretkey.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreConfig/properties/secretKey") |
 | [hostname](#hostname-2)   | `string`  | Required | cannot be null | [AppConfig](schema-definitions-objectstoreconfig-properties-hostname.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreConfig/properties/hostname")   |
 | [port](#port-2)           | `integer` | Required | cannot be null | [AppConfig](schema-definitions-objectstoreconfig-properties-port.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreConfig/properties/port")           |
-| [tls](#tls)               | `boolean` | Required | cannot be null | [AppConfig](schema-definitions-objectstoreconfig-properties-tls.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreConfig/properties/tls")             |
+| [tls](#tls-1)             | `boolean` | Required | cannot be null | [AppConfig](schema-definitions-objectstoreconfig-properties-tls.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreConfig/properties/tls")             |
 
 ### buckets
 


### PR DESCRIPTION
The problem here is that secrets that were being "considered" as useful were able to set the hostname, so I made two tweaks to this.
1) I moved the logic for setting the hostname so that it happens during the step where we validate the hostname. It's still not great because it means that you could get one or other of two hostnames, assuming that there are multiple secrets with differing endpoints.
2) As part of this, I needed a way to send the endpoint through to that stage of the process, so I now added the ability for the endpoint to be exposed at the bucket level too. This means that buckets can have their own configuration of differing endpoints. It will be on applications to change to adopt this and I expect us to put out an ADR to deprecate the old approach very soon.