### PR TITLE
Supports `db.ca_cert` in appinterface db secrets

### DIFF
--- a/controllers/cloud.redhat.com/providers/database/appinterface_test.go
+++ b/controllers/cloud.redhat.com/providers/database/appinterface_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAppInterfaceDb(t *testing.T) {
 	dbName := "test-db"
+	dbNameWithCa := "test-db-with-ca"
 	secrets := []core.Secret{{
 		Data: map[string][]byte{
 			"db.host":     []byte(fmt.Sprintf("%s-prod.amazing.aws.amazon.com", dbName)),
@@ -19,16 +20,36 @@ func TestAppInterfaceDb(t *testing.T) {
 			"db.password": []byte("password"),
 			"db.name":     []byte(dbName),
 		},
-	}}
+	},
+		{
+			Data: map[string][]byte{
+				"db.host":     []byte(fmt.Sprintf("%s-prod.amazing.aws.amazon.com", dbNameWithCa)),
+				"db.port":     []byte("5432"),
+				"db.user":     []byte("user"),
+				"db.password": []byte("password"),
+				"db.name":     []byte(dbNameWithCa),
+				"db.ca_cert":  []byte("im-a-cert"),
+			},
+		},
+	}
 
 	configs, err := genDbConfigs(secrets, false)
 
 	assert.NoError(t, err, "failed to gen db config")
-	assert.Equal(t, len(configs), 1, "wrong number of configs")
+	assert.Equal(t, len(configs), 2, "wrong number of configs")
 
 	spec := crd.DatabaseSpec{Name: dbName}
 
 	resolved := resolveDb(spec, configs)
 
 	assert.Equal(t, configs[0], resolved, "resolveDb did not match given config")
+	assert.Nil(t, resolved.Config.RdsCa, nil)
+
+	specWithCa := crd.DatabaseSpec{Name: dbNameWithCa}
+	resolvedWithCa := resolveDb(specWithCa, configs)
+
+	assert.Equal(t, configs[1], resolvedWithCa, "resolveDb did not match given config")
+	assert.NotNil(t, resolvedWithCa.Config.RdsCa)
+	assert.Equal(t, *resolvedWithCa.Config.RdsCa, "im-a-cert")
+
 }


### PR DESCRIPTION
Created this to test embedding the CA within the secret for IoP - really unsure if this is how app interface works, but apparently the CA would be embedded in the secret from what i understood here:

  https://gitlab.cee.redhat.com/service/app-interface#manage-rds-databases-via-app-interface-openshiftnamespace-1yml

Created the PR in case it would be useful, but please close it if it is not.