### PR TITLE
Update Clowder to reconcile on changes to non-app secrets/configmaps

### DIFF
--- a/controllers/cloud.redhat.com/clowdenvironment_controller.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_controller.go
@@ -165,6 +165,7 @@ func (r *ClowdEnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		env:       &env,
 		log:       &log,
 		oldStatus: env.Status.DeepCopy(),
+		hashCache: r.HashCache,
 	}
 
 	result, resErr := reconciliation.Reconcile()

--- a/controllers/cloud.redhat.com/clowdenvironment_reconciliation.go
+++ b/controllers/cloud.redhat.com/clowdenvironment_reconciliation.go
@@ -7,6 +7,7 @@ import (
 
 	crd "github.com/RedHatInsights/clowder/apis/cloud.redhat.com/v1alpha1"
 	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/clowderconfig"
+	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/hashcache"
 	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/providers"
 	rc "github.com/RedHatInsights/rhc-osdk-utils/resourceCache"
 	"github.com/go-logr/logr"
@@ -57,6 +58,7 @@ type ClowdEnvironmentReconciliation struct {
 	env       *crd.ClowdEnvironment
 	log       *logr.Logger
 	oldStatus *crd.ClowdEnvironmentStatus
+	hashCache *hashcache.HashCache
 }
 
 // Returns a list of step methods that should be run during reconciliation
@@ -285,6 +287,9 @@ func (r *ClowdEnvironmentReconciliation) isTargetNamespaceMarkedForDeletion() (c
 }
 
 func (r *ClowdEnvironmentReconciliation) runProviders() (ctrl.Result, error) {
+
+	r.hashCache.RemoveClowdObjectFromObjects(r.env)
+
 	provider := providers.Provider{
 		Ctx:    r.ctx,
 		Client: r.client,

--- a/controllers/cloud.redhat.com/handlers.go
+++ b/controllers/cloud.redhat.com/handlers.go
@@ -106,7 +106,15 @@ func (e *enqueueRequestForObjectCustom) updateHashCacheForConfigMapAndSecret(obj
 	switch obj.(type) {
 	case *core.ConfigMap, *core.Secret:
 		if obj.GetAnnotations()[clowderconfig.LoadedConfig.Settings.RestarterAnnotationName] == "true" {
-			return e.hashCache.CreateOrUpdateObject(obj)
+			return e.hashCache.CreateOrUpdateObject(obj, false)
+		} else {
+			hcOjb, err := e.hashCache.Read(obj)
+			if err != nil {
+				return false, err
+			}
+			if hcOjb.Always {
+				return e.hashCache.CreateOrUpdateObject(obj, false)
+			}
 		}
 	}
 	return false, nil

--- a/controllers/cloud.redhat.com/hashcache/hashcache_test.go
+++ b/controllers/cloud.redhat.com/hashcache/hashcache_test.go
@@ -21,7 +21,7 @@ func TestHashCacheAddItemAndRetrieve(t *testing.T) {
 	}
 
 	hc := NewHashCache()
-	update, err := hc.CreateOrUpdateObject(sec)
+	update, err := hc.CreateOrUpdateObject(sec, false)
 	assert.NoError(t, err)
 	assert.True(t, update)
 	obj, err := hc.Read(sec)
@@ -39,7 +39,7 @@ func TestHashCacheDeleteItem(t *testing.T) {
 	}
 
 	hc := NewHashCache()
-	shouldUpdate, err := hc.CreateOrUpdateObject(sec)
+	shouldUpdate, err := hc.CreateOrUpdateObject(sec, false)
 	assert.True(t, shouldUpdate)
 	assert.NoError(t, err)
 	obj, err := hc.Read(sec)
@@ -63,7 +63,7 @@ func TestHashCacheUpdateItem(t *testing.T) {
 	}
 
 	hc := NewHashCache()
-	_, err := hc.CreateOrUpdateObject(sec)
+	_, err := hc.CreateOrUpdateObject(sec, false)
 	assert.NoError(t, err)
 
 	obj, err := hc.Read(sec)
@@ -75,7 +75,7 @@ func TestHashCacheUpdateItem(t *testing.T) {
 		"test2": []byte("test2"),
 	}
 
-	update, err := hc.CreateOrUpdateObject(sec)
+	update, err := hc.CreateOrUpdateObject(sec, false)
 	assert.NoError(t, err)
 	assert.True(t, update)
 	obj, err = hc.Read(sec)
@@ -120,7 +120,7 @@ func TestHashCacheAddClowdObj(t *testing.T) {
 	}
 
 	hc := NewHashCache()
-	_, err := hc.CreateOrUpdateObject(sec)
+	_, err := hc.CreateOrUpdateObject(sec, false)
 	assert.NoError(t, err)
 
 	err = hc.AddClowdObjectToObject(capp, sec)
@@ -152,7 +152,7 @@ func TestHashCacheDeleteClowdObj(t *testing.T) {
 	}
 
 	hc := NewHashCache()
-	_, err := hc.CreateOrUpdateObject(sec)
+	_, err := hc.CreateOrUpdateObject(sec, false)
 	assert.NoError(t, err)
 
 	err = hc.AddClowdObjectToObject(capp, sec)
@@ -196,7 +196,7 @@ func TestHashCacheSuperCache(t *testing.T) {
 	}
 
 	hc := NewHashCache()
-	_, err := hc.CreateOrUpdateObject(sec)
+	_, err := hc.CreateOrUpdateObject(sec, false)
 	assert.NoError(t, err)
 	err = hc.AddClowdObjectToObject(capp, sec)
 	assert.NoError(t, err)
@@ -204,7 +204,7 @@ func TestHashCacheSuperCache(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, obj.ClowdApps, clowdObjNamespaceName)
 
-	_, err = hc.CreateOrUpdateObject(sec2)
+	_, err = hc.CreateOrUpdateObject(sec2, false)
 	assert.NoError(t, err)
 	err = hc.AddClowdObjectToObject(capp, sec2)
 	assert.NoError(t, err)

--- a/controllers/cloud.redhat.com/providers/kafka/appinterface.go
+++ b/controllers/cloud.redhat.com/providers/kafka/appinterface.go
@@ -51,8 +51,15 @@ func (a *appInterface) setKafkaCA(broker *config.BrokerConfig) error {
 			return err
 		}
 
-		a.HashCache.CreateOrUpdateObject(&kafkaCASecret, true)
-		a.HashCache.AddClowdObjectToObject(a.Env, &kafkaCASecret)
+		_, err := a.HashCache.CreateOrUpdateObject(&kafkaCASecret, true)
+		if err != nil {
+			return err
+		}
+
+		err = a.HashCache.AddClowdObjectToObject(a.Env, &kafkaCASecret)
+		if err != nil {
+			return err
+		}
 
 		broker.Cacert = utils.StringPtr(string(kafkaCASecret.Data["ca.crt"]))
 		broker.Port = utils.IntPtr(9093)

--- a/controllers/cloud.redhat.com/providers/kafka/appinterface.go
+++ b/controllers/cloud.redhat.com/providers/kafka/appinterface.go
@@ -51,6 +51,9 @@ func (a *appInterface) setKafkaCA(broker *config.BrokerConfig) error {
 			return err
 		}
 
+		a.HashCache.CreateOrUpdateObject(&kafkaCASecret, true)
+		a.HashCache.AddClowdObjectToObject(a.Env, &kafkaCASecret)
+
 		broker.Cacert = utils.StringPtr(string(kafkaCASecret.Data["ca.crt"]))
 		broker.Port = utils.IntPtr(9093)
 		broker.SecurityProtocol = utils.StringPtr("SSL")


### PR DESCRIPTION
* Add hashCache to the Environment reconciler for usage later
* Remove all Secrets/ConfigMaps from Environment at start of reconciliation cycle
* Embue HashObject with the always flag
* Change updateHashCacheForConfigMapAndSecret to try to read in the sec/config and return true if always set
* Slight concern of erroring if not in the cache, but
* Make app_interface add the secret to the cache at the start of reconciliation so it should be there, and also link the objects.