### PR TITLE
Update Security-Compliance Updates to Main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,11 @@ COPY controllers/ controllers/
 RUN make manifests generate fmt vet release
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -o manager main.go
+RUN CGO_ENABLED=1 GOOS=linux GO111MODULE=on go build -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1014
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1072
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/manifest.yaml .

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -4,7 +4,7 @@ set -exv
 
 IMAGE="quay.io/cloudservices/clowder"
 IMAGE_TAG=$(git rev-parse --short=8 HEAD)
-SECURITY_COMPLIANCE_TAG="sc-$(date +%Y%m%d)"
+SECURITY_COMPLIANCE_TAG="sc-$(date +%Y%m%d)-$(git rev-parse --short=7 HEAD)"
 
 if [[ -z "$QUAY_USER" || -z "$QUAY_TOKEN" ]]; then
     echo "QUAY_USER and QUAY_TOKEN must be set"


### PR DESCRIPTION
## Overview

### Update Security-Compliance Tag Naming Convention 

Updating the `Security-Compliance Tag` Naming Convention within the `build_deploy.sh` to make it easier to identify the Git Commit the image is based on.

Example:
- OLD: `sc-20230920`
- NEW: `sc-20230920-f963f6f`

### Changing the CGO_Enabled value to 1

The change `CGO_ENABLED=1` makes the Go executable dynamically load the host OS's native libraries (e.g. glibc , OpenSSL, DNS resolver etc.). This is needed to ensure that we are using Red Hat version of the OpenSSL package in more restrictive environments.

- Testing:
   - The security team has tested the `CGO_ENABLED=1` change in our Stage Environment and Clowder ran and functioned normally. 

### Update UBI8-Minimal Image

This is a general update to pull minor Security Updates and Patches into the the Clowder Image. 

