### PR TITLE
Updating kafka schema and docs to provide better details

### DIFF
--- a/controllers/cloud.redhat.com/config/schema.json
+++ b/controllers/cloud.redhat.com/config/schema.json
@@ -201,17 +201,22 @@
             "description": "SASL Configuration for Kafka",
             "properties": {
                 "username": {
+                    "description": "Broker SASL username",
                     "type": "string"
                 },
                 "password": {
+                    "description": "Broker SASL password",
                     "type": "string"
                 },
                 "securityProtocol": {
-                    "description": "Deprecated: Use the top level securityProtocol field instead",
-                    "type": "string"
+                    "description": "Broker security protocol. DEPRECATED, use the top level securityProtocol field instead",
+                    "type": "string",
+                    "enum": ["SASL_SSL", "SSL"]
                 },
                 "saslMechanism": {
-                    "type": "string"
+                    "description": "Broker SASL mechanism",
+                    "type": "string",
+                    "enum": ["SCRAM-SHA-512"]
                 }
             },
             "required": []
@@ -222,23 +227,28 @@
             "description": "Broker Configuration",
             "properties": {
                 "hostname": {
+                    "description": "Hostname of kafka broker",
                     "type": "string"
                 },
                 "port": {
+                    "description": "Port of kafka broker",
                     "type": "integer"
                 },
                 "cacert": {
+                    "description": "CA certificate trust list for broker in PEM format. If absent, client should use OS default trust list",
                     "type": "string"
                 },
                 "authtype": {
                     "type": "string",
-                    "enum": ["mtls", "sasl"]
+                    "enum": ["sasl"]
                 },
                 "sasl": {
                     "$ref": "#/definitions/KafkaSASLConfig"
                 },
                 "securityProtocol": {
-                    "type": "string"
+                    "description": "Broker security procotol",
+                    "type": "string",
+                    "enum": ["SASL_SSL", "SSL"]
                 }
             },
             "required": [

--- a/controllers/cloud.redhat.com/config/schema.json
+++ b/controllers/cloud.redhat.com/config/schema.json
@@ -209,14 +209,12 @@
                     "type": "string"
                 },
                 "securityProtocol": {
-                    "description": "Broker security protocol. DEPRECATED, use the top level securityProtocol field instead",
-                    "type": "string",
-                    "enum": ["SASL_SSL", "SSL"]
+                    "description": "Broker security protocol, expect one of either: SASL_SSL, SSL. DEPRECATED, use the top level securityProtocol field instead",
+                    "type": "string"
                 },
                 "saslMechanism": {
-                    "description": "Broker SASL mechanism",
-                    "type": "string",
-                    "enum": ["SCRAM-SHA-512"]
+                    "description": "Broker SASL mechanism, expect: SCRAM-SHA-512",
+                    "type": "string"
                 }
             },
             "required": []
@@ -246,9 +244,8 @@
                     "$ref": "#/definitions/KafkaSASLConfig"
                 },
                 "securityProtocol": {
-                    "description": "Broker security procotol",
-                    "type": "string",
-                    "enum": ["SASL_SSL", "SSL"]
+                    "description": "Broker security procotol, expect one of either: SASL_SSL, SSL",
+                    "type": "string"
                 }
             },
             "required": [

--- a/controllers/cloud.redhat.com/config/types.go
+++ b/controllers/cloud.redhat.com/config/types.go
@@ -6,66 +6,6 @@ import "fmt"
 import "encoding/json"
 import "reflect"
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *TopicConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
-	}
-	if v, ok := raw["requestedName"]; !ok || v == nil {
-		return fmt.Errorf("field requestedName: required")
-	}
-	type Plain TopicConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = TopicConfig(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *DatabaseConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["adminPassword"]; !ok || v == nil {
-		return fmt.Errorf("field adminPassword: required")
-	}
-	if v, ok := raw["adminUsername"]; !ok || v == nil {
-		return fmt.Errorf("field adminUsername: required")
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
-	}
-	if v, ok := raw["password"]; !ok || v == nil {
-		return fmt.Errorf("field password: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
-	}
-	if v, ok := raw["sslMode"]; !ok || v == nil {
-		return fmt.Errorf("field sslMode: required")
-	}
-	if v, ok := raw["username"]; !ok || v == nil {
-		return fmt.Errorf("field username: required")
-	}
-	type Plain DatabaseConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = DatabaseConfig(plain)
-	return nil
-}
-
 // ClowdApp deployment configuration for Clowder enabled apps.
 type AppConfig struct {
 	// Defines the path to the BOPURL.
@@ -124,128 +64,6 @@ type AppConfig struct {
 	WebPort *int `json:"webPort,omitempty"`
 }
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *DependencyEndpoint) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["apiPath"]; !ok || v == nil {
-		return fmt.Errorf("field apiPath: required")
-	}
-	if v, ok := raw["app"]; !ok || v == nil {
-		return fmt.Errorf("field app: required")
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
-	}
-	type Plain DependencyEndpoint
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = DependencyEndpoint(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *PrivateDependencyEndpoint) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["app"]; !ok || v == nil {
-		return fmt.Errorf("field app: required")
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
-	}
-	type Plain PrivateDependencyEndpoint
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = PrivateDependencyEndpoint(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *ObjectStoreConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
-	}
-	if v, ok := raw["tls"]; !ok || v == nil {
-		return fmt.Errorf("field tls: required")
-	}
-	type Plain ObjectStoreConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = ObjectStoreConfig(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *FeatureFlagsConfigScheme) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_FeatureFlagsConfigScheme {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_FeatureFlagsConfigScheme, v)
-	}
-	*j = FeatureFlagsConfigScheme(v)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *ObjectStoreBucket) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
-	}
-	if v, ok := raw["requestedName"]; !ok || v == nil {
-		return fmt.Errorf("field requestedName: required")
-	}
-	type Plain ObjectStoreBucket
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = ObjectStoreBucket(plain)
-	return nil
-}
-
 // Arbitrary metadata pertaining to the application application
 type AppMetadata struct {
 	// Metadata pertaining to an application's deployments
@@ -258,141 +76,36 @@ type AppMetadata struct {
 	Name *string `json:"name,omitempty"`
 }
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *DeploymentMetadata) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["image"]; !ok || v == nil {
-		return fmt.Errorf("field image: required")
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
-	}
-	type Plain DeploymentMetadata
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = DeploymentMetadata(plain)
-	return nil
-}
+// Broker Configuration
+type BrokerConfig struct {
+	// Authtype corresponds to the JSON schema field "authtype".
+	Authtype *BrokerConfigAuthtype `json:"authtype,omitempty"`
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *FeatureFlagsConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
-	}
-	if v, ok := raw["scheme"]; !ok || v == nil {
-		return fmt.Errorf("field scheme: required")
-	}
-	type Plain FeatureFlagsConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = FeatureFlagsConfig(plain)
-	return nil
-}
+	// CA certificate trust list for broker in PEM format. If absent, client should
+	// use OS default trust list
+	Cacert *string `json:"cacert,omitempty"`
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *LoggingConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["type"]; !ok || v == nil {
-		return fmt.Errorf("field type: required")
-	}
-	type Plain LoggingConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = LoggingConfig(plain)
-	return nil
-}
+	// Hostname of kafka broker
+	Hostname string `json:"hostname"`
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *InMemoryDBConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
-	}
-	type Plain InMemoryDBConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = InMemoryDBConfig(plain)
-	return nil
+	// Port of kafka broker
+	Port *int `json:"port,omitempty"`
+
+	// Sasl corresponds to the JSON schema field "sasl".
+	Sasl *KafkaSASLConfig `json:"sasl,omitempty"`
+
+	// Broker security procotol
+	SecurityProtocol *BrokerConfigSecurityProtocol `json:"securityProtocol,omitempty"`
 }
 
 type BrokerConfigAuthtype string
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *CloudWatchConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["accessKeyId"]; !ok || v == nil {
-		return fmt.Errorf("field accessKeyId: required")
-	}
-	if v, ok := raw["logGroup"]; !ok || v == nil {
-		return fmt.Errorf("field logGroup: required")
-	}
-	if v, ok := raw["region"]; !ok || v == nil {
-		return fmt.Errorf("field region: required")
-	}
-	if v, ok := raw["secretAccessKey"]; !ok || v == nil {
-		return fmt.Errorf("field secretAccessKey: required")
-	}
-	type Plain CloudWatchConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = CloudWatchConfig(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *BrokerConfigAuthtype) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_BrokerConfigAuthtype {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_BrokerConfigAuthtype, v)
-	}
-	*j = BrokerConfigAuthtype(v)
-	return nil
-}
-
-const BrokerConfigAuthtypeMtls BrokerConfigAuthtype = "mtls"
 const BrokerConfigAuthtypeSasl BrokerConfigAuthtype = "sasl"
+
+type BrokerConfigSecurityProtocol string
+
+const BrokerConfigSecurityProtocolSASLSSL BrokerConfigSecurityProtocol = "SASL_SSL"
+const BrokerConfigSecurityProtocolSSL BrokerConfigSecurityProtocol = "SSL"
 
 // Cloud Watch configuration
 type CloudWatchConfig struct {
@@ -407,66 +120,6 @@ type CloudWatchConfig struct {
 
 	// Defines the secret key that the app should use for configuring CloudWatch.
 	SecretAccessKey string `json:"secretAccessKey"`
-}
-
-// Broker Configuration
-type BrokerConfig struct {
-	// Authtype corresponds to the JSON schema field "authtype".
-	Authtype *BrokerConfigAuthtype `json:"authtype,omitempty"`
-
-	// Cacert corresponds to the JSON schema field "cacert".
-	Cacert *string `json:"cacert,omitempty"`
-
-	// Hostname corresponds to the JSON schema field "hostname".
-	Hostname string `json:"hostname"`
-
-	// Port corresponds to the JSON schema field "port".
-	Port *int `json:"port,omitempty"`
-
-	// Sasl corresponds to the JSON schema field "sasl".
-	Sasl *KafkaSASLConfig `json:"sasl,omitempty"`
-
-	// SecurityProtocol corresponds to the JSON schema field "securityProtocol".
-	SecurityProtocol *string `json:"securityProtocol,omitempty"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *BrokerConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	type Plain BrokerConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = BrokerConfig(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *KafkaConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["brokers"]; !ok || v == nil {
-		return fmt.Errorf("field brokers: required")
-	}
-	if v, ok := raw["topics"]; !ok || v == nil {
-		return fmt.Errorf("field topics: required")
-	}
-	type Plain KafkaConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = KafkaConfig(plain)
-	return nil
 }
 
 // Database Configuration
@@ -581,20 +234,442 @@ type KafkaConfig struct {
 	Topics []TopicConfig `json:"topics"`
 }
 
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *ObjectStoreBucket) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name: required")
+	}
+	if v, ok := raw["requestedName"]; !ok || v == nil {
+		return fmt.Errorf("field requestedName: required")
+	}
+	type Plain ObjectStoreBucket
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = ObjectStoreBucket(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *KafkaSASLConfigSaslMechanism) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_KafkaSASLConfigSaslMechanism {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_KafkaSASLConfigSaslMechanism, v)
+	}
+	*j = KafkaSASLConfigSaslMechanism(v)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *ObjectStoreConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port: required")
+	}
+	if v, ok := raw["tls"]; !ok || v == nil {
+		return fmt.Errorf("field tls: required")
+	}
+	type Plain ObjectStoreConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = ObjectStoreConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *BrokerConfigAuthtype) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_BrokerConfigAuthtype {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_BrokerConfigAuthtype, v)
+	}
+	*j = BrokerConfigAuthtype(v)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *DeploymentMetadata) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["image"]; !ok || v == nil {
+		return fmt.Errorf("field image: required")
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name: required")
+	}
+	type Plain DeploymentMetadata
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = DeploymentMetadata(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *KafkaSASLConfigSecurityProtocol) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_KafkaSASLConfigSecurityProtocol {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_KafkaSASLConfigSecurityProtocol, v)
+	}
+	*j = KafkaSASLConfigSecurityProtocol(v)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *PrivateDependencyEndpoint) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["app"]; !ok || v == nil {
+		return fmt.Errorf("field app: required")
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname: required")
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port: required")
+	}
+	type Plain PrivateDependencyEndpoint
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = PrivateDependencyEndpoint(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *LoggingConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["type"]; !ok || v == nil {
+		return fmt.Errorf("field type: required")
+	}
+	type Plain LoggingConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = LoggingConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *InMemoryDBConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port: required")
+	}
+	type Plain InMemoryDBConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = InMemoryDBConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *FeatureFlagsConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port: required")
+	}
+	if v, ok := raw["scheme"]; !ok || v == nil {
+		return fmt.Errorf("field scheme: required")
+	}
+	type Plain FeatureFlagsConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = FeatureFlagsConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *CloudWatchConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["accessKeyId"]; !ok || v == nil {
+		return fmt.Errorf("field accessKeyId: required")
+	}
+	if v, ok := raw["logGroup"]; !ok || v == nil {
+		return fmt.Errorf("field logGroup: required")
+	}
+	if v, ok := raw["region"]; !ok || v == nil {
+		return fmt.Errorf("field region: required")
+	}
+	if v, ok := raw["secretAccessKey"]; !ok || v == nil {
+		return fmt.Errorf("field secretAccessKey: required")
+	}
+	type Plain CloudWatchConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = CloudWatchConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *BrokerConfigSecurityProtocol) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_BrokerConfigSecurityProtocol {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_BrokerConfigSecurityProtocol, v)
+	}
+	*j = BrokerConfigSecurityProtocol(v)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *FeatureFlagsConfigScheme) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_FeatureFlagsConfigScheme {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_FeatureFlagsConfigScheme, v)
+	}
+	*j = FeatureFlagsConfigScheme(v)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *DependencyEndpoint) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["apiPath"]; !ok || v == nil {
+		return fmt.Errorf("field apiPath: required")
+	}
+	if v, ok := raw["app"]; !ok || v == nil {
+		return fmt.Errorf("field app: required")
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname: required")
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port: required")
+	}
+	type Plain DependencyEndpoint
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = DependencyEndpoint(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *DatabaseConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["adminPassword"]; !ok || v == nil {
+		return fmt.Errorf("field adminPassword: required")
+	}
+	if v, ok := raw["adminUsername"]; !ok || v == nil {
+		return fmt.Errorf("field adminUsername: required")
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname: required")
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name: required")
+	}
+	if v, ok := raw["password"]; !ok || v == nil {
+		return fmt.Errorf("field password: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port: required")
+	}
+	if v, ok := raw["sslMode"]; !ok || v == nil {
+		return fmt.Errorf("field sslMode: required")
+	}
+	if v, ok := raw["username"]; !ok || v == nil {
+		return fmt.Errorf("field username: required")
+	}
+	type Plain DatabaseConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = DatabaseConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *BrokerConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname: required")
+	}
+	type Plain BrokerConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = BrokerConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *KafkaConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["brokers"]; !ok || v == nil {
+		return fmt.Errorf("field brokers: required")
+	}
+	if v, ok := raw["topics"]; !ok || v == nil {
+		return fmt.Errorf("field topics: required")
+	}
+	type Plain KafkaConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = KafkaConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *TopicConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name: required")
+	}
+	if v, ok := raw["requestedName"]; !ok || v == nil {
+		return fmt.Errorf("field requestedName: required")
+	}
+	type Plain TopicConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = TopicConfig(plain)
+	return nil
+}
+
 // SASL Configuration for Kafka
 type KafkaSASLConfig struct {
-	// Password corresponds to the JSON schema field "password".
+	// Broker SASL password
 	Password *string `json:"password,omitempty"`
 
-	// SaslMechanism corresponds to the JSON schema field "saslMechanism".
-	SaslMechanism *string `json:"saslMechanism,omitempty"`
+	// Broker SASL mechanism
+	SaslMechanism *KafkaSASLConfigSaslMechanism `json:"saslMechanism,omitempty"`
 
-	// Deprecated: Use the top level securityProtocol field instead
-	SecurityProtocol *string `json:"securityProtocol,omitempty"`
+	// Broker security protocol. DEPRECATED, use the top level securityProtocol field
+	// instead
+	SecurityProtocol *KafkaSASLConfigSecurityProtocol `json:"securityProtocol,omitempty"`
 
-	// Username corresponds to the JSON schema field "username".
+	// Broker SASL username
 	Username *string `json:"username,omitempty"`
 }
+
+type KafkaSASLConfigSaslMechanism string
+
+const KafkaSASLConfigSaslMechanismSCRAMSHA512 KafkaSASLConfigSaslMechanism = "SCRAM-SHA-512"
+
+type KafkaSASLConfigSecurityProtocol string
+
+const KafkaSASLConfigSecurityProtocolSASLSSL KafkaSASLConfigSecurityProtocol = "SASL_SSL"
+const KafkaSASLConfigSecurityProtocolSSL KafkaSASLConfigSecurityProtocol = "SSL"
 
 // Logging Configuration
 type LoggingConfig struct {
@@ -678,12 +753,22 @@ type TopicConfig struct {
 }
 
 var enumValues_BrokerConfigAuthtype = []interface{}{
-	"mtls",
 	"sasl",
+}
+var enumValues_BrokerConfigSecurityProtocol = []interface{}{
+	"SASL_SSL",
+	"SSL",
 }
 var enumValues_FeatureFlagsConfigScheme = []interface{}{
 	"http",
 	"https",
+}
+var enumValues_KafkaSASLConfigSaslMechanism = []interface{}{
+	"SCRAM-SHA-512",
+}
+var enumValues_KafkaSASLConfigSecurityProtocol = []interface{}{
+	"SASL_SSL",
+	"SSL",
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/controllers/cloud.redhat.com/config/types.go
+++ b/controllers/cloud.redhat.com/config/types.go
@@ -6,6 +6,66 @@ import "fmt"
 import "encoding/json"
 import "reflect"
 
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *TopicConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name: required")
+	}
+	if v, ok := raw["requestedName"]; !ok || v == nil {
+		return fmt.Errorf("field requestedName: required")
+	}
+	type Plain TopicConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = TopicConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *DatabaseConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["adminPassword"]; !ok || v == nil {
+		return fmt.Errorf("field adminPassword: required")
+	}
+	if v, ok := raw["adminUsername"]; !ok || v == nil {
+		return fmt.Errorf("field adminUsername: required")
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname: required")
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name: required")
+	}
+	if v, ok := raw["password"]; !ok || v == nil {
+		return fmt.Errorf("field password: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port: required")
+	}
+	if v, ok := raw["sslMode"]; !ok || v == nil {
+		return fmt.Errorf("field sslMode: required")
+	}
+	if v, ok := raw["username"]; !ok || v == nil {
+		return fmt.Errorf("field username: required")
+	}
+	type Plain DatabaseConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = DatabaseConfig(plain)
+	return nil
+}
+
 // ClowdApp deployment configuration for Clowder enabled apps.
 type AppConfig struct {
 	// Defines the path to the BOPURL.
@@ -64,6 +124,128 @@ type AppConfig struct {
 	WebPort *int `json:"webPort,omitempty"`
 }
 
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *DependencyEndpoint) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["apiPath"]; !ok || v == nil {
+		return fmt.Errorf("field apiPath: required")
+	}
+	if v, ok := raw["app"]; !ok || v == nil {
+		return fmt.Errorf("field app: required")
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname: required")
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port: required")
+	}
+	type Plain DependencyEndpoint
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = DependencyEndpoint(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *PrivateDependencyEndpoint) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["app"]; !ok || v == nil {
+		return fmt.Errorf("field app: required")
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname: required")
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port: required")
+	}
+	type Plain PrivateDependencyEndpoint
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = PrivateDependencyEndpoint(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *ObjectStoreConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port: required")
+	}
+	if v, ok := raw["tls"]; !ok || v == nil {
+		return fmt.Errorf("field tls: required")
+	}
+	type Plain ObjectStoreConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = ObjectStoreConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *FeatureFlagsConfigScheme) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_FeatureFlagsConfigScheme {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_FeatureFlagsConfigScheme, v)
+	}
+	*j = FeatureFlagsConfigScheme(v)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *ObjectStoreBucket) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name: required")
+	}
+	if v, ok := raw["requestedName"]; !ok || v == nil {
+		return fmt.Errorf("field requestedName: required")
+	}
+	type Plain ObjectStoreBucket
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = ObjectStoreBucket(plain)
+	return nil
+}
+
 // Arbitrary metadata pertaining to the application application
 type AppMetadata struct {
 	// Metadata pertaining to an application's deployments
@@ -74,6 +256,156 @@ type AppMetadata struct {
 
 	// Name of the ClowdApp
 	Name *string `json:"name,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *DeploymentMetadata) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["image"]; !ok || v == nil {
+		return fmt.Errorf("field image: required")
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name: required")
+	}
+	type Plain DeploymentMetadata
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = DeploymentMetadata(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *FeatureFlagsConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port: required")
+	}
+	if v, ok := raw["scheme"]; !ok || v == nil {
+		return fmt.Errorf("field scheme: required")
+	}
+	type Plain FeatureFlagsConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = FeatureFlagsConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *LoggingConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["type"]; !ok || v == nil {
+		return fmt.Errorf("field type: required")
+	}
+	type Plain LoggingConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = LoggingConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *InMemoryDBConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port: required")
+	}
+	type Plain InMemoryDBConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = InMemoryDBConfig(plain)
+	return nil
+}
+
+type BrokerConfigAuthtype string
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *CloudWatchConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["accessKeyId"]; !ok || v == nil {
+		return fmt.Errorf("field accessKeyId: required")
+	}
+	if v, ok := raw["logGroup"]; !ok || v == nil {
+		return fmt.Errorf("field logGroup: required")
+	}
+	if v, ok := raw["region"]; !ok || v == nil {
+		return fmt.Errorf("field region: required")
+	}
+	if v, ok := raw["secretAccessKey"]; !ok || v == nil {
+		return fmt.Errorf("field secretAccessKey: required")
+	}
+	type Plain CloudWatchConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = CloudWatchConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *BrokerConfigAuthtype) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_BrokerConfigAuthtype {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_BrokerConfigAuthtype, v)
+	}
+	*j = BrokerConfigAuthtype(v)
+	return nil
+}
+
+const BrokerConfigAuthtypeSasl BrokerConfigAuthtype = "sasl"
+
+// Cloud Watch configuration
+type CloudWatchConfig struct {
+	// Defines the access key that the app should use for configuring CloudWatch.
+	AccessKeyId string `json:"accessKeyId"`
+
+	// Defines the logGroup that the app should use for configuring CloudWatch.
+	LogGroup string `json:"logGroup"`
+
+	// Defines the region that the app should use for configuring CloudWatch.
+	Region string `json:"region"`
+
+	// Defines the secret key that the app should use for configuring CloudWatch.
+	SecretAccessKey string `json:"secretAccessKey"`
 }
 
 // Broker Configuration
@@ -94,32 +426,47 @@ type BrokerConfig struct {
 	// Sasl corresponds to the JSON schema field "sasl".
 	Sasl *KafkaSASLConfig `json:"sasl,omitempty"`
 
-	// Broker security procotol
-	SecurityProtocol *BrokerConfigSecurityProtocol `json:"securityProtocol,omitempty"`
+	// Broker security procotol, expect one of either: SASL_SSL, SSL
+	SecurityProtocol *string `json:"securityProtocol,omitempty"`
 }
 
-type BrokerConfigAuthtype string
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *BrokerConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname: required")
+	}
+	type Plain BrokerConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = BrokerConfig(plain)
+	return nil
+}
 
-const BrokerConfigAuthtypeSasl BrokerConfigAuthtype = "sasl"
-
-type BrokerConfigSecurityProtocol string
-
-const BrokerConfigSecurityProtocolSASLSSL BrokerConfigSecurityProtocol = "SASL_SSL"
-const BrokerConfigSecurityProtocolSSL BrokerConfigSecurityProtocol = "SSL"
-
-// Cloud Watch configuration
-type CloudWatchConfig struct {
-	// Defines the access key that the app should use for configuring CloudWatch.
-	AccessKeyId string `json:"accessKeyId"`
-
-	// Defines the logGroup that the app should use for configuring CloudWatch.
-	LogGroup string `json:"logGroup"`
-
-	// Defines the region that the app should use for configuring CloudWatch.
-	Region string `json:"region"`
-
-	// Defines the secret key that the app should use for configuring CloudWatch.
-	SecretAccessKey string `json:"secretAccessKey"`
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *KafkaConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["brokers"]; !ok || v == nil {
+		return fmt.Errorf("field brokers: required")
+	}
+	if v, ok := raw["topics"]; !ok || v == nil {
+		return fmt.Errorf("field topics: required")
+	}
+	type Plain KafkaConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = KafkaConfig(plain)
+	return nil
 }
 
 // Database Configuration
@@ -234,442 +581,21 @@ type KafkaConfig struct {
 	Topics []TopicConfig `json:"topics"`
 }
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *ObjectStoreBucket) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
-	}
-	if v, ok := raw["requestedName"]; !ok || v == nil {
-		return fmt.Errorf("field requestedName: required")
-	}
-	type Plain ObjectStoreBucket
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = ObjectStoreBucket(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *KafkaSASLConfigSaslMechanism) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_KafkaSASLConfigSaslMechanism {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_KafkaSASLConfigSaslMechanism, v)
-	}
-	*j = KafkaSASLConfigSaslMechanism(v)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *ObjectStoreConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
-	}
-	if v, ok := raw["tls"]; !ok || v == nil {
-		return fmt.Errorf("field tls: required")
-	}
-	type Plain ObjectStoreConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = ObjectStoreConfig(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *BrokerConfigAuthtype) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_BrokerConfigAuthtype {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_BrokerConfigAuthtype, v)
-	}
-	*j = BrokerConfigAuthtype(v)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *DeploymentMetadata) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["image"]; !ok || v == nil {
-		return fmt.Errorf("field image: required")
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
-	}
-	type Plain DeploymentMetadata
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = DeploymentMetadata(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *KafkaSASLConfigSecurityProtocol) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_KafkaSASLConfigSecurityProtocol {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_KafkaSASLConfigSecurityProtocol, v)
-	}
-	*j = KafkaSASLConfigSecurityProtocol(v)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *PrivateDependencyEndpoint) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["app"]; !ok || v == nil {
-		return fmt.Errorf("field app: required")
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
-	}
-	type Plain PrivateDependencyEndpoint
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = PrivateDependencyEndpoint(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *LoggingConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["type"]; !ok || v == nil {
-		return fmt.Errorf("field type: required")
-	}
-	type Plain LoggingConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = LoggingConfig(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *InMemoryDBConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
-	}
-	type Plain InMemoryDBConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = InMemoryDBConfig(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *FeatureFlagsConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
-	}
-	if v, ok := raw["scheme"]; !ok || v == nil {
-		return fmt.Errorf("field scheme: required")
-	}
-	type Plain FeatureFlagsConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = FeatureFlagsConfig(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *CloudWatchConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["accessKeyId"]; !ok || v == nil {
-		return fmt.Errorf("field accessKeyId: required")
-	}
-	if v, ok := raw["logGroup"]; !ok || v == nil {
-		return fmt.Errorf("field logGroup: required")
-	}
-	if v, ok := raw["region"]; !ok || v == nil {
-		return fmt.Errorf("field region: required")
-	}
-	if v, ok := raw["secretAccessKey"]; !ok || v == nil {
-		return fmt.Errorf("field secretAccessKey: required")
-	}
-	type Plain CloudWatchConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = CloudWatchConfig(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *BrokerConfigSecurityProtocol) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_BrokerConfigSecurityProtocol {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_BrokerConfigSecurityProtocol, v)
-	}
-	*j = BrokerConfigSecurityProtocol(v)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *FeatureFlagsConfigScheme) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_FeatureFlagsConfigScheme {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_FeatureFlagsConfigScheme, v)
-	}
-	*j = FeatureFlagsConfigScheme(v)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *DependencyEndpoint) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["apiPath"]; !ok || v == nil {
-		return fmt.Errorf("field apiPath: required")
-	}
-	if v, ok := raw["app"]; !ok || v == nil {
-		return fmt.Errorf("field app: required")
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
-	}
-	type Plain DependencyEndpoint
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = DependencyEndpoint(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *DatabaseConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["adminPassword"]; !ok || v == nil {
-		return fmt.Errorf("field adminPassword: required")
-	}
-	if v, ok := raw["adminUsername"]; !ok || v == nil {
-		return fmt.Errorf("field adminUsername: required")
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
-	}
-	if v, ok := raw["password"]; !ok || v == nil {
-		return fmt.Errorf("field password: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port: required")
-	}
-	if v, ok := raw["sslMode"]; !ok || v == nil {
-		return fmt.Errorf("field sslMode: required")
-	}
-	if v, ok := raw["username"]; !ok || v == nil {
-		return fmt.Errorf("field username: required")
-	}
-	type Plain DatabaseConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = DatabaseConfig(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *BrokerConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname: required")
-	}
-	type Plain BrokerConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = BrokerConfig(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *KafkaConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["brokers"]; !ok || v == nil {
-		return fmt.Errorf("field brokers: required")
-	}
-	if v, ok := raw["topics"]; !ok || v == nil {
-		return fmt.Errorf("field topics: required")
-	}
-	type Plain KafkaConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = KafkaConfig(plain)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *TopicConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name: required")
-	}
-	if v, ok := raw["requestedName"]; !ok || v == nil {
-		return fmt.Errorf("field requestedName: required")
-	}
-	type Plain TopicConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = TopicConfig(plain)
-	return nil
-}
-
 // SASL Configuration for Kafka
 type KafkaSASLConfig struct {
 	// Broker SASL password
 	Password *string `json:"password,omitempty"`
 
-	// Broker SASL mechanism
-	SaslMechanism *KafkaSASLConfigSaslMechanism `json:"saslMechanism,omitempty"`
+	// Broker SASL mechanism, expect: SCRAM-SHA-512
+	SaslMechanism *string `json:"saslMechanism,omitempty"`
 
-	// Broker security protocol. DEPRECATED, use the top level securityProtocol field
-	// instead
-	SecurityProtocol *KafkaSASLConfigSecurityProtocol `json:"securityProtocol,omitempty"`
+	// Broker security protocol, expect one of either: SASL_SSL, SSL. DEPRECATED, use
+	// the top level securityProtocol field instead
+	SecurityProtocol *string `json:"securityProtocol,omitempty"`
 
 	// Broker SASL username
 	Username *string `json:"username,omitempty"`
 }
-
-type KafkaSASLConfigSaslMechanism string
-
-const KafkaSASLConfigSaslMechanismSCRAMSHA512 KafkaSASLConfigSaslMechanism = "SCRAM-SHA-512"
-
-type KafkaSASLConfigSecurityProtocol string
-
-const KafkaSASLConfigSecurityProtocolSASLSSL KafkaSASLConfigSecurityProtocol = "SASL_SSL"
-const KafkaSASLConfigSecurityProtocolSSL KafkaSASLConfigSecurityProtocol = "SSL"
 
 // Logging Configuration
 type LoggingConfig struct {
@@ -755,20 +681,9 @@ type TopicConfig struct {
 var enumValues_BrokerConfigAuthtype = []interface{}{
 	"sasl",
 }
-var enumValues_BrokerConfigSecurityProtocol = []interface{}{
-	"SASL_SSL",
-	"SSL",
-}
 var enumValues_FeatureFlagsConfigScheme = []interface{}{
 	"http",
 	"https",
-}
-var enumValues_KafkaSASLConfigSaslMechanism = []interface{}{
-	"SCRAM-SHA-512",
-}
-var enumValues_KafkaSASLConfigSecurityProtocol = []interface{}{
-	"SASL_SSL",
-	"SSL",
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/docs/antora/modules/providers/pages/kafka.adoc
+++ b/docs/antora/modules/providers/pages/kafka.adoc
@@ -46,25 +46,11 @@ CR. The CR will be placed in the environment specified in the `ClowdEnv`. The
 topic name will be modified as described above, to facilitate using the same
 Kafka instance for multiple apps in differing environments.
 
-ClowdEnv Config options available:
-
-- `clusterName`
-- `namespace`
-- `connectNamespace`
-- `connectClusterName`
-
 === app-interface
 
 In app-interface mode, the Clowder operator does not create any resources and
 simply passes through the topic names from the `ClowdApp` to the client
 config. The topics should be created via the usual app-interface means.
-
-ClowdEnv Config options available:
-
-- `clusterName`
-- `namespace`
-- `connectNamespace`
-- `connectClusterName`
 
 == Generated App Configuration
 
@@ -78,67 +64,92 @@ the `name` attribute of a topic when connecting to Kafka.
 
 A helper is available below to facilitate quick access via a map.
 
-If a the `cacert` and `securityProtocol` fields are populated, then the kafka
-instance will be using TLS and the client should be configured as such
+== Authentication, SSL, and CA Certificates
+
+If the `securityProtocol` field is populated and its value is "SSL" or
+"SASL_SSL", then the client should use SSL to communicate with the broker.
 
 NOTE: The `securityProtocol` field has been deprecated from within the SASL
 stanza and in the future will only be available at the top level broker
 stanza.
 
-=== JSON structure
+If the `cacert` field is populated, clients should use this as the CA trust
+list when connecting to the broker. If it is not populated, then the broker's
+certificate is expected to be signed using a well-trusted certificate
+authority and clients should use the OS default CA trust list.
 
+=== Example JSON structures
+
+Broker is using SSL, a custom CA cert, and username/password auth:
 [source,json]
 ----
 {
   "kafka": {
-      "brokers": [
-          {
-              "hostname": "broker-host",
-              "port": 27015,
-              "securityProtocol": "SSL",
-              "cacert": "<some CA string>"
-          }
-      ],
-      "topics": [
-          {
-              "requestedName": "originalName",
-              "name": "someTopic",
-              "consumerGroupName": "someGroupName"
-          }
-      ]
+    "brokers": [
+      {
+        "authtype": "sasl",
+        "cacert": "<CA certs in PEM format>",
+        "hostname": "hostname.kafka.com",
+        "port": 9096,
+        "sasl": {
+          "password": "pw",
+          "saslMechanism": "SCRAM-SHA-512",
+          "securityProtocol": "SASL_SSL",
+          "username": "username"
+        },
+        "securityProtocol": "SASL_SSL"
+      }
+    ],
+    "topics": [
+      {
+        "requestedName": "originalName",
+        "name": "actualTopicName",
+      }
+    ]
   }
 }
 ----
 
-A User auth enabled Kafka will look like this
+Broker is unsecured (common in ephemeral environments)
 [source,json]
 ----
-{
   "kafka": {
-      "brokers": [
-          {
-              "hostname": "broker-host",
-              "port": 27015,
-              "authtype": "sasl",
-              "cacert": "-----BEGIN CERTIFICATE-----\nMIIDLTCCAhWgAwIBAgIJAPOWU.........",
-              "sasl":{
-                  "username": "kafkausername",
-                  "password": "kafkapassword",
-                  "securityProtocol": "SASL_SSL"
-              }
-          }
-      ],
-      "topics": [
-          {
-              "requestedName": "originalName",
-              "name": "someTopic",
-              "consumerGroupName": "someGroupName"
-          }
-      ]
+    "brokers": [
+      {
+        "hostname": "hostname.kafka.com",
+        "port": 9092
+      }
+    ],
+    "topics": [
+      {
+        "requestedName": "originalName",
+        "name": "actualTopicName",
+      }
+    ]
   }
 }
 ----
 
+Broker is using SSL but not SASL, and is signed by a commonly trusted CA (cacert not provided by Clowder)
+[source,json]
+----
+  "kafka": {
+    "brokers": [
+      {
+        "hostname": "hostname.kafka.com",
+        "port": 9093,
+        "securityProtocol": "SSL"
+      }
+    ],
+    "topics": [
+      {
+        "requestedName": "originalName",
+        "name": "actualTopicName",
+      }
+    ]
+  }
+}
+----
 
 === Client access
 
@@ -202,21 +213,19 @@ more information can be found in the API reference.
 :cyndi-operator: https://github.com/RedHatInsights/cyndi-operator#cyndi-operator
 :clowder-api-cyndi: https://redhatinsights.github.io/clowder/clowder/dev/api_reference.html#k8s-api-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-cyndispec
 
-The *Cyndi* attribute of a ClowdApp definition is responsible for ensuring the Cyndi host
-syndication process is in place for the ClowdApp. On Clowder managed environments, the
-provider is also responsible of creating the CyndiPipeline resource, and configuring the underlying
-`Kafka Connect` so that the data syndication from Host Inventory database to the app's database
-works correctly.
-
 {kafka-connect}[Kafka Connect] is the core component used to perform Inventory’s host database
-syndication for some of the Insights platform applications, and uses an Operator to orchestrate
-the synchronization process.
-
-It does so by using a `CyndiPipeline` resource, which can be created by Clowder, and by injecting
-in the database secrets for both the target db (the application’s) and the host inventory db.
+syndication for some of the Insights platform applications, with the Cyndi operator managing the
+creation of KafkaConnector resources which facilitate the synchronization process via a `CyndiPipeline`
+resource.
 
 {kafka-connect}[Kafka Connect] streams table updates to keep data syndicated between the host
-inventory db and the application’s hosts view.
+inventory DB and the application database's "hosts" view.
+
+The *cyndi* attribute of a ClowdApp definition causes Clowder to ensure that a `CyndiPipeline` is in
+place for the ClowdApp. In ephemeral environments, Clowder will create the CyndiPipeline resource,
+itself, while in static environments like stage/prod, the CyndiPipeline is expected to already be
+present in the cluster. The ClowdEnvironment configuration controls Clowder's behavior in these
+different environments.
 
 Please refer to the corresponing projects for more information about the
 {project-cyndi}[Cyndi project], the `CyndiPipeline` resource or the {cyndi-operator}[Cyndi Operator]
@@ -224,8 +233,8 @@ itself.
 
 === ClowdApp Configuration
 
-In order to request a `ClowdApp` to get the host syndication enabled by Cyndi, the `Cyndi` stanza
-needs to be used. A snippet of how that config would look like follows.
+In order to request a `ClowdApp` to get the host syndication enabled by Cyndi, the `cyndi` stanza
+needs to be used. A snippet of how that config would look like follows:
 
 [source,yaml]
 ----
@@ -243,19 +252,3 @@ The attributes are described in Clowder’s API Spec documentation {clowder-api-
 * *enabled* `[bool] default: true` - enables or disables the Cyndi dependency for this particular ClowdApp resource.
 * *appName* `[str] default: ''` - a string that sets the unique identifier of this ClowdApp on Cyndi.
 * *insightsOnly* `[bool] default: false` - enables the data syndication for all hosts or Insights hosts only.
-
-=== ClowdEnv Configuration
-
-The *Cyndi* provider will run in one of the two following modes, depending on whether if Clowder
-manages the environment or not;
-
-On non-Clowder managed environments (at the time of this writing, Stage and Production) Clowder
-will only check that the CyndiPipeline resource is available for the Clowdapp that is being
-reconciled in case it has the “cyndi” flag enabled in it’s template definition.
-Clowder will not try to create or update any resource related to Cyndi on environments it does not
-manage.
-
-On Clowder managed environments (Ephemeral environment) Clowder will configure and deploy Kafka
-using the Strimzi operator and will setup the CyndiPipeline to enable the host syndication process
-for the Clowdapps that require it on their spec files (see {clowder-api-cyndi}[Clowder API reference])
-

--- a/docs/appconfig/README.md
+++ b/docs/appconfig/README.md
@@ -54,11 +54,13 @@
 -   [Untitled array in AppConfig](./schema-definitions-kafkaconfig-properties-topics.md "Defines a list of the topic configurations available to the application") – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/KafkaConfig/properties/topics`
 -   [Untitled array in AppConfig](./schema-definitions-objectstoreconfig-properties-buckets.md) – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreConfig/properties/buckets`
 -   [Untitled array in AppConfig](./schema-definitions-appconfig-properties-endpoints.md) – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/AppConfig/properties/endpoints`
+-   [Untitled array in AppConfig](./schema-definitions-dependencyendpoint-properties-apipaths.md "The list of API paths (each matching format: '/api/some-path/') that this app will serve requests from") – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPaths`
 -   [Untitled array in AppConfig](./schema-definitions-appconfig-properties-privateendpoints.md) – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/AppConfig/properties/privateEndpoints`
 -   [Untitled array in AppConfig](./schema-definitions-appmetadata-properties-deployments.md "Metadata pertaining to an application's deployments") – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/AppMetadata/properties/deployments`
 -   [Untitled array in AppConfig](./schema-definitions-kafkaconfig-properties-brokers.md "Defines the brokers the app should connect to for Kafka services") – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/KafkaConfig/properties/brokers`
 -   [Untitled array in AppConfig](./schema-definitions-kafkaconfig-properties-topics.md "Defines a list of the topic configurations available to the application") – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/KafkaConfig/properties/topics`
 -   [Untitled array in AppConfig](./schema-definitions-objectstoreconfig-properties-buckets.md) – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreConfig/properties/buckets`
+-   [Untitled array in AppConfig](./schema-definitions-dependencyendpoint-properties-apipaths.md "The list of API paths (each matching format: '/api/some-path/') that this app will serve requests from") – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPaths`
 
 ## Version Note
 

--- a/docs/appconfig/schema-definitions-brokerconfig-properties-authtype.md
+++ b/docs/appconfig/schema-definitions-brokerconfig-properties-authtype.md
@@ -21,5 +21,4 @@ https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/BrokerConfig/pro
 
 | Value    | Explanation |
 | :------- | ----------- |
-| `"mtls"` |             |
 | `"sasl"` |             |

--- a/docs/appconfig/schema-definitions-brokerconfig-properties-cacert.md
+++ b/docs/appconfig/schema-definitions-brokerconfig-properties-cacert.md
@@ -4,7 +4,7 @@
 https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/BrokerConfig/properties/cacert
 ```
 
-
+CA certificate trust list for broker in PEM format. If absent, client should use OS default trust list
 
 
 | Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                    |

--- a/docs/appconfig/schema-definitions-brokerconfig-properties-hostname.md
+++ b/docs/appconfig/schema-definitions-brokerconfig-properties-hostname.md
@@ -4,7 +4,7 @@
 https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/BrokerConfig/properties/hostname
 ```
 
-
+Hostname of kafka broker
 
 
 | Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                    |

--- a/docs/appconfig/schema-definitions-brokerconfig-properties-port.md
+++ b/docs/appconfig/schema-definitions-brokerconfig-properties-port.md
@@ -4,7 +4,7 @@
 https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/BrokerConfig/properties/port
 ```
 
-
+Port of kafka broker
 
 
 | Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                    |

--- a/docs/appconfig/schema-definitions-brokerconfig-properties-securityprotocol.md
+++ b/docs/appconfig/schema-definitions-brokerconfig-properties-securityprotocol.md
@@ -4,7 +4,7 @@
 https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/BrokerConfig/properties/securityProtocol
 ```
 
-Broker security procotol
+Broker security procotol, expect one of either: SASL_SSL, SSL
 
 
 | Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                    |
@@ -14,12 +14,3 @@ Broker security procotol
 ## securityProtocol Type
 
 `string`
-
-## securityProtocol Constraints
-
-**enum**: the value of this property must be equal to one of the following values:
-
-| Value        | Explanation |
-| :----------- | ----------- |
-| `"SASL_SSL"` |             |
-| `"SSL"`      |             |

--- a/docs/appconfig/schema-definitions-brokerconfig-properties-securityprotocol.md
+++ b/docs/appconfig/schema-definitions-brokerconfig-properties-securityprotocol.md
@@ -4,7 +4,7 @@
 https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/BrokerConfig/properties/securityProtocol
 ```
 
-
+Broker security procotol
 
 
 | Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                    |
@@ -14,3 +14,12 @@ https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/BrokerConfig/pro
 ## securityProtocol Type
 
 `string`
+
+## securityProtocol Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value        | Explanation |
+| :----------- | ----------- |
+| `"SASL_SSL"` |             |
+| `"SSL"`      |             |

--- a/docs/appconfig/schema-definitions-brokerconfig.md
+++ b/docs/appconfig/schema-definitions-brokerconfig.md
@@ -116,7 +116,7 @@ SASL Configuration for Kafka
 
 ## securityProtocol
 
-Broker security procotol
+Broker security procotol, expect one of either: SASL_SSL, SSL
 
 
 `securityProtocol`
@@ -129,12 +129,3 @@ Broker security procotol
 ### securityProtocol Type
 
 `string`
-
-### securityProtocol Constraints
-
-**enum**: the value of this property must be equal to one of the following values:
-
-| Value        | Explanation |
-| :----------- | ----------- |
-| `"SASL_SSL"` |             |
-| `"SSL"`      |             |

--- a/docs/appconfig/schema-definitions-brokerconfig.md
+++ b/docs/appconfig/schema-definitions-brokerconfig.md
@@ -28,7 +28,7 @@ Broker Configuration
 
 ## hostname
 
-
+Hostname of kafka broker
 
 
 `hostname`
@@ -44,7 +44,7 @@ Broker Configuration
 
 ## port
 
-
+Port of kafka broker
 
 
 `port`
@@ -60,7 +60,7 @@ Broker Configuration
 
 ## cacert
 
-
+CA certificate trust list for broker in PEM format. If absent, client should use OS default trust list
 
 
 `cacert`
@@ -96,7 +96,6 @@ Broker Configuration
 
 | Value    | Explanation |
 | :------- | ----------- |
-| `"mtls"` |             |
 | `"sasl"` |             |
 
 ## sasl
@@ -117,7 +116,7 @@ SASL Configuration for Kafka
 
 ## securityProtocol
 
-
+Broker security procotol
 
 
 `securityProtocol`
@@ -130,3 +129,12 @@ SASL Configuration for Kafka
 ### securityProtocol Type
 
 `string`
+
+### securityProtocol Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value        | Explanation |
+| :----------- | ----------- |
+| `"SASL_SSL"` |             |
+| `"SSL"`      |             |

--- a/docs/appconfig/schema-definitions-dependencyendpoint-properties-apipath.md
+++ b/docs/appconfig/schema-definitions-dependencyendpoint-properties-apipath.md
@@ -1,10 +1,10 @@
-# Untitled undefined type in AppConfig Schema
+# Untitled string in AppConfig Schema
 
 ```txt
 https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPath
 ```
 
-The top level api path that the app should serve from /api/<apiPath>
+The top level api path that the app should serve from /api/<apiPath> (deprecated, use apiPaths)
 
 
 | Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                    |
@@ -13,4 +13,4 @@ The top level api path that the app should serve from /api/<apiPath>
 
 ## apiPath Type
 
-unknown
+`string`

--- a/docs/appconfig/schema-definitions-dependencyendpoint.md
+++ b/docs/appconfig/schema-definitions-dependencyendpoint.md
@@ -17,14 +17,15 @@ Dependent service connection info
 
 # undefined Properties
 
-| Property              | Type          | Required | Nullable       | Defined by                                                                                                                                                                              |
-| :-------------------- | ------------- | -------- | -------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [name](#name)         | `string`      | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-name.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/name")         |
-| [hostname](#hostname) | `string`      | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-hostname.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/hostname") |
-| [port](#port)         | `integer`     | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-port.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/port")         |
-| [app](#app)           | `string`      | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-app.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/app")           |
-| [tlsPort](#tlsport)   | `integer`     | Optional | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-tlsport.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/tlsPort")   |
-| [apiPath](#apipath)   | Not specified | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-apipath.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPath")   |
+| Property              | Type      | Required | Nullable       | Defined by                                                                                                                                                                              |
+| :-------------------- | --------- | -------- | -------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [name](#name)         | `string`  | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-name.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/name")         |
+| [hostname](#hostname) | `string`  | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-hostname.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/hostname") |
+| [port](#port)         | `integer` | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-port.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/port")         |
+| [app](#app)           | `string`  | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-app.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/app")           |
+| [tlsPort](#tlsport)   | `integer` | Optional | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-tlsport.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/tlsPort")   |
+| [apiPath](#apipath)   | `string`  | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-apipath.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPath")   |
+| [apiPaths](#apipaths) | `array`   | Optional | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-apipaths.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPaths") |
 
 ## name
 
@@ -108,16 +109,32 @@ The TLS port of the dependent service.
 
 ## apiPath
 
-The top level api path that the app should serve from /api/<apiPath>
+The top level api path that the app should serve from /api/<apiPath> (deprecated, use apiPaths)
 
 
 `apiPath`
 
 -   is required
--   Type: unknown
+-   Type: `string`
 -   cannot be null
 -   defined in: [AppConfig](schema-definitions-dependencyendpoint-properties-apipath.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPath")
 
 ### apiPath Type
 
-unknown
+`string`
+
+## apiPaths
+
+The list of API paths (each matching format: '/api/some-path/') that this app will serve requests from
+
+
+`apiPaths`
+
+-   is optional
+-   Type: `string[]`
+-   cannot be null
+-   defined in: [AppConfig](schema-definitions-dependencyendpoint-properties-apipaths.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPaths")
+
+### apiPaths Type
+
+`string[]`

--- a/docs/appconfig/schema-definitions-kafkasaslconfig-properties-password.md
+++ b/docs/appconfig/schema-definitions-kafkasaslconfig-properties-password.md
@@ -4,7 +4,7 @@
 https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/KafkaSASLConfig/properties/password
 ```
 
-
+Broker SASL password
 
 
 | Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                    |

--- a/docs/appconfig/schema-definitions-kafkasaslconfig-properties-saslmechanism.md
+++ b/docs/appconfig/schema-definitions-kafkasaslconfig-properties-saslmechanism.md
@@ -4,7 +4,7 @@
 https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/KafkaSASLConfig/properties/saslMechanism
 ```
 
-
+Broker SASL mechanism
 
 
 | Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                    |
@@ -14,3 +14,11 @@ https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/KafkaSASLConfig/
 ## saslMechanism Type
 
 `string`
+
+## saslMechanism Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value             | Explanation |
+| :---------------- | ----------- |
+| `"SCRAM-SHA-512"` |             |

--- a/docs/appconfig/schema-definitions-kafkasaslconfig-properties-saslmechanism.md
+++ b/docs/appconfig/schema-definitions-kafkasaslconfig-properties-saslmechanism.md
@@ -4,7 +4,7 @@
 https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/KafkaSASLConfig/properties/saslMechanism
 ```
 
-Broker SASL mechanism
+Broker SASL mechanism, expect: SCRAM-SHA-512
 
 
 | Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                    |
@@ -14,11 +14,3 @@ Broker SASL mechanism
 ## saslMechanism Type
 
 `string`
-
-## saslMechanism Constraints
-
-**enum**: the value of this property must be equal to one of the following values:
-
-| Value             | Explanation |
-| :---------------- | ----------- |
-| `"SCRAM-SHA-512"` |             |

--- a/docs/appconfig/schema-definitions-kafkasaslconfig-properties-securityprotocol.md
+++ b/docs/appconfig/schema-definitions-kafkasaslconfig-properties-securityprotocol.md
@@ -4,7 +4,7 @@
 https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/KafkaSASLConfig/properties/securityProtocol
 ```
 
-Broker security protocol. DEPRECATED, use the top level securityProtocol field instead
+Broker security protocol, expect one of either: SASL_SSL, SSL. DEPRECATED, use the top level securityProtocol field instead
 
 
 | Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                    |
@@ -14,12 +14,3 @@ Broker security protocol. DEPRECATED, use the top level securityProtocol field i
 ## securityProtocol Type
 
 `string`
-
-## securityProtocol Constraints
-
-**enum**: the value of this property must be equal to one of the following values:
-
-| Value        | Explanation |
-| :----------- | ----------- |
-| `"SASL_SSL"` |             |
-| `"SSL"`      |             |

--- a/docs/appconfig/schema-definitions-kafkasaslconfig-properties-securityprotocol.md
+++ b/docs/appconfig/schema-definitions-kafkasaslconfig-properties-securityprotocol.md
@@ -4,7 +4,7 @@
 https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/KafkaSASLConfig/properties/securityProtocol
 ```
 
-Deprecated: Use the top level securityProtocol field instead
+Broker security protocol. DEPRECATED, use the top level securityProtocol field instead
 
 
 | Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                    |
@@ -14,3 +14,12 @@ Deprecated: Use the top level securityProtocol field instead
 ## securityProtocol Type
 
 `string`
+
+## securityProtocol Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value        | Explanation |
+| :----------- | ----------- |
+| `"SASL_SSL"` |             |
+| `"SSL"`      |             |

--- a/docs/appconfig/schema-definitions-kafkasaslconfig-properties-username.md
+++ b/docs/appconfig/schema-definitions-kafkasaslconfig-properties-username.md
@@ -4,7 +4,7 @@
 https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/KafkaSASLConfig/properties/username
 ```
 
-
+Broker SASL username
 
 
 | Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                    |

--- a/docs/appconfig/schema-definitions-kafkasaslconfig.md
+++ b/docs/appconfig/schema-definitions-kafkasaslconfig.md
@@ -26,7 +26,7 @@ SASL Configuration for Kafka
 
 ## username
 
-
+Broker SASL username
 
 
 `username`
@@ -42,7 +42,7 @@ SASL Configuration for Kafka
 
 ## password
 
-
+Broker SASL password
 
 
 `password`
@@ -58,7 +58,7 @@ SASL Configuration for Kafka
 
 ## securityProtocol
 
-Deprecated: Use the top level securityProtocol field instead
+Broker security protocol. DEPRECATED, use the top level securityProtocol field instead
 
 
 `securityProtocol`
@@ -72,9 +72,18 @@ Deprecated: Use the top level securityProtocol field instead
 
 `string`
 
+### securityProtocol Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value        | Explanation |
+| :----------- | ----------- |
+| `"SASL_SSL"` |             |
+| `"SSL"`      |             |
+
 ## saslMechanism
 
-
+Broker SASL mechanism
 
 
 `saslMechanism`
@@ -87,3 +96,11 @@ Deprecated: Use the top level securityProtocol field instead
 ### saslMechanism Type
 
 `string`
+
+### saslMechanism Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value             | Explanation |
+| :---------------- | ----------- |
+| `"SCRAM-SHA-512"` |             |

--- a/docs/appconfig/schema-definitions-kafkasaslconfig.md
+++ b/docs/appconfig/schema-definitions-kafkasaslconfig.md
@@ -58,7 +58,7 @@ Broker SASL password
 
 ## securityProtocol
 
-Broker security protocol. DEPRECATED, use the top level securityProtocol field instead
+Broker security protocol, expect one of either: SASL_SSL, SSL. DEPRECATED, use the top level securityProtocol field instead
 
 
 `securityProtocol`
@@ -72,18 +72,9 @@ Broker security protocol. DEPRECATED, use the top level securityProtocol field i
 
 `string`
 
-### securityProtocol Constraints
-
-**enum**: the value of this property must be equal to one of the following values:
-
-| Value        | Explanation |
-| :----------- | ----------- |
-| `"SASL_SSL"` |             |
-| `"SSL"`      |             |
-
 ## saslMechanism
 
-Broker SASL mechanism
+Broker SASL mechanism, expect: SCRAM-SHA-512
 
 
 `saslMechanism`
@@ -96,11 +87,3 @@ Broker SASL mechanism
 ### saslMechanism Type
 
 `string`
-
-### saslMechanism Constraints
-
-**enum**: the value of this property must be equal to one of the following values:
-
-| Value             | Explanation |
-| :---------------- | ----------- |
-| `"SCRAM-SHA-512"` |             |

--- a/docs/appconfig/schema.md
+++ b/docs/appconfig/schema.md
@@ -642,7 +642,7 @@ Broker SASL password
 
 ### securityProtocol
 
-Broker security protocol. DEPRECATED, use the top level securityProtocol field instead
+Broker security protocol, expect one of either: SASL_SSL, SSL. DEPRECATED, use the top level securityProtocol field instead
 
 
 `securityProtocol`
@@ -656,18 +656,9 @@ Broker security protocol. DEPRECATED, use the top level securityProtocol field i
 
 `string`
 
-#### securityProtocol Constraints
-
-**enum**: the value of this property must be equal to one of the following values:
-
-| Value        | Explanation |
-| :----------- | ----------- |
-| `"SASL_SSL"` |             |
-| `"SSL"`      |             |
-
 ### saslMechanism
 
-Broker SASL mechanism
+Broker SASL mechanism, expect: SCRAM-SHA-512
 
 
 `saslMechanism`
@@ -680,14 +671,6 @@ Broker SASL mechanism
 #### saslMechanism Type
 
 `string`
-
-#### saslMechanism Constraints
-
-**enum**: the value of this property must be equal to one of the following values:
-
-| Value             | Explanation |
-| :---------------- | ----------- |
-| `"SCRAM-SHA-512"` |             |
 
 ## Definitions group BrokerConfig
 
@@ -796,7 +779,7 @@ SASL Configuration for Kafka
 
 ### securityProtocol
 
-Broker security procotol
+Broker security procotol, expect one of either: SASL_SSL, SSL
 
 
 `securityProtocol`
@@ -809,15 +792,6 @@ Broker security procotol
 #### securityProtocol Type
 
 `string`
-
-#### securityProtocol Constraints
-
-**enum**: the value of this property must be equal to one of the following values:
-
-| Value        | Explanation |
-| :----------- | ----------- |
-| `"SASL_SSL"` |             |
-| `"SSL"`      |             |
 
 ## Definitions group TopicConfig
 

--- a/docs/appconfig/schema.md
+++ b/docs/appconfig/schema.md
@@ -610,7 +610,7 @@ Reference this group by using
 
 ### username
 
-
+Broker SASL username
 
 
 `username`
@@ -626,7 +626,7 @@ Reference this group by using
 
 ### password
 
-
+Broker SASL password
 
 
 `password`
@@ -642,7 +642,7 @@ Reference this group by using
 
 ### securityProtocol
 
-Deprecated: Use the top level securityProtocol field instead
+Broker security protocol. DEPRECATED, use the top level securityProtocol field instead
 
 
 `securityProtocol`
@@ -656,9 +656,18 @@ Deprecated: Use the top level securityProtocol field instead
 
 `string`
 
+#### securityProtocol Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value        | Explanation |
+| :----------- | ----------- |
+| `"SASL_SSL"` |             |
+| `"SSL"`      |             |
+
 ### saslMechanism
 
-
+Broker SASL mechanism
 
 
 `saslMechanism`
@@ -671,6 +680,14 @@ Deprecated: Use the top level securityProtocol field instead
 #### saslMechanism Type
 
 `string`
+
+#### saslMechanism Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value             | Explanation |
+| :---------------- | ----------- |
+| `"SCRAM-SHA-512"` |             |
 
 ## Definitions group BrokerConfig
 
@@ -691,7 +708,7 @@ Reference this group by using
 
 ### hostname
 
-
+Hostname of kafka broker
 
 
 `hostname`
@@ -707,7 +724,7 @@ Reference this group by using
 
 ### port
 
-
+Port of kafka broker
 
 
 `port`
@@ -723,7 +740,7 @@ Reference this group by using
 
 ### cacert
 
-
+CA certificate trust list for broker in PEM format. If absent, client should use OS default trust list
 
 
 `cacert`
@@ -759,7 +776,6 @@ Reference this group by using
 
 | Value    | Explanation |
 | :------- | ----------- |
-| `"mtls"` |             |
 | `"sasl"` |             |
 
 ### sasl
@@ -780,7 +796,7 @@ SASL Configuration for Kafka
 
 ### securityProtocol
 
-
+Broker security procotol
 
 
 `securityProtocol`
@@ -793,6 +809,15 @@ SASL Configuration for Kafka
 #### securityProtocol Type
 
 `string`
+
+#### securityProtocol Constraints
+
+**enum**: the value of this property must be equal to one of the following values:
+
+| Value        | Explanation |
+| :----------- | ----------- |
+| `"SASL_SSL"` |             |
+| `"SSL"`      |             |
 
 ## Definitions group TopicConfig
 
@@ -1438,14 +1463,15 @@ Reference this group by using
 {"$ref":"https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint"}
 ```
 
-| Property                | Type          | Required | Nullable       | Defined by                                                                                                                                                                              |
-| :---------------------- | ------------- | -------- | -------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [name](#name-5)         | `string`      | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-name.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/name")         |
-| [hostname](#hostname-5) | `string`      | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-hostname.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/hostname") |
-| [port](#port-5)         | `integer`     | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-port.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/port")         |
-| [app](#app)             | `string`      | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-app.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/app")           |
-| [tlsPort](#tlsport)     | `integer`     | Optional | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-tlsport.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/tlsPort")   |
-| [apiPath](#apipath)     | Not specified | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-apipath.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPath")   |
+| Property                | Type      | Required | Nullable       | Defined by                                                                                                                                                                              |
+| :---------------------- | --------- | -------- | -------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [name](#name-5)         | `string`  | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-name.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/name")         |
+| [hostname](#hostname-5) | `string`  | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-hostname.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/hostname") |
+| [port](#port-5)         | `integer` | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-port.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/port")         |
+| [app](#app)             | `string`  | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-app.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/app")           |
+| [tlsPort](#tlsport)     | `integer` | Optional | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-tlsport.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/tlsPort")   |
+| [apiPath](#apipath)     | `string`  | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-apipath.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPath")   |
+| [apiPaths](#apipaths)   | `array`   | Optional | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-apipaths.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPaths") |
 
 ### name
 
@@ -1529,19 +1555,35 @@ The TLS port of the dependent service.
 
 ### apiPath
 
-The top level api path that the app should serve from /api/<apiPath>
+The top level api path that the app should serve from /api/<apiPath> (deprecated, use apiPaths)
 
 
 `apiPath`
 
 -   is required
--   Type: unknown
+-   Type: `string`
 -   cannot be null
 -   defined in: [AppConfig](schema-definitions-dependencyendpoint-properties-apipath.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPath")
 
 #### apiPath Type
 
-unknown
+`string`
+
+### apiPaths
+
+The list of API paths (each matching format: '/api/some-path/') that this app will serve requests from
+
+
+`apiPaths`
+
+-   is optional
+-   Type: `string[]`
+-   cannot be null
+-   defined in: [AppConfig](schema-definitions-dependencyendpoint-properties-apipaths.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPaths")
+
+#### apiPaths Type
+
+`string[]`
 
 ## Definitions group PrivateDependencyEndpoint
 


### PR DESCRIPTION
The kafka docs are a bit out of date, especially since ADR-20. Some people were confused on what values they can expect to see in the cdappconfig, so the new examples here hopefully clear it up. Also I updated the schema to provide better descriptions. Tried to use enums but that ended up resulting in the code generator creating new types for the fields instead of sticking with `*string` ... I want to avoid code breakage so just updating the `description` to indicate what values people can expect the fields to be set to by Clowder.