### PR TITLE
Control dependency metrics via a config or env

### DIFF
--- a/config/deployment-template/clowder_config.yaml
+++ b/config/deployment-template/clowder_config.yaml
@@ -23,7 +23,8 @@ data:
             "watchStrimziResources": ${WATCH_STRIMZI_RESOURCES},
             "enableKedaResources": ${ENABLE_KEDA_RESOURCES},
             "perProviderMetrics": ${PER_PROVIDER_METRICS},
-            "reconciliationMetrics": ${RECONCILIATION_METRICS}
+            "reconciliationMetrics": ${RECONCILIATION_METRICS},
+            "enableDependencyMetrics": ${ENABLE_TELEMETRY_METRICS}
         },
         "settings": {
             "managedKafkaEphemDeleteRegex": "${MANAGED_EPHEM_DELETE_REGEX}"

--- a/controllers/cloud.redhat.com/clowdapp_reconciliation.go
+++ b/controllers/cloud.redhat.com/clowdapp_reconciliation.go
@@ -94,6 +94,11 @@ func ReportDependencies(ctx context.Context, pClient client.Client, app *crd.Clo
 	appDependencies := app.Spec.Dependencies
 	appDependencies = append(appDependencies, app.Spec.OptionalDependencies...)
 
+	// Don't record metrics if not enabled
+	if !clowderconfig.LoadedConfig.Features.EnableDependencyMetrics {
+		return nil
+	}
+
 	applist, err := env.GetAppsInEnv(ctx, pClient)
 	if err != nil {
 		return err

--- a/controllers/cloud.redhat.com/clowderconfig/config.go
+++ b/controllers/cloud.redhat.com/clowderconfig/config.go
@@ -41,6 +41,7 @@ type ClowderConfig struct {
 		KedaResources               bool `json:"enableKedaResources"`
 		PerProviderMetrics          bool `json:"perProviderMetrics"`
 		ReconciliationMetrics       bool `json:"reconciliationMetrics"`
+		EnableDependencyMetrics     bool `json:"enableDependencyMetrics"`
 		DisableCloudWatchLogging    bool `json:"disableCloudWatchLogging"`
 		EnableExternalStrimzi       bool `json:"enableExternalStrimzi"`
 		DisableRandomRoutes         bool `json:"disableRandomRoutes"`

--- a/deploy-mutate.yml
+++ b/deploy-mutate.yml
@@ -8395,8 +8395,9 @@ objects:
       features\": {\n        \"createServiceMonitor\": ${CREATE_SERVICE_MONITORS},\n\
       \        \"watchStrimziResources\": ${WATCH_STRIMZI_RESOURCES},\n        \"\
       enableKedaResources\": ${ENABLE_KEDA_RESOURCES},\n        \"perProviderMetrics\"\
-      : ${PER_PROVIDER_METRICS},\n        \"reconciliationMetrics\": ${RECONCILIATION_METRICS}\n\
-      \    },\n    \"settings\": {\n        \"managedKafkaEphemDeleteRegex\": \"${MANAGED_EPHEM_DELETE_REGEX}\"\
+      : ${PER_PROVIDER_METRICS},\n        \"reconciliationMetrics\": ${RECONCILIATION_METRICS},\n\
+      \        \"enableDependencyMetrics\": ${ENABLE_TELEMETRY_METRICS}\n    },\n\
+      \    \"settings\": {\n        \"managedKafkaEphemDeleteRegex\": \"${MANAGED_EPHEM_DELETE_REGEX}\"\
       \n    }\n}\n"
   kind: ConfigMap
   metadata:
@@ -8423,6 +8424,8 @@ parameters:
 - name: PER_PROVIDER_METRICS
   value: 'false'
 - name: RECONCILIATION_METRICS
+  value: 'false'
+- name: ENABLE_TELEMETRY_METRICS
   value: 'false'
 - name: MANAGED_EPHEM_DELETE_REGEX
   value: .*ephemeral.*

--- a/deploy.yml
+++ b/deploy.yml
@@ -8368,8 +8368,9 @@ objects:
       features\": {\n        \"createServiceMonitor\": ${CREATE_SERVICE_MONITORS},\n\
       \        \"watchStrimziResources\": ${WATCH_STRIMZI_RESOURCES},\n        \"\
       enableKedaResources\": ${ENABLE_KEDA_RESOURCES},\n        \"perProviderMetrics\"\
-      : ${PER_PROVIDER_METRICS},\n        \"reconciliationMetrics\": ${RECONCILIATION_METRICS}\n\
-      \    },\n    \"settings\": {\n        \"managedKafkaEphemDeleteRegex\": \"${MANAGED_EPHEM_DELETE_REGEX}\"\
+      : ${PER_PROVIDER_METRICS},\n        \"reconciliationMetrics\": ${RECONCILIATION_METRICS},\n\
+      \        \"enableDependencyMetrics\": ${ENABLE_TELEMETRY_METRICS}\n    },\n\
+      \    \"settings\": {\n        \"managedKafkaEphemDeleteRegex\": \"${MANAGED_EPHEM_DELETE_REGEX}\"\
       \n    }\n}\n"
   kind: ConfigMap
   metadata:
@@ -8396,6 +8397,8 @@ parameters:
 - name: PER_PROVIDER_METRICS
   value: 'false'
 - name: RECONCILIATION_METRICS
+  value: 'false'
+- name: ENABLE_TELEMETRY_METRICS
   value: 'false'
 - name: MANAGED_EPHEM_DELETE_REGEX
   value: .*ephemeral.*

--- a/docsmd/developer-guide.md
+++ b/docsmd/developer-guide.md
@@ -463,6 +463,7 @@ behaviour. They are detailed as follows:
 | ``features.enablekedaResources`` | Turns on the addition of Keda resources into the protectedGVK list. | No
 | ``features.perProviderMetrics`` | Turns on metrics that calculate reconciliation time per provider. | Yes
 | ``features.reconciliationMetrics`` | Enables extra detailed metrics on reconciliations per application. | Yes
+| ``features.enableDependencyMetrics`` | Turns on metrics that report availability of a ClowdApps dependencies. | Yes
 | ``disableCloudWatchLogging`` | Disables logging to CloudWatch. | Yes
 | ``enableExternalStrimzi`` | Enables talking to Strimzi via a local nodeport (only useful on minikube) | Yes
 | ``disableRandomRoutes`` | Gives the ability to disable the extra portion of randomness added to routes. | Yes

--- a/template.yml
+++ b/template.yml
@@ -25,6 +25,8 @@ parameters:
   value: "false"
 - name: RECONCILIATION_METRICS
   value: "false"
+- name: ENABLE_TELEMETRY_METRICS
+  value: "false"
 - name: MANAGED_EPHEM_DELETE_REGEX
   value: ".*ephemeral.*"
 - name: ENABLE_KEDA_RESOURCES


### PR DESCRIPTION
This adds a flag for enabling dependency metrics.
The env var is `ENABLE_TELEMETRY_METRICS`