### PR TITLE
Update strimzi-client-go to v0.38.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/RedHatInsights/cyndi-operator v0.1.12
 	github.com/RedHatInsights/go-difflib v1.0.0
 	github.com/RedHatInsights/rhc-osdk-utils v0.12.0
-	github.com/RedHatInsights/strimzi-client-go v0.34.2
+	github.com/RedHatInsights/strimzi-client-go v0.38.0
 	github.com/caddyserver/caddy/v2 v2.8.4
 	github.com/cert-manager/cert-manager v1.12.14
 	github.com/go-logr/logr v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/RedHatInsights/go-difflib v1.0.0 h1:BoruyjZfxO81sEynhkG6c4SMAQOjuBWez
 github.com/RedHatInsights/go-difflib v1.0.0/go.mod h1:UMKOFdypYfrKT1B1nbGodM09nhOiAmcjes8qWP7Myrs=
 github.com/RedHatInsights/rhc-osdk-utils v0.12.0 h1:hjJ+U7a+/BCXQb7Y/CIpERv5Cm9wIY1VaPkQkBATWW8=
 github.com/RedHatInsights/rhc-osdk-utils v0.12.0/go.mod h1:5UYiKYXToQB1KN2Pxr27p6Y10w+XrJYzCoMcIOhQBl8=
-github.com/RedHatInsights/strimzi-client-go v0.34.2 h1:6DJJc/spMBRwC8jKLYRDoYzCYLXy2+NV1J4t0Ui46u0=
-github.com/RedHatInsights/strimzi-client-go v0.34.2/go.mod h1:7OPvvx8wg6NrP+3wbBoRlrE5UB0N0m3xeR/PZ2ofSHM=
+github.com/RedHatInsights/strimzi-client-go v0.38.0 h1:p6TMI2Cg9dkHyw4uV3hsMpBNuFn+RAlT85IJpGRgMY8=
+github.com/RedHatInsights/strimzi-client-go v0.38.0/go.mod h1:aOsHx9Lu4ZvS3KR+j6/X+uiyweX594098CYDEdg8kYM=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=

--- a/tests/kuttl/test-annotations-job/00-install.yaml
+++ b/tests/kuttl/test-annotations-job/00-install.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: test-clowder-jobs
+  name: test-annotations-job
 spec:
   finalizers:
   - kubernetes

--- a/tests/kuttl/test-annotations-job/01-assert.yaml
+++ b/tests/kuttl/test-annotations-job/01-assert.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: puptoo
-  namespace: test-clowder-jobs
+  namespace: test-annotations-job
   labels:
     app: puptoo
   ownerReferences:
@@ -16,13 +16,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: puptoo-processor
-  namespace: test-clowder-jobs
+  namespace: test-annotations-job
 ---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: puptoo-standard-cron
-  namespace: test-clowder-jobs
+  namespace: test-annotations-job
   annotations:
     CustomAnnotation: "Much Annotate. Very inform."
 spec:
@@ -55,7 +55,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: puptoo-suspend-cron
-  namespace: test-clowder-jobs
+  namespace: test-annotations-job
   annotations:
     CustomAnnotation: "Much Annotate. Very inform."
 spec:
@@ -82,7 +82,7 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: puptoo-restart-on-failure
-  namespace: test-clowder-jobs
+  namespace: test-annotations-job
   annotations:
     CustomAnnotation: "Much Annotate. Very inform."
 spec:
@@ -105,7 +105,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  namespace: test-clowder-jobs
+  namespace: test-annotations-job
   labels:
     job: puptoo-hello-cji
   annotations:

--- a/tests/kuttl/test-annotations-job/01-pods.yaml
+++ b/tests/kuttl/test-annotations-job/01-pods.yaml
@@ -2,9 +2,9 @@
 apiVersion: cloud.redhat.com/v1alpha1
 kind: ClowdEnvironment
 metadata:
-  name: test-clowder-jobs
+  name: test-annotations-job
 spec:
-  targetNamespace: test-clowder-jobs
+  targetNamespace: test-annotations-job
   providers:
     web:
       port: 8000
@@ -37,11 +37,11 @@ apiVersion: cloud.redhat.com/v1alpha1
 kind: ClowdApp
 metadata:
   name: puptoo
-  namespace: test-clowder-jobs
+  namespace: test-annotations-job
   annotations:
     CustomAnnotation: "Much Annotate. Very inform."
 spec:
-  envName: test-clowder-jobs
+  envName: test-annotations-job
   deployments:
     - name: processor
       podSpec:
@@ -49,7 +49,7 @@ spec:
   jobs:
     - name: standard-cron
       schedule: "*/1 * * * *"
-      suspend: false 
+      suspend: false
       successfulJobsHistoryLimit: 2
       failedJobsHistoryLimit: 2
       activeDeadlineSeconds: 6000
@@ -69,7 +69,7 @@ spec:
         args:
           - ./clowder-hello
           - boo
-    - name: restart-on-failure 
+    - name: restart-on-failure
       schedule: "*/1 * * * *"
       restartPolicy: OnFailure
       podSpec:
@@ -95,7 +95,7 @@ apiVersion: cloud.redhat.com/v1alpha1
 kind: ClowdJobInvocation
 metadata:
   name: runner
-  namespace: test-clowder-jobs
+  namespace: test-annotations-job
 spec:
   appName: puptoo
   jobs:

--- a/tests/kuttl/test-annotations-job/02-json-asserts.yaml
+++ b/tests/kuttl/test-annotations-job/02-json-asserts.yaml
@@ -3,9 +3,9 @@ apiVersion: kuttl.dev/v1alpha1
 kind: TestStep
 commands:
 - script: sleep 90
-- script: kubectl get pod -l app=puptoo -l pod=puptoo-standard-cron -n test-clowder-jobs -o json > /tmp/test-clowder-jobs
-- script: kubectl logs `jq -r '.items[0].metadata.name' < /tmp/test-clowder-jobs` -n test-clowder-jobs > /tmp/test-clowder-jobs-output
-- script: grep "Hi" /tmp/test-clowder-jobs-output
-- script: kubectl get pod -l app=puptoo -l job=puptoo-hello-cji -n test-clowder-jobs -o json > /tmp/test-clowder-jobs
-- script: kubectl logs `jq -r '.items[0].metadata.name' < /tmp/test-clowder-jobs` -n test-clowder-jobs > /tmp/test-clowder-jobs-output-hello-cji-runner
-- script: grep "Hello!" /tmp/test-clowder-jobs-output-hello-cji-runner
+- script: kubectl get pod -l app=puptoo -l pod=puptoo-standard-cron -n test-annotations-job -o json > /tmp/test-annotations-job
+- script: kubectl logs `jq -r '.items[0].metadata.name' < /tmp/test-annotations-job` -n test-annotations-job > /tmp/test-annotations-job-output
+- script: grep "Hi" /tmp/test-annotations-job-output
+- script: kubectl get pod -l app=puptoo -l job=puptoo-hello-cji -n test-annotations-job -o json > /tmp/test-annotations-job
+- script: kubectl logs `jq -r '.items[0].metadata.name' < /tmp/test-annotations-job` -n test-annotations-job > /tmp/test-annotations-job-output-hello-cji-runner
+- script: grep "Hello!" /tmp/test-annotations-job-output-hello-cji-runner

--- a/tests/kuttl/test-annotations-job/03-delete.yaml
+++ b/tests/kuttl/test-annotations-job/03-delete.yaml
@@ -4,7 +4,7 @@ kind: TestStep
 delete:
 - apiVersion: v1
   kind: Namespace
-  name: test-clowder-jobs
+  name: test-annotations-job
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdEnvironment
-  name: test-clowder-jobs
+  name: test-annotations-job


### PR DESCRIPTION
This puts the client in line with AMQ Streams 2.6 (which is based on strimzi v0.38.0)