### PR TITLE
Multi arch build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY controllers/ controllers/
 RUN make manifests generate fmt vet release
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ docker-build: update-version
 
 # Build the docker image
 docker-build-no-test-quick: update-version
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o bin/manager-cgo main.go
+	CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -o bin/manager-cgo main.go
 	$(RUNTIME) build -f build/Dockerfile-local . -t ${IMG}
 
 # Build the docker image

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -40,8 +40,14 @@ if [[ "$VALID_TAGS_LENGTH" -eq 0 ]]; then
 fi
 
 make update-version
-docker --config="$DOCKER_CONF" build  --build-arg BASE_IMAGE="$BASE_IMG" -t "${IMAGE}:${IMAGE_TAG}" .
-docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+docker --config="$DOCKER_CONF"  build  --platform linux/amd64 --build-arg BASE_IMAGE="$BASE_IMG" -t "${IMAGE}:${IMAGE_TAG}-amd64" --push .
+docker --config="$DOCKER_CONF"  build  --platform linux/arm64 --build-arg BASE_IMAGE="$BASE_IMG" -t "${IMAGE}:${IMAGE_TAG}-arm64" --push .
+
+docker --config="$DOCKER_CONF" manifest create "${IMAGE}:${IMAGE_TAG}" \
+    "${IMAGE}:${IMAGE_TAG}-amd64" \
+    "${IMAGE}:${IMAGE_TAG}-arm64"
+
+docker --config="$DOCKER_CONF" manifest push "${IMAGE}:${IMAGE_TAG}"
 
 # If the "security-compliance" branch is used for the build, it will tag the image as such.
 if [[ $GIT_BRANCH == *"security-compliance"* ]]; then


### PR DESCRIPTION
This patch adds multi arch build support for arm64 as well as amd64. A single manifest is created on quay. The correct image will be pulled for the platform doing the pulling.