### PR TITLE
feat: remove finalizer on topics in eph

### DIFF
--- a/controllers/cloud.redhat.com/clowderconfig/config.go
+++ b/controllers/cloud.redhat.com/clowderconfig/config.go
@@ -47,7 +47,7 @@ type ClowderConfig struct {
 		DisableCloudWatchLogging    bool `json:"disableCloudWatchLogging"`
 		EnableExternalStrimzi       bool `json:"enableExternalStrimzi"`
 		DisableRandomRoutes         bool `json:"disableRandomRoutes"`
-		EnableStrimziFinalizer      bool `json:"enableStrimziFinalizerUse"`
+		DisableStrimziFinalizer     bool `json:"disableStrimziFinalizerUse"`
 	} `json:"features"`
 	Settings struct {
 		ManagedKafkaEphemDeleteRegex string `json:"managedKafkaEphemDeleteRegex"`

--- a/controllers/cloud.redhat.com/clowderconfig/config.go
+++ b/controllers/cloud.redhat.com/clowderconfig/config.go
@@ -47,7 +47,7 @@ type ClowderConfig struct {
 		DisableCloudWatchLogging    bool `json:"disableCloudWatchLogging"`
 		EnableExternalStrimzi       bool `json:"enableExternalStrimzi"`
 		DisableRandomRoutes         bool `json:"disableRandomRoutes"`
-		EnableStrimziFinalizerUse   bool `json:"enableStrimziFinalizerUse"`
+		EnableStrimziFinalizer      bool `json:"enableStrimziFinalizerUse"`
 	} `json:"features"`
 	Settings struct {
 		ManagedKafkaEphemDeleteRegex string `json:"managedKafkaEphemDeleteRegex"`

--- a/controllers/cloud.redhat.com/clowderconfig/config.go
+++ b/controllers/cloud.redhat.com/clowderconfig/config.go
@@ -47,6 +47,7 @@ type ClowderConfig struct {
 		DisableCloudWatchLogging    bool `json:"disableCloudWatchLogging"`
 		EnableExternalStrimzi       bool `json:"enableExternalStrimzi"`
 		DisableRandomRoutes         bool `json:"disableRandomRoutes"`
+		EnableStrimziFinalizerUse   bool `json:"enableStrimziFinalizerUse"`
 	} `json:"features"`
 	Settings struct {
 		ManagedKafkaEphemDeleteRegex string `json:"managedKafkaEphemDeleteRegex"`

--- a/controllers/cloud.redhat.com/providers/kafka/strimzi.go
+++ b/controllers/cloud.redhat.com/providers/kafka/strimzi.go
@@ -297,14 +297,14 @@ func (s *strimziProvider) configureKafkaCluster() error {
 		useFinalizersEnv = []strimzi.KafkaSpecEntityOperatorTemplateTopicOperatorContainerEnvElem{
 			{
 				Name:  utils.StringPtr("STRIMZI_USE_FINALIZERS"),
-				Value: utils.StringPtr("true"),
+				Value: utils.StringPtr("false"),
 			},
 		}
 	} else {
 		useFinalizersEnv = []strimzi.KafkaSpecEntityOperatorTemplateTopicOperatorContainerEnvElem{
 			{
 				Name:  utils.StringPtr("STRIMZI_USE_FINALIZERS"),
-				Value: utils.StringPtr("false"),
+				Value: utils.StringPtr("true"),
 			},
 		}
 	}

--- a/controllers/cloud.redhat.com/providers/kafka/strimzi.go
+++ b/controllers/cloud.redhat.com/providers/kafka/strimzi.go
@@ -370,14 +370,14 @@ func (s *strimziProvider) configureKafkaCluster() error {
 	}
 
 	if clowderconfig.LoadedConfig.Features.EnableStrimziFinalizerUse {
-		k.Spec.EntityOperator.Template = KafkaSpecEntityOperatorTemplateTopicOperatorContainer{{
+		k.Spec.EntityOperator.Template.TopicOperatorContainer = &strimzi.KafkaSpecEntityOperatorTemplateTopicOperatorContainer{
 			Env: []strimzi.KafkaSpecEntityOperatorTemplateTopicOperatorContainerEnvElem{
 				{
 					Name:  utils.StringPtr("STRIMZI_USE_FINALIZERS"),
 					Value: utils.StringPtr("true"),
 				},
 			},
-		},
+		}
 	}
 
 	if s.Env.Spec.Providers.Kafka.Cluster.Config != nil && len(*s.Env.Spec.Providers.Kafka.Cluster.Config) != 0 {

--- a/controllers/cloud.redhat.com/providers/kafka/strimzi.go
+++ b/controllers/cloud.redhat.com/providers/kafka/strimzi.go
@@ -339,19 +339,19 @@ func (s *strimziProvider) configureKafkaCluster() error {
 						Labels: &klabels,
 					},
 				},
-			},
-			TopicOperator: &strimzi.KafkaSpecEntityOperatorTopicOperator{
-				Resources: &strimzi.KafkaSpecEntityOperatorTopicOperatorResources{
-					Requests: &entityTopicRequests,
-					Limits:   &entityTopicLimits,
-				},
-				JvmOptions: &strimzi.KafkaSpecEntityOperatorTopicOperatorJvmOptions{
-					JavaSystemProperties: []strimzi.KafkaSpecEntityOperatorTopicOperatorJvmOptionsJavaSystemPropertiesElem{
+				TopicOperatorContainer: &strimzi.KafkaSpecEntityOperatorTemplateTopicOperatorContainer{
+					Env: []strimzi.KafkaSpecEntityOperatorTemplateTopicOperatorContainerEnvElem{
 						{
 							Name:  utils.StringPtr("STRIMZI_USE_FINALIZERS"),
 							Value: utils.StringPtr("false"),
 						},
 					},
+				},
+			},
+			TopicOperator: &strimzi.KafkaSpecEntityOperatorTopicOperator{
+				Resources: &strimzi.KafkaSpecEntityOperatorTopicOperatorResources{
+					Requests: &entityTopicRequests,
+					Limits:   &entityTopicLimits,
 				},
 			},
 			UserOperator: &strimzi.KafkaSpecEntityOperatorUserOperator{

--- a/controllers/cloud.redhat.com/providers/kafka/strimzi.go
+++ b/controllers/cloud.redhat.com/providers/kafka/strimzi.go
@@ -369,6 +369,17 @@ func (s *strimziProvider) configureKafkaCluster() error {
 		},
 	}
 
+	if clowderconfig.LoadedConfig.Features.EnableStrimziFinalizerUse {
+		k.Spec.EntityOperator.Template = KafkaSpecEntityOperatorTemplateTopicOperatorContainer{{
+			Env: []strimzi.KafkaSpecEntityOperatorTemplateTopicOperatorContainerEnvElem{
+				{
+					Name:  utils.StringPtr("STRIMZI_USE_FINALIZERS"),
+					Value: utils.StringPtr("true"),
+				},
+			},
+		},
+	}
+
 	if s.Env.Spec.Providers.Kafka.Cluster.Config != nil && len(*s.Env.Spec.Providers.Kafka.Cluster.Config) != 0 {
 		jsonData, err := json.Marshal(s.Env.Spec.Providers.Kafka.Cluster.Config)
 		if err != nil {

--- a/controllers/cloud.redhat.com/providers/kafka/strimzi.go
+++ b/controllers/cloud.redhat.com/providers/kafka/strimzi.go
@@ -293,7 +293,7 @@ func (s *strimziProvider) configureKafkaCluster() error {
 
 	var useFinalizersEnv []strimzi.KafkaSpecEntityOperatorTemplateTopicOperatorContainerEnvElem
 
-	if clowderconfig.LoadedConfig.Features.EnableStrimziFinalizer {
+	if clowderconfig.LoadedConfig.Features.DisableStrimziFinalizer {
 		useFinalizersEnv = []strimzi.KafkaSpecEntityOperatorTemplateTopicOperatorContainerEnvElem{
 			{
 				Name:  utils.StringPtr("STRIMZI_USE_FINALIZERS"),

--- a/controllers/cloud.redhat.com/providers/kafka/strimzi.go
+++ b/controllers/cloud.redhat.com/providers/kafka/strimzi.go
@@ -345,6 +345,14 @@ func (s *strimziProvider) configureKafkaCluster() error {
 					Requests: &entityTopicRequests,
 					Limits:   &entityTopicLimits,
 				},
+				JvmOptions: &strimzi.KafkaSpecEntityOperatorTopicOperatorJvmOptions{
+					JavaSystemProperties: []strimzi.KafkaSpecEntityOperatorTopicOperatorJvmOptionsJavaSystemPropertiesElem{
+						{
+							Name:  utils.StringPtr("STRIMZI_USE_FINALIZERS"),
+							Value: utils.StringPtr("false"),
+						},
+					},
+				},
 			},
 			UserOperator: &strimzi.KafkaSpecEntityOperatorUserOperator{
 				Resources: &strimzi.KafkaSpecEntityOperatorUserOperatorResources{


### PR DESCRIPTION
In ephemeral environments, when a namespace is cleaned up, the topics operator gets removed before handling cleanup of the topics within the namespace. These topics contain a finalizer on them and are forcing namespaces to get stuck in `deleting` status. 

Per these [docs](https://strimzi.io/blog/2023/11/02/unidirectional-topic-operator/), we need to add the following to the topics operator deployment template to ensure finalizers aren't added to the topics:
```
spec:
  template:
    spec:
      containers:
        - name: STRIMZI_USE_FINALIZERS
          value: "false"
```