### PR TITLE
Do not override env vars with empty values on IQE CJI

### DIFF
--- a/controllers/cloud.redhat.com/providers/iqe/impl.go
+++ b/controllers/cloud.redhat.com/providers/iqe/impl.go
@@ -39,6 +39,10 @@ func joinNullableSlice(s *[]string) string {
 
 func updateEnvVars(existingEnvVars []core.EnvVar, newEnvVars []core.EnvVar) []core.EnvVar {
 	for _, newEnvVar := range newEnvVars {
+		if newEnvVar.Value == "" {
+			// do not update value of an env var if the new value is empty
+			continue
+		}
 		replaced := false
 		for idx, existingEnvVar := range existingEnvVars {
 			if existingEnvVar.Name == newEnvVar.Name {
@@ -56,12 +60,13 @@ func updateEnvVars(existingEnvVars []core.EnvVar, newEnvVars []core.EnvVar) []co
 }
 
 func createIqeContainer(j *batchv1.Job, nn types.NamespacedName, cji *crd.ClowdJobInvocation, env *crd.ClowdEnvironment, app *crd.ClowdApp) *core.Container {
-	// create env vars
+	// iqePlugins comes from ClowdApp spec unless overridden
 	iqePlugins := app.Spec.Testing.IqePlugin
 	if cji.Spec.Testing.Iqe.IqePlugins != "" {
 		iqePlugins = cji.Spec.Testing.Iqe.IqePlugins
 	}
 
+	// default log level is "info" unless overridden
 	logLevel := cji.Spec.Testing.Iqe.LogLevel
 	if cji.Spec.Testing.Iqe.LogLevel == "" {
 		logLevel = "info"

--- a/tests/kuttl/test-iqe-jobs/01-assert.yaml
+++ b/tests/kuttl/test-iqe-jobs/01-assert.yaml
@@ -45,7 +45,7 @@ spec:
             - name: ACG_CONFIG
               value: /cdapp/cdappconfig.json
             - name: IQE_PLUGINS
-              value: "some,different,plugins"
+              value: "host-inventory"
             - name: IQE_MARKER_EXPRESSION
               value: "smoke"
             - name: IQE_FILTER_EXPRESSION

--- a/tests/kuttl/test-iqe-jobs/01-pods.yaml
+++ b/tests/kuttl/test-iqe-jobs/01-pods.yaml
@@ -72,13 +72,15 @@ spec:
   testing:
     iqe:
       imageTag: latest
-      plugins: "some,different,plugins"
       env:
       - name: SOME_ENV_VAR
         value: some_value
       # test env var override behavior using IQE_LOG_LEVEL
       - name: IQE_LOG_LEVEL
         value: warning
+      # ensure that this does not override plugin defined on the ClowdApp
+      - name: IQE_PLUGINS
+        value: ""
       ui:
         enabled: false
       marker: "smoke"


### PR DESCRIPTION
Fixes a bug that is found when using the `bonfire deploy-iqe-cji` command. If `IQE_PLUGINS` is not provided by the CJI, we expect it to be set by Clowder by looking up the ClowdApp `.spec.testing.iqePlugin` value. However, if a CJI is applied with env var set to: `{name: "IQE_PLUGINS", "value": ""}` then the empty env var will end up being passed to the pod. This changes the `updateEnvVars` function to only override env vars when they have a non-empty value.