### PR TITLE
Update Go version to 1.22.7

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.21.13-1.1727869850 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.22.7-5 as builder
 USER 0
 RUN dnf install -y openssh-clients git make which jq python3
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RedHatInsights/clowder
 
-go 1.21.9
+go 1.22.7
 
 require (
 	github.com/RedHatInsights/crc-caddy-plugin v0.4.0


### PR DESCRIPTION
- Update go version to 1.22.7
- Update go toolset builder image to latest available