### PR TITLE
Remove use of POSTGRESQL_MASTER env vars

### DIFF
--- a/controllers/cloud.redhat.com/providers/database/localdb_test.go
+++ b/controllers/cloud.redhat.com/providers/database/localdb_test.go
@@ -112,9 +112,7 @@ func TestLocalDBDeployment(t *testing.T) {
 	envVars := []core.EnvVar{
 		{Name: "POSTGRESQL_USER", Value: cfg.Username},
 		{Name: "POSTGRESQL_PASSWORD", Value: cfg.Password},
-		{Name: "PGPASSWORD", Value: cfg.AdminPassword},
-		{Name: "POSTGRESQL_MASTER_USER", Value: cfg.AdminUsername},
-		{Name: "POSTGRESQL_MASTER_PASSWORD", Value: cfg.AdminPassword},
+		{Name: "POSTGRESQL_ADMIN_PASSWORD", Value: cfg.AdminPassword},
 		{Name: "POSTGRESQL_DATABASE", Value: app.Spec.Database.Name},
 	}
 

--- a/controllers/cloud.redhat.com/providers/utils/utils.go
+++ b/controllers/cloud.redhat.com/providers/utils/utils.go
@@ -86,9 +86,7 @@ func MakeLocalDB(dd *apps.Deployment, nn types.NamespacedName, baseResource obj.
 	envVars := []core.EnvVar{
 		{Name: "POSTGRESQL_USER", Value: cfg.Username},
 		{Name: "POSTGRESQL_PASSWORD", Value: cfg.Password},
-		{Name: "PGPASSWORD", Value: cfg.AdminPassword}, // Legacy for old db images can likely be removed soon
-		{Name: "POSTGRESQL_MASTER_USER", Value: cfg.AdminUsername},
-		{Name: "POSTGRESQL_MASTER_PASSWORD", Value: cfg.AdminPassword},
+		{Name: "POSTGRESQL_ADMIN_PASSWORD", Value: cfg.AdminPassword},
 		{Name: "POSTGRESQL_DATABASE", Value: dbName},
 	}
 	ports := []core.ContainerPort{{


### PR DESCRIPTION
Currently when the ephemeral DB's start up, the container in the pod always restarts once.

If you look at the container logs, you can see it is running into this error:
```
waiting for server to start....2024-02-05 16:09:50.580 UTC [35] LOG:  starting PostgreSQL 12.14 on x86_64-redhat-linux-gnu, compiled by gcc (GCC) 13.0.1 20230208 (Red Hat 13.0.1-0), 64-bit
2024-02-05 16:09:50.581 UTC [35] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2024-02-05 16:09:50.582 UTC [35] LOG:  listening on Unix socket "/tmp/.s.PGSQL.5432"
2024-02-05 16:09:50.599 UTC [35] LOG:  redirecting log output to logging collector process
2024-02-05 16:09:50.599 UTC [35] HINT:  Future log output will appear in directory "log".
 done
server started
/var/run/postgresql:5432 - accepting connections
createuser: error: creation of new role failed: ERROR:  role "postgres" already exists
```

And I think this is due to us setting the `POSTGRESQL_MASTER_USER` to be `postgres` -- it causes the scl container scripts to invoke this:

https://github.com/sclorg/postgresql-container/blob/16cd132d4986523b531a353401e6ed4ee0703c8b/10/root/usr/share/container-scripts/postgresql/common.sh#L241

Reading through this: https://github.com/sclorg/postgresql-container/tree/16cd132d4986523b531a353401e6ed4ee0703c8b/examples/replica#postgresql_master_password it seems that the MASTER_ env vars only relate to DB replication. We don't use this feature so we don't even need to set these env vars. We should use `POSTGRESQL_ADMIN_PASSWORD` though to configure the admin password: https://github.com/sclorg/postgresql-container/tree/16cd132d4986523b531a353401e6ed4ee0703c8b/examples/replica#postgresql_password-and-postgresql_admin_password

We also should not need to set `PGPASSWORD` on the pods anymore, so I removed that. It doesn't look like any of the images at https://github.com/sclorg/postgresql-container use this environment variable.