### PR TITLE
Fix ca cert location in web 'local' mode

### DIFF
--- a/controllers/cloud.redhat.com/providers/web/local.go
+++ b/controllers/cloud.redhat.com/providers/web/local.go
@@ -230,7 +230,7 @@ func (web *localWebProvider) createIngress(app *crd.ClowdApp, deployment *crd.De
 
 func (web *localWebProvider) populateCA() error {
 	if web.Env.Spec.Providers.Web.TLS.Enabled {
-		web.Config.TlsCAPath = utils.StringPtr("/cdapp/certs/openshift-service-ca.crt")
+		web.Config.TlsCAPath = utils.StringPtr("/cdapp/certs/service-ca.crt")
 	}
 	return nil
 }


### PR DESCRIPTION
Although the ConfigMap is named 'openshift-service-ca.crt', the ca service cert is actually mounted at `/cdapp/certs/service-ca.crt`:

```
oc get configmap openshift-service-ca.crt -o yaml
apiVersion: v1
data:
  service-ca.crt: |+
    -----BEGIN CERTIFICATE-----
```

The 'default' web provider mode has this correct, the `local` web provider mode path needs to be changed.