### PR TITLE
feat: share Downloads between iqe and selenium container

### DIFF
--- a/controllers/cloud.redhat.com/providers/iqe/impl.go
+++ b/controllers/cloud.redhat.com/providers/iqe/impl.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
 	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -129,6 +130,14 @@ func createIqeContainer(j *batchv1.Job, nn types.NamespacedName, cji *crd.ClowdJ
 		TerminationMessagePolicy: core.TerminationMessageReadFile,
 	}
 
+	// attach sel-downloads volume to access Downloads from selenim container in case selenium is deployed
+	if cji.Spec.Testing.Iqe.UI.Selenium.Deploy {
+		c.VolumeMounts = append(c.VolumeMounts, core.VolumeMount{
+			Name:      "sel-downloads",
+			MountPath: "/sel-downloads",
+		})
+	}
+
 	return &c
 }
 
@@ -169,6 +178,23 @@ func createSeleniumContainer(j *batchv1.Job, cji *crd.ClowdJobInvocation, env *c
 	c.VolumeMounts = append(c.VolumeMounts, core.VolumeMount{
 		Name:      "shm",
 		MountPath: "/dev/shm",
+	})
+
+	// attach sel-downloads volume to share Downloads with iqe container
+	sizeLimit := resource.MustParse("64Mi")
+	j.Spec.Template.Spec.Volumes = append(j.Spec.Template.Spec.Volumes, core.Volume{
+		Name:         "sel-downloads",
+		VolumeSource: core.VolumeSource{
+			EmptyDir: &core.EmptyDirVolumeSource{
+				Medium: "Memory",
+				SizeLimit: &sizeLimit,
+			},
+		},
+	})
+
+	c.VolumeMounts = append(c.VolumeMounts, core.VolumeMount{
+		Name:      "sel-downloads",
+		MountPath: "/home/selenium/Downloads",
 	})
 
 	return &c

--- a/controllers/cloud.redhat.com/providers/iqe/impl.go
+++ b/controllers/cloud.redhat.com/providers/iqe/impl.go
@@ -183,10 +183,10 @@ func createSeleniumContainer(j *batchv1.Job, cji *crd.ClowdJobInvocation, env *c
 	// attach sel-downloads volume to share Downloads with iqe container
 	sizeLimit := resource.MustParse("64Mi")
 	j.Spec.Template.Spec.Volumes = append(j.Spec.Template.Spec.Volumes, core.Volume{
-		Name:         "sel-downloads",
+		Name: "sel-downloads",
 		VolumeSource: core.VolumeSource{
 			EmptyDir: &core.EmptyDirVolumeSource{
-				Medium: "Memory",
+				Medium:    "Memory",
 				SizeLimit: &sizeLimit,
 			},
 		},

--- a/tests/kuttl/test-iqe-jobs-selenium/01-assert.yaml
+++ b/tests/kuttl/test-iqe-jobs-selenium/01-assert.yaml
@@ -39,6 +39,10 @@ spec:
       - emptyDir:
           medium: Memory
         name: shm
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 64Mi
+        name: sel-downloads
       containers:
         - args:
           - "clowder"
@@ -79,6 +83,8 @@ spec:
               cpu: 200m
               memory: 256Mi
           volumeMounts:
+          - mountPath: /sel-downloads
+            name: sel-downloads
           - mountPath: /cdenv
             name: cdenvconfig
           - mountPath: /cdapp
@@ -94,6 +100,8 @@ spec:
           volumeMounts:
           - mountPath: /dev/shm
             name: shm
+          - mountPath: /home/selenium/Downloads
+            name: sel-downloads
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
We want to be able to access the selenium Downloads directory from the iqe container for testing.