### PR TITLE
test(ff): Stabilize FF tests

### DIFF
--- a/tests/kuttl/test-ff-local/02-json-asserts.yaml
+++ b/tests/kuttl/test-ff-local/02-json-asserts.yaml
@@ -2,7 +2,7 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-- script: sleep 1
+- script: sleep 10
 - script: kubectl get secret --namespace=test-ff-local puptoo -o json > /tmp/test-ff-local
 - script: jq -r '.data["cdappconfig.json"]' < /tmp/test-ff-local | base64 -d > /tmp/test-ff-local-json
 


### PR DESCRIPTION
* Occasionally there is a race condition where the FF server restarts an extra time though I dislike arbitrary sleeps, right now this is possibly the quickest way to stabilize the tests.