### PR TITLE
Update schema.json to add apiPaths

### DIFF
--- a/controllers/cloud.redhat.com/config/schema.json
+++ b/controllers/cloud.redhat.com/config/schema.json
@@ -482,7 +482,15 @@
                     "type": "integer"
                 },
                 "apiPath": {
-                    "description": "The top level api path that the app should serve from /api/<apiPath>"
+                    "description": "The top level api path that the app should serve from /api/<apiPath> (deprecated, use apiPaths)",
+                    "type": "string"
+                },
+                "apiPaths": {
+                    "description": "The list of API paths (each matching format: '/api/some-path/') that this app will serve requests from",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             },
             "required": [

--- a/controllers/cloud.redhat.com/config/types.go
+++ b/controllers/cloud.redhat.com/config/types.go
@@ -501,11 +501,13 @@ type DatabaseConfig struct {
 
 // Dependent service connection info
 type DependencyEndpoint struct {
-	// (DEPRECATED, use apiPaths instead) Defines the API path that this app should serve requests from.
-    ApiPath string `json:"apiPath"`
+	// The top level api path that the app should serve from /api/<apiPath>
+	// (deprecated, use apiPaths)
+	ApiPath string `json:"apiPath"`
 
-	// Defines the list of API paths that this app should serve requests from.
-	ApiPaths []string `json:"apiPaths"`
+	// The list of API paths (each matching format: '/api/some-path/') that this app
+	// will serve requests from
+	ApiPaths []string `json:"apiPaths,omitempty"`
 
 	// The app name of the ClowdApp hosting the service.
 	App string `json:"app"`


### PR DESCRIPTION
When #869 went in, I did not update `schema.json`, I modified the config types file directly. Here I updated the schema and then ran `make genconfig`