### PR TITLE
[RHCLOUD-36096] Document TLS enabled if inMemoryDb.password is returned

### DIFF
--- a/controllers/cloud.redhat.com/providers/inmemorydb/elasticache.go
+++ b/controllers/cloud.redhat.com/providers/inmemorydb/elasticache.go
@@ -53,6 +53,8 @@ func (e *elasticache) Provide(app *crd.ClowdApp) error {
 				)
 			}
 
+			// ElastiCache and Terraform resources, via qontract-reconcile, guarantee that `db.auth_token` is provided
+			// only if in-transit encryption is enabled.
 			passwd := string(secret.Data["db.auth_token"])
 			if passwd != "" {
 				creds.Password = &passwd

--- a/docs/providers/inmemorydb.md
+++ b/docs/providers/inmemorydb.md
@@ -39,7 +39,7 @@ ClowdEnv Config options available:
 In elasticache mode, the *In-Memory DB Provider* will search for a secret named
 `in-memory-db` inside the same namespace as the `ClowdApp` that requested it.
 The hostname and port will then be passed to the `cdappconfig.json` for use by
-the app.
+the app. If a password is provided, it is known that in-transit encryption is enabled, as per [ElastiCache requirements](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/auth.html#auth-using).
 
 ## Generated App Configuration
 


### PR DESCRIPTION
## JIRA issue

https://issues.redhat.com/browse/RHCLOUD-36096

## Background

Notifications is loading its ElastiCache configuration via Clowder (see https://github.com/RedHatInsights/clowder-quarkus-config-source/pull/291). We plan to use in-transit encryption (TLS), which requires a URI scheme of `rediss://`. However, we cannot use TLS for our test suite, and it's ~~impossible~~ very difficult to find a way to consistently rewrite the URL.

The easiest fix is to have the ConfigSource set the correct scheme when it knows TLS is being used. After reviewing [Elasticache documentation](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/auth.html#auth-using), the [qontract-reconcile code](https://github.com/app-sre/qontract-reconcile/blob/e43e0200a68608089bc28e65a54431a10ab61309/reconcile/utils/terrascript_aws_client.py#L2546-L2557), and internal documentation, it's clear that `db.auth_token` can only be generated and provided when in-transit encryption is enabled. While the reverse is not necessarily true, this is enough for our purposes.

## Description

Add a comment to the ElastiCache provider, and update the In-Memory DB docs, to publicly confirm that if the `.inMemoryDb.password` field in `cdappconfig.json`, then it is known that in-transit encryption is enabled.