### PR TITLE
fix for post artifacts on failed pipeline run

### DIFF
--- a/ci/minikube_e2e_tests.sh
+++ b/ci/minikube_e2e_tests.sh
@@ -2,8 +2,6 @@
 
 echo "$MINIKUBE_SSH_KEY" > minikube-ssh-ident
 
-set -x
-
 set -exv
 
 DOCKER_CONF="$PWD/.docker"
@@ -19,6 +17,7 @@ docker rm $tempid
 
 docker build -f Dockerfile.test --build-arg BASE_IMAGE=${BASE_IMG} -t $CONTAINER_NAME .
 
+set +e
 docker run -i \
     --name $CONTAINER_NAME \
     -v $PWD:/workspace:ro \


### PR DESCRIPTION
Fix for posting artifacts on failed Jenkins pipeline run. Needed to add `+e` before running the `docker run` command that would kick off the E2E tests. The `-e` flag will exit immediately if a non-zero code occurs. When this was happening it was skipping the `docker cp` command that copies the artifacts from the container following the `docker run` command.

Unrelated, but also removed duplicate `set -x`.