### PR TITLE
Add pyyaml to build scripts

### DIFF
--- a/build/kube_setup.sh
+++ b/build/kube_setup.sh
@@ -50,7 +50,7 @@ fi
 python3 -m venv "build/.build_venv"
 source build/.build_venv/bin/activate
 pip install --upgrade pip setuptools wheel
-pip install ruamel.yaml
+pip install pyyaml
 
 GO_BIN_PATH="$(go env GOPATH)/bin"
 


### PR DESCRIPTION
We switched from ruamel to pyyaml but forgot to add it to the install script