### PR TITLE
Clowdapp Dependency metrics

### DIFF
--- a/controllers/cloud.redhat.com/clowdapp_reconciliation.go
+++ b/controllers/cloud.redhat.com/clowdapp_reconciliation.go
@@ -393,7 +393,10 @@ func (r *ClowdAppReconciliation) deletedUnusedResources() (ctrl.Result, error) {
 }
 
 func (r *ClowdAppReconciliation) setReconciliationSuccessful() (ctrl.Result, error) {
-	reportDependencies(r.ctx, r.client, r.app)
+	_, err := reportDependencies(r.ctx, r.client, r.app)
+	if err != nil {
+		r.log.Info("Error during depency metric reporting", "err", err)
+	}
 
 	if setClowdStatusErr := SetClowdAppConditions(r.ctx, r.client, r.app, crd.ReconciliationSuccessful, r.oldStatus, nil); setClowdStatusErr != nil {
 		r.log.Info("Set status error", "err", setClowdStatusErr)

--- a/controllers/cloud.redhat.com/clowdapp_reconciliation.go
+++ b/controllers/cloud.redhat.com/clowdapp_reconciliation.go
@@ -89,7 +89,7 @@ func (r *ClowdAppReconciliation) stopMetrics() (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
-func reportDependencies(ctx context.Context, pClient client.Client, o *crd.ClowdApp) {
+func reportDependencies(ctx context.Context, pClient client.Client, o *crd.ClowdApp) (ctrl.Result, error) {
 	// get parent clowdapp name
 	var appName string = o.Name
 	var dependencies []string
@@ -100,7 +100,11 @@ func reportDependencies(ctx context.Context, pClient client.Client, o *crd.Clowd
 
 	applist := crd.ClowdAppList{}
 
-	pClient.List(ctx, &applist, client.MatchingFields{"spec.envName": o.Spec.EnvName})
+	err := pClient.List(ctx, &applist, client.MatchingFields{"spec.envName": o.Spec.EnvName})
+
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
 	// for each dependency
 	for _, dependency := range dependencies {
@@ -116,6 +120,8 @@ func reportDependencies(ctx context.Context, pClient client.Client, o *crd.Clowd
 			}
 		}
 	}
+
+	return ctrl.Result{}, nil
 }
 
 func (r *ClowdAppReconciliation) setPresentAndManagedApps() (ctrl.Result, error) {

--- a/controllers/cloud.redhat.com/clowdapp_reconciliation.go
+++ b/controllers/cloud.redhat.com/clowdapp_reconciliation.go
@@ -92,13 +92,14 @@ func (r *ClowdAppReconciliation) stopMetrics() (ctrl.Result, error) {
 func ReportDependencies(ctx context.Context, pClient client.Client, o *crd.ClowdApp) error {
 	appName := o.Name
 	applist := crd.ClowdAppList{}
-	dependencies := append(o.Spec.Dependencies, o.Spec.OptionalDependencies...)
+	appDependencies := o.Spec.Dependencies
+	appDependencies = append(appDependencies, o.Spec.OptionalDependencies...)
 
 	if err := pClient.List(ctx, &applist, client.MatchingFields{"spec.envName": o.Spec.EnvName}); err != nil {
 		return err
 	}
 
-	for _, dependency := range dependencies {
+	for _, dependency := range appDependencies {
 		for _, app := range applist.Items {
 			if app.Name != dependency {
 				continue

--- a/controllers/cloud.redhat.com/metrics.go
+++ b/controllers/cloud.redhat.com/metrics.go
@@ -95,6 +95,13 @@ var (
 		},
 		[]string{"app", "env"},
 	)
+	dependencyMetrics = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "clowder_dependency_availability",
+			Help: "Clowder dependency availability",
+		},
+		[]string{"app", "dependency"},
+	)
 )
 
 func init() {
@@ -108,5 +115,6 @@ func init() {
 		presentAppsMetric,
 		presentEnvsMetric,
 		reconciliationMetrics,
+		dependencyMetrics,
 	)
 }


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/RHCLOUD-30912

This adds a new metric, clowder_dependency_availability, that reports the availability of each clowdapp's clowdapp dependencies + optional dependencies. 1 being UP and 0 being DOWN.
This metric gets recorded during ClowdApp reconciliation.