### PR TITLE
feat(clowdapp): add sessionAffinity support for PublicWebService

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
@@ -157,6 +157,9 @@ type PublicWebService struct {
 
 	// WhitelistPaths define the paths that do not require authentication
 	WhitelistPaths []string `json:"whitelistPaths,omitempty"`
+
+	// Set SessionAffinity to true to enable sticky sessions
+	SessionAffinity bool `json:"sessionAffinity,omitempty"`
 }
 
 // AppProtocol is used to define an appProtocol for Istio

--- a/config/crd/bases/cloud.redhat.com_clowdapps.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdapps.yaml
@@ -3172,6 +3172,10 @@ spec:
                                 the public service and provide the configuration in
                                 the cdappconfig.
                               type: boolean
+                            sessionAffinity:
+                              description: Set SessionAffinity to true to enable sticky
+                                sessions
+                              type: boolean
                             whitelistPaths:
                               description: WhitelistPaths define the paths that do
                                 not require authentication

--- a/controllers/cloud.redhat.com/providers/web/impl.go
+++ b/controllers/cloud.redhat.com/providers/web/impl.go
@@ -108,6 +108,11 @@ func makeService(cache *rc.ObjectCache, deployment *crd.Deployment, app *crd.Clo
 				Protocol:      core.ProtocolTCP,
 			},
 		)
+
+		// Set session affinity if enabled
+		if deployment.WebServices.Public.SessionAffinity {
+			s.Spec.SessionAffinity = core.ServiceAffinityClientIP
+		}
 	}
 
 	var pub, priv bool

--- a/deploy-mutate.yml
+++ b/deploy-mutate.yml
@@ -3254,6 +3254,10 @@ objects:
                                   the public service and provide the configuration
                                   in the cdappconfig.
                                 type: boolean
+                              sessionAffinity:
+                                description: Set SessionAffinity to true to enable
+                                  sticky sessions
+                                type: boolean
                               whitelistPaths:
                                 description: WhitelistPaths define the paths that
                                   do not require authentication

--- a/deploy.yml
+++ b/deploy.yml
@@ -3254,6 +3254,10 @@ objects:
                                   the public service and provide the configuration
                                   in the cdappconfig.
                                 type: boolean
+                              sessionAffinity:
+                                description: Set SessionAffinity to true to enable
+                                  sticky sessions
+                                type: boolean
                               whitelistPaths:
                                 description: WhitelistPaths define the paths that
                                   do not require authentication

--- a/docs/antora/modules/ROOT/pages/api_reference.adoc
+++ b/docs/antora/modules/ROOT/pages/api_reference.adoc
@@ -1380,6 +1380,7 @@ PublicWebService is the definition of the public web service. There can be only 
 | *`apiPath`* __string__ | (DEPRECATED, use apiPaths instead) Configures a path named '/api/<apiPath>/' that this app will serve requests from.
 | *`apiPaths`* __xref:{anchor_prefix}-github-com-redhatinsights-clowder-apis-cloud-redhat-com-v1alpha1-apipath[$$APIPath$$] array__ | Defines a list of API paths (each matching format: "/api/some-path/") that this app will serve requests from.
 | *`whitelistPaths`* __string array__ | WhitelistPaths define the paths that do not require authentication
+| *`sessionAffinity`* __boolean__ | Set SessionAffinity to true to enable sticky sessions
 |===
 
 

--- a/tests/kuttl/test-public-webservice-sessionaffinity/00-install.yaml
+++ b/tests/kuttl/test-public-webservice-sessionaffinity/00-install.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-web-services-sessionaffinity
+spec:
+  finalizers:
+  - kubernetes

--- a/tests/kuttl/test-public-webservice-sessionaffinity/01-assert.yaml
+++ b/tests/kuttl/test-public-webservice-sessionaffinity/01-assert.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: puptoo
+  namespace: test-web-services-sessionaffinity
+  labels:
+    app: puptoo
+  ownerReferences:
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdApp
+    name: puptoo
+type: Opaque
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: puptoo-processor
+  namespace: test-web-services-sessionaffinity
+spec:
+  template:
+    spec:
+      containers:
+      - env:
+        - name: ENV_VAR_1
+          value: "env_var_1"
+        - name: ENV_VAR_2
+          value: "env_var_2"
+        - name: ACG_CONFIG
+          value: /cdapp/cdappconfig.json
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: puptoo-processor
+  namespace: test-web-services-sessionaffinity
+spec:
+  selector:
+    pod: puptoo-processor
+  sessionAffinity: ClientIP
+  ports:
+  - port: 8000
+    targetPort: 8000
+    name: public
+    protocol: TCP
+    appProtocol: http
+  - port: 10000
+    targetPort: 10000
+    name: private
+    protocol: TCP
+    appProtocol: http
+  - port: 9000
+    targetPort: 9000
+    name: metrics
+    protocol: TCP
+    appProtocol: http
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdEnvironment
+metadata:
+  name: test-web-services-sessionaffinity
+status:
+  apps:
+    - name: puptoo
+      deployments:
+      - hostname: puptoo-processor.test-web-services-sessionaffinity.svc
+        name: puptoo-processor
+        port: 8000

--- a/tests/kuttl/test-public-webservice-sessionaffinity/01-pods.yaml
+++ b/tests/kuttl/test-public-webservice-sessionaffinity/01-pods.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdEnvironment
+metadata:
+  name: test-web-services-sessionaffinity
+spec:
+  targetNamespace: test-web-services-sessionaffinity
+  providers:
+    web:
+      port: 8000
+      privatePort: 10000
+      mode: operator
+    metrics:
+      port: 9000
+      mode: operator
+      path: "/metrics"
+    kafka:
+      mode: none
+    db:
+      mode: none
+    logging:
+      mode: none
+    objectStore:
+      mode: none
+    inMemoryDb:
+      mode: none
+  resourceDefaults:
+    limits:
+      cpu: 400m
+      memory: 1024Mi
+    requests:
+      cpu: 30m
+      memory: 512Mi
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: puptoo
+  namespace: test-web-services-sessionaffinity
+spec:
+  envName: test-web-services-sessionaffinity
+  deployments:
+  - name: processor
+    podSpec:
+      image: quay.io/psav/clowder-hello
+      env: 
+        - name: ENV_VAR_1
+          value: env_var_1
+        - name: ENV_VAR_2
+          value: env_var_2
+    webServices:
+      private:
+        enabled: True
+      public:
+        enabled: True
+        sessionAffinity: True

--- a/tests/kuttl/test-public-webservice-sessionaffinity/03-delete.yaml
+++ b/tests/kuttl/test-public-webservice-sessionaffinity/03-delete.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: v1
+  kind: Namespace
+  name: test-web-services
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdEnvironment
+  name: test-web-services

--- a/tests/kuttl/test-public-webservice-sessionaffinity/03-delete.yaml
+++ b/tests/kuttl/test-public-webservice-sessionaffinity/03-delete.yaml
@@ -4,7 +4,7 @@ kind: TestStep
 delete:
 - apiVersion: v1
   kind: Namespace
-  name: test-web-services
+  name: test-web-services-sessionaffinity
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdEnvironment
-  name: test-web-services
+  name: test-web-services-sessionaffinity


### PR DESCRIPTION
This commit introduces a new boolean field  in the PublicWebService struct of the ClowdApp CRD. When set to true, this enables session affinity (ClientIP) for the corresponding Kubernetes service, ensuring that requests from the same client are routed to the same pod.