### PR TITLE
Fix uint64 conversion

### DIFF
--- a/controllers/cloud.redhat.com/config/config.go
+++ b/controllers/cloud.redhat.com/config/config.go
@@ -8,7 +8,7 @@ import (
 
 // Populate sets the database configuration on the object from the passed in map.
 func (dbc *DatabaseConfig) Populate(data *map[string]string) error {
-	port, err := strconv.ParseUint((*data)["port"], 10, 16)
+	port, err := strconv.Atoi((*data)["port"])
 	if err != nil {
 		return err
 	}

--- a/controllers/cloud.redhat.com/providers/database/appinterface.go
+++ b/controllers/cloud.redhat.com/providers/database/appinterface.go
@@ -207,7 +207,7 @@ func genDbConfigs(secrets []core.Secret, verify bool) ([]config.DatabaseConfigCo
 	var err error
 
 	extractFn := func(secret *core.Secret) {
-		port, erro := strconv.ParseUint(string(secret.Data["db.port"]), 10, 16)
+		port, erro := strconv.Atoi(string(secret.Data["db.port"]))
 
 		if erro != nil {
 			err = errors.Wrap("Failed to parse DB port", err)

--- a/controllers/cloud.redhat.com/providers/database/shareddb.go
+++ b/controllers/cloud.redhat.com/providers/database/shareddb.go
@@ -238,7 +238,7 @@ func (db *sharedDbProvider) Provide(app *crd.ClowdApp) error {
 		return err
 	}
 
-	port, err := strconv.ParseUint(string(vSec.Data["port"]), 10, 16)
+	port, err := strconv.Atoi(string(vSec.Data["port"]))
 	if err != nil {
 		return err
 	}

--- a/controllers/cloud.redhat.com/providers/database/shareddb.go
+++ b/controllers/cloud.redhat.com/providers/database/shareddb.go
@@ -238,9 +238,8 @@ func (db *sharedDbProvider) Provide(app *crd.ClowdApp) error {
 		return err
 	}
 
-	var port uint64
-	var err error
-	if port, err = strconv.ParseUint(string(vSec.Data["port"]), 10, 16); err != nil {
+	port, err := strconv.ParseUint(string(vSec.Data["port"]), 10, 16)
+	if err != nil {
 		return err
 	}
 

--- a/controllers/cloud.redhat.com/providers/inmemorydb/elasticache.go
+++ b/controllers/cloud.redhat.com/providers/inmemorydb/elasticache.go
@@ -44,7 +44,7 @@ func (e *elasticache) Provide(app *crd.ClowdApp) error {
 
 	for _, secret := range secrets.Items {
 		if secret.Name == secretName {
-			port, err := strconv.ParseUint(string(secret.Data["db.port"]), 10, 16)
+			port, err := strconv.Atoi(string(secret.Data["db.port"]))
 
 			if err != nil {
 				return errors.Wrap(

--- a/controllers/cloud.redhat.com/providers/kafka/managed.go
+++ b/controllers/cloud.redhat.com/providers/kafka/managed.go
@@ -70,7 +70,7 @@ func (k *managedKafkaProvider) appendTopic(topic crd.KafkaTopicSpec, kafkaConfig
 }
 
 func (k *managedKafkaProvider) destructureSecret(secret *core.Secret) (int, string, string, string, []string, string, string, error) {
-	port, err := strconv.ParseUint(string(secret.Data["port"]), 10, 16)
+	port, err := strconv.Atoi(string(secret.Data["port"]))
 	if err != nil {
 		return 0, "", "", "", []string{}, "", "", err
 	}

--- a/controllers/cloud.redhat.com/providers/kafka/provider.go
+++ b/controllers/cloud.redhat.com/providers/kafka/provider.go
@@ -246,7 +246,7 @@ func processTopicValues(
 		if err != nil {
 			return errors.NewClowderError(fmt.Sprintf("could not compute max for %v", replicaValList))
 		}
-		maxReplicasInt, err := strconv.ParseUint(maxReplicas, 10, 16)
+		maxReplicasInt, err := strconv.Atoi(maxReplicas)
 		if err != nil {
 			return errors.NewClowderError(fmt.Sprintf("could not convert string to int32 for %v", maxReplicas))
 		}
@@ -262,7 +262,7 @@ func processTopicValues(
 		if err != nil {
 			return errors.NewClowderError(fmt.Sprintf("could not compute max for %v", partitionValList))
 		}
-		maxPartitionsInt, err := strconv.ParseUint(maxPartitions, 10, 16)
+		maxPartitionsInt, err := strconv.Atoi(maxPartitions)
 		if err != nil {
 			return errors.NewClowderError(fmt.Sprintf("could not convert to string to int32 for %v", maxPartitions))
 		}
@@ -469,7 +469,7 @@ func getBrokerConfig(secret *core.Secret) ([]config.BrokerConfig, error) {
 }
 
 func destructureSecret(secret *core.Secret) (int, string, string, string, []string, string, string, error) {
-	port, err := strconv.ParseUint(string(secret.Data["port"]), 10, 16)
+	port, err := strconv.Atoi(string(secret.Data["port"]))
 	if err != nil {
 		return 0, "", "", "", []string{}, "", "", err
 	}

--- a/controllers/cloud.redhat.com/providers/objectstore/minio.go
+++ b/controllers/cloud.redhat.com/providers/objectstore/minio.go
@@ -111,7 +111,7 @@ func (m *minioProvider) Provide(app *crd.ClowdApp) error {
 		return err
 	}
 
-	port, err := strconv.ParseUint(string(secret.Data["port"]), 10, 16)
+	port, err := strconv.Atoi(string(secret.Data["port"]))
 	if err != nil {
 		return err
 	}
@@ -212,7 +212,7 @@ func createMinioProvider(
 ) (*minioProvider, error) {
 	mp := &minioProvider{Provider: *p}
 
-	port, err := strconv.ParseUint(secMap["port"], 10, 16)
+	port, err := strconv.Atoi(secMap["port"])
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/cloud.redhat.com/providers/objectstore/minio.go
+++ b/controllers/cloud.redhat.com/providers/objectstore/minio.go
@@ -111,9 +111,8 @@ func (m *minioProvider) Provide(app *crd.ClowdApp) error {
 		return err
 	}
 
-	var port uint64
-	var err error
-	if port, err = strconv.ParseUint(string(secret.Data["port"]), 10, 16); err != nil {
+	port, err := strconv.ParseUint(string(secret.Data["port"]), 10, 16)
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fix the gosec lint complaints by using `strconv.Atoi()` which is "equivalent to `ParseInt(s, 10, 0)`, converted to type `int`. See https://github.com/golang/go/blob/master/src/strconv/atoi.go?name=release#L241