### PR TITLE
manually scale down a deployment without going thru zero

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
@@ -251,6 +251,10 @@ func (d *Deployment) GetReplicaCount() *int32 {
 	return &retVal
 }
 
+func (d *Deployment) HasAutoScaler() bool {
+	return d.AutoScaler != nil || d.AutoScalerSimple != nil
+}
+
 type DeploymentStrategy struct {
 	// PrivateStrategy allows a deployment that only uses a private port to set
 	// the deployment strategy one of Recreate or Rolling, default for a

--- a/controllers/cloud.redhat.com/providers/deployment/impl.go
+++ b/controllers/cloud.redhat.com/providers/deployment/impl.go
@@ -65,7 +65,14 @@ func setMinReplicas(deployment *crd.Deployment, d *apps.Deployment) {
 
 	// No sense in running all these conditionals if desired state and observed state match
 	if d.Spec.Replicas != nil && (*d.Spec.Replicas >= *replicaCount) {
-		return
+		// if deployment has an autoscaler, just keep the replica count the same it currently is
+		// since it has at least the desired count
+		if deployment.HasAutoScaler() {
+			return
+		}
+		// reset the replica count when there is no autoscaler. this will scale down a deployment that
+		// has more than desired count
+		d.Spec.Replicas = replicaCount
 	}
 
 	// If the spec has nil replicas or the spec replicas are less than the deployment replicas

--- a/tests/kuttl/test-replica-scaledown-nonzero/00-install.yaml
+++ b/tests/kuttl/test-replica-scaledown-nonzero/00-install.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-replica-scaledown-nonzero
+spec:
+  finalizers:
+  - kubernetes

--- a/tests/kuttl/test-replica-scaledown-nonzero/01-assert.yaml
+++ b/tests/kuttl/test-replica-scaledown-nonzero/01-assert.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: puptoo
+  namespace: test-replica-scaledown-nonzero
+  labels:
+    app: puptoo
+  ownerReferences:
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdApp
+    name: puptoo
+type: Opaque
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: puptoo-processor
+  namespace: test-replica-scaledown-nonzero
+spec:
+  replicas: 4

--- a/tests/kuttl/test-replica-scaledown-nonzero/01-pods.yaml
+++ b/tests/kuttl/test-replica-scaledown-nonzero/01-pods.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdEnvironment
+metadata:
+  name: test-replica-scaledown-nonzero
+spec:
+  targetNamespace: test-replica-scaledown-nonzero
+  providers:
+    web:
+      port: 8000
+      mode: operator
+    metrics:
+      port: 9000
+      mode: operator
+      path: "/metrics"
+    kafka:
+      mode: none
+    db:
+      mode: none
+    logging:
+      mode: none
+    objectStore:
+      mode: none
+    inMemoryDb:
+      mode: none
+    featureFlags:
+      mode: none
+  resourceDefaults:
+    limits:
+      cpu: 400m
+      memory: 1024Mi
+    requests:
+      cpu: 30m
+      memory: 512Mi
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: puptoo
+  namespace: test-replica-scaledown-nonzero
+spec:
+  envName: test-replica-scaledown-nonzero
+  deployments:
+  - name: processor
+    replicas: 4
+    podSpec:
+      image: quay.io/psav/clowder-hello

--- a/tests/kuttl/test-replica-scaledown-nonzero/02-assert.yaml
+++ b/tests/kuttl/test-replica-scaledown-nonzero/02-assert.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: puptoo-processor
+  namespace: test-replica-scaledown-nonzero
+spec:
+  replicas: 1

--- a/tests/kuttl/test-replica-scaledown-nonzero/02-pods.yaml
+++ b/tests/kuttl/test-replica-scaledown-nonzero/02-pods.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: puptoo
+  namespace: test-replica-scaledown-nonzero
+spec:
+  envName: test-replica-scaledown-nonzero
+  deployments:
+  - name: processor
+    replicas: 1
+    podSpec:
+      image: quay.io/psav/clowder-hello

--- a/tests/kuttl/test-replica-scaledown-nonzero/03-delete.yaml
+++ b/tests/kuttl/test-replica-scaledown-nonzero/03-delete.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: v1
+  kind: Namespace
+  name: test-replica-scaledown-nonzero
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdEnvironment
+  name: test-replica-scaledown-nonzero


### PR DESCRIPTION
This will enable a user to scale down a deployment which does not have an associated AutoScaler without scaling down to zero first.