### PR TITLE
fix: align cloudwatch provider with documentation

### DIFF
--- a/controllers/cloud.redhat.com/providers/logging/appinterface.go
+++ b/controllers/cloud.redhat.com/providers/logging/appinterface.go
@@ -48,6 +48,7 @@ func setCloudwatchSecret(ns string, p *providers.Provider, c *config.LoggingConf
 		Region:          string(secret.Data["aws_region"]),
 		LogGroup:        string(secret.Data["log_group_name"]),
 	}
+	c.Type = "cloudwatch"
 
 	return nil
 }


### PR DESCRIPTION
We observed the value for the `Type` field is an empty
string when we are using the cloudwatch provider.

We think this could fix the root cause by setting
the value for the clouderwatch logging provider, and
this value would be propagated to the configuration
injected in the final deployed pods.

https://github.com/RedHatInsights/clowder/blob/master/docsmd/providers/logging.md