### PR TITLE
Re-generate API docs for new config schema

### DIFF
--- a/docs/appconfig/README.md
+++ b/docs/appconfig/README.md
@@ -54,11 +54,13 @@
 -   [Untitled array in AppConfig](./schema-definitions-kafkaconfig-properties-topics.md "Defines a list of the topic configurations available to the application") – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/KafkaConfig/properties/topics`
 -   [Untitled array in AppConfig](./schema-definitions-objectstoreconfig-properties-buckets.md) – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreConfig/properties/buckets`
 -   [Untitled array in AppConfig](./schema-definitions-appconfig-properties-endpoints.md) – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/AppConfig/properties/endpoints`
+-   [Untitled array in AppConfig](./schema-definitions-dependencyendpoint-properties-apipaths.md "The list of API paths (each matching format: '/api/some-path/') that this app will serve requests from") – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPaths`
 -   [Untitled array in AppConfig](./schema-definitions-appconfig-properties-privateendpoints.md) – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/AppConfig/properties/privateEndpoints`
 -   [Untitled array in AppConfig](./schema-definitions-appmetadata-properties-deployments.md "Metadata pertaining to an application's deployments") – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/AppMetadata/properties/deployments`
 -   [Untitled array in AppConfig](./schema-definitions-kafkaconfig-properties-brokers.md "Defines the brokers the app should connect to for Kafka services") – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/KafkaConfig/properties/brokers`
 -   [Untitled array in AppConfig](./schema-definitions-kafkaconfig-properties-topics.md "Defines a list of the topic configurations available to the application") – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/KafkaConfig/properties/topics`
 -   [Untitled array in AppConfig](./schema-definitions-objectstoreconfig-properties-buckets.md) – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/ObjectStoreConfig/properties/buckets`
+-   [Untitled array in AppConfig](./schema-definitions-dependencyendpoint-properties-apipaths.md "The list of API paths (each matching format: '/api/some-path/') that this app will serve requests from") – `https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPaths`
 
 ## Version Note
 

--- a/docs/appconfig/schema-definitions-dependencyendpoint-properties-apipath.md
+++ b/docs/appconfig/schema-definitions-dependencyendpoint-properties-apipath.md
@@ -1,10 +1,10 @@
-# Untitled undefined type in AppConfig Schema
+# Untitled string in AppConfig Schema
 
 ```txt
 https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPath
 ```
 
-The top level api path that the app should serve from /api/<apiPath>
+The top level api path that the app should serve from /api/<apiPath> (deprecated, use apiPaths)
 
 
 | Abstract            | Extensible | Status         | Identifiable            | Custom Properties | Additional Properties | Access Restrictions | Defined In                                                    |
@@ -13,4 +13,4 @@ The top level api path that the app should serve from /api/<apiPath>
 
 ## apiPath Type
 
-unknown
+`string`

--- a/docs/appconfig/schema-definitions-dependencyendpoint.md
+++ b/docs/appconfig/schema-definitions-dependencyendpoint.md
@@ -17,14 +17,15 @@ Dependent service connection info
 
 # undefined Properties
 
-| Property              | Type          | Required | Nullable       | Defined by                                                                                                                                                                              |
-| :-------------------- | ------------- | -------- | -------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [name](#name)         | `string`      | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-name.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/name")         |
-| [hostname](#hostname) | `string`      | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-hostname.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/hostname") |
-| [port](#port)         | `integer`     | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-port.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/port")         |
-| [app](#app)           | `string`      | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-app.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/app")           |
-| [tlsPort](#tlsport)   | `integer`     | Optional | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-tlsport.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/tlsPort")   |
-| [apiPath](#apipath)   | Not specified | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-apipath.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPath")   |
+| Property              | Type      | Required | Nullable       | Defined by                                                                                                                                                                              |
+| :-------------------- | --------- | -------- | -------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [name](#name)         | `string`  | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-name.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/name")         |
+| [hostname](#hostname) | `string`  | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-hostname.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/hostname") |
+| [port](#port)         | `integer` | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-port.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/port")         |
+| [app](#app)           | `string`  | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-app.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/app")           |
+| [tlsPort](#tlsport)   | `integer` | Optional | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-tlsport.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/tlsPort")   |
+| [apiPath](#apipath)   | `string`  | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-apipath.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPath")   |
+| [apiPaths](#apipaths) | `array`   | Optional | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-apipaths.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPaths") |
 
 ## name
 
@@ -108,16 +109,32 @@ The TLS port of the dependent service.
 
 ## apiPath
 
-The top level api path that the app should serve from /api/<apiPath>
+The top level api path that the app should serve from /api/<apiPath> (deprecated, use apiPaths)
 
 
 `apiPath`
 
 -   is required
--   Type: unknown
+-   Type: `string`
 -   cannot be null
 -   defined in: [AppConfig](schema-definitions-dependencyendpoint-properties-apipath.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPath")
 
 ### apiPath Type
 
-unknown
+`string`
+
+## apiPaths
+
+The list of API paths (each matching format: '/api/some-path/') that this app will serve requests from
+
+
+`apiPaths`
+
+-   is optional
+-   Type: `string[]`
+-   cannot be null
+-   defined in: [AppConfig](schema-definitions-dependencyendpoint-properties-apipaths.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPaths")
+
+### apiPaths Type
+
+`string[]`

--- a/docs/appconfig/schema.md
+++ b/docs/appconfig/schema.md
@@ -1438,14 +1438,15 @@ Reference this group by using
 {"$ref":"https://cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint"}
 ```
 
-| Property                | Type          | Required | Nullable       | Defined by                                                                                                                                                                              |
-| :---------------------- | ------------- | -------- | -------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [name](#name-5)         | `string`      | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-name.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/name")         |
-| [hostname](#hostname-5) | `string`      | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-hostname.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/hostname") |
-| [port](#port-5)         | `integer`     | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-port.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/port")         |
-| [app](#app)             | `string`      | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-app.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/app")           |
-| [tlsPort](#tlsport)     | `integer`     | Optional | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-tlsport.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/tlsPort")   |
-| [apiPath](#apipath)     | Not specified | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-apipath.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPath")   |
+| Property                | Type      | Required | Nullable       | Defined by                                                                                                                                                                              |
+| :---------------------- | --------- | -------- | -------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [name](#name-5)         | `string`  | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-name.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/name")         |
+| [hostname](#hostname-5) | `string`  | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-hostname.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/hostname") |
+| [port](#port-5)         | `integer` | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-port.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/port")         |
+| [app](#app)             | `string`  | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-app.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/app")           |
+| [tlsPort](#tlsport)     | `integer` | Optional | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-tlsport.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/tlsPort")   |
+| [apiPath](#apipath)     | `string`  | Required | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-apipath.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPath")   |
+| [apiPaths](#apipaths)   | `array`   | Optional | cannot be null | [AppConfig](schema-definitions-dependencyendpoint-properties-apipaths.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPaths") |
 
 ### name
 
@@ -1529,19 +1530,35 @@ The TLS port of the dependent service.
 
 ### apiPath
 
-The top level api path that the app should serve from /api/<apiPath>
+The top level api path that the app should serve from /api/<apiPath> (deprecated, use apiPaths)
 
 
 `apiPath`
 
 -   is required
--   Type: unknown
+-   Type: `string`
 -   cannot be null
 -   defined in: [AppConfig](schema-definitions-dependencyendpoint-properties-apipath.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPath")
 
 #### apiPath Type
 
-unknown
+`string`
+
+### apiPaths
+
+The list of API paths (each matching format: '/api/some-path/') that this app will serve requests from
+
+
+`apiPaths`
+
+-   is optional
+-   Type: `string[]`
+-   cannot be null
+-   defined in: [AppConfig](schema-definitions-dependencyendpoint-properties-apipaths.md "https&#x3A;//cloud.redhat.com/schemas/clowder-appconfig#/definitions/DependencyEndpoint/properties/apiPaths")
+
+#### apiPaths Type
+
+`string[]`
 
 ## Definitions group PrivateDependencyEndpoint
 


### PR DESCRIPTION
I should have run `make api-docs` on #882