### PR TITLE
[RHCLOUD-30525] - fix: Caddy TLS proxy disable auto_https

### DIFF
--- a/controllers/cloud.redhat.com/providers/web/caddy_reverse_proxy.go
+++ b/controllers/cloud.redhat.com/providers/web/caddy_reverse_proxy.go
@@ -47,6 +47,9 @@ func generateServer(port uint32, appPort int32, tlsConnPolicy []*caddytls.Connec
 
 	server := &caddyhttp.Server{
 		Listen: []string{fmt.Sprintf(":%d", port)},
+		AutoHTTPS: &caddyhttp.AutoHTTPSConfig{
+			Disabled: true,
+		},
 		Routes: caddyhttp.RouteList{{
 			HandlersRaw: []json.RawMessage{
 				caddyconfig.JSONModuleObject(reverseProxy, "handler", "reverse_proxy", &warnings),


### PR DESCRIPTION
If we have auto_https enabled, caddy will try to listen on port 80. Disabling it will keep it from trying to open that port