### PR TITLE
Correct typo for dependency metric env variable

### DIFF
--- a/config/deployment-template/clowder_config.yaml
+++ b/config/deployment-template/clowder_config.yaml
@@ -24,7 +24,7 @@ data:
             "enableKedaResources": ${ENABLE_KEDA_RESOURCES},
             "perProviderMetrics": ${PER_PROVIDER_METRICS},
             "reconciliationMetrics": ${RECONCILIATION_METRICS},
-            "enableDependencyMetrics": ${ENABLE_TELEMETRY_METRICS}
+            "enableDependencyMetrics": ${ENABLE_DEPENDENCY_METRICS}
         },
         "settings": {
             "managedKafkaEphemDeleteRegex": "${MANAGED_EPHEM_DELETE_REGEX}"

--- a/deploy-mutate.yml
+++ b/deploy-mutate.yml
@@ -8397,7 +8397,7 @@ objects:
       \        \"watchStrimziResources\": ${WATCH_STRIMZI_RESOURCES},\n        \"\
       enableKedaResources\": ${ENABLE_KEDA_RESOURCES},\n        \"perProviderMetrics\"\
       : ${PER_PROVIDER_METRICS},\n        \"reconciliationMetrics\": ${RECONCILIATION_METRICS},\n\
-      \        \"enableDependencyMetrics\": ${ENABLE_TELEMETRY_METRICS}\n    },\n\
+      \        \"enableDependencyMetrics\": ${ENABLE_DEPENDENCY_METRICS}\n    },\n\
       \    \"settings\": {\n        \"managedKafkaEphemDeleteRegex\": \"${MANAGED_EPHEM_DELETE_REGEX}\"\
       \n    }\n}\n"
   kind: ConfigMap
@@ -8426,7 +8426,7 @@ parameters:
   value: 'false'
 - name: RECONCILIATION_METRICS
   value: 'false'
-- name: ENABLE_TELEMETRY_METRICS
+- name: ENABLE_DEPENDENCY_METRICS
   value: 'false'
 - name: MANAGED_EPHEM_DELETE_REGEX
   value: .*ephemeral.*

--- a/deploy.yml
+++ b/deploy.yml
@@ -8370,7 +8370,7 @@ objects:
       \        \"watchStrimziResources\": ${WATCH_STRIMZI_RESOURCES},\n        \"\
       enableKedaResources\": ${ENABLE_KEDA_RESOURCES},\n        \"perProviderMetrics\"\
       : ${PER_PROVIDER_METRICS},\n        \"reconciliationMetrics\": ${RECONCILIATION_METRICS},\n\
-      \        \"enableDependencyMetrics\": ${ENABLE_TELEMETRY_METRICS}\n    },\n\
+      \        \"enableDependencyMetrics\": ${ENABLE_DEPENDENCY_METRICS}\n    },\n\
       \    \"settings\": {\n        \"managedKafkaEphemDeleteRegex\": \"${MANAGED_EPHEM_DELETE_REGEX}\"\
       \n    }\n}\n"
   kind: ConfigMap
@@ -8399,7 +8399,7 @@ parameters:
   value: 'false'
 - name: RECONCILIATION_METRICS
   value: 'false'
-- name: ENABLE_TELEMETRY_METRICS
+- name: ENABLE_DEPENDENCY_METRICS
   value: 'false'
 - name: MANAGED_EPHEM_DELETE_REGEX
   value: .*ephemeral.*

--- a/template.yml
+++ b/template.yml
@@ -25,7 +25,7 @@ parameters:
   value: "false"
 - name: RECONCILIATION_METRICS
   value: "false"
-- name: ENABLE_TELEMETRY_METRICS
+- name: ENABLE_DEPENDENCY_METRICS
   value: "false"
 - name: MANAGED_EPHEM_DELETE_REGEX
   value: ".*ephemeral.*"


### PR DESCRIPTION
The env variable for activating dependency metrics should be ENABLE_DEPENDENCY_METRICS.
Currently it is ENABLE_TELEMETRY_METRICS which doesn't make sense. (my wires got crossed with another feature)