### PR TITLE
Fix redis valkey transition

### DIFF
--- a/controllers/cloud.redhat.com/providers/featureflags/localfeatureflags.go
+++ b/controllers/cloud.redhat.com/providers/featureflags/localfeatureflags.go
@@ -91,7 +91,7 @@ func (ff *localFeatureFlagsProvider) EnvProvide() error {
 		LocalFFService,
 	}
 
-	if err := providers.CachedMakeComponent(ff.Cache, objList, ff.Env, "featureflags", makeLocalFeatureFlags, false, ff.Env.IsNodePort()); err != nil {
+	if err := providers.CachedMakeComponent(ff.Cache, objList, ff.Env, ff.Env, "featureflags", makeLocalFeatureFlags, false, ff.Env.IsNodePort()); err != nil {
 		return err
 	}
 
@@ -100,7 +100,7 @@ func (ff *localFeatureFlagsProvider) EnvProvide() error {
 		LocalFFEdgeService,
 	}
 
-	if err := providers.CachedMakeComponent(ff.Cache, objList2, ff.Env, "featureflags-edge", makeLocalFeatureFlagsEdge, false, ff.Env.IsNodePort()); err != nil {
+	if err := providers.CachedMakeComponent(ff.Cache, objList2, ff.Env, ff.Env, "featureflags-edge", makeLocalFeatureFlagsEdge, false, ff.Env.IsNodePort()); err != nil {
 		return err
 	}
 
@@ -229,7 +229,7 @@ func (ff *localFeatureFlagsProvider) Provide(_ *crd.ClowdApp) error {
 	return nil
 }
 
-func makeLocalFeatureFlags(o obj.ClowdObject, objMap providers.ObjectMap, _ bool, nodePort bool) error {
+func makeLocalFeatureFlags(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMap providers.ObjectMap, _ bool, nodePort bool) error {
 	nn := providers.GetNamespacedName(o, "featureflags")
 
 	dd := objMap[LocalFFDeployment].(*apps.Deployment)
@@ -340,7 +340,7 @@ func makeLocalFeatureFlags(o obj.ClowdObject, objMap providers.ObjectMap, _ bool
 	return nil
 }
 
-func makeLocalFeatureFlagsEdge(o obj.ClowdObject, objMap providers.ObjectMap, _ bool, nodePort bool) error {
+func makeLocalFeatureFlagsEdge(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMap providers.ObjectMap, _ bool, nodePort bool) error {
 
 	nnFF := providers.GetNamespacedName(o, "featureflags")
 	nn := providers.GetNamespacedName(o, "featureflags-edge")

--- a/controllers/cloud.redhat.com/providers/featureflags/localfeatureflags.go
+++ b/controllers/cloud.redhat.com/providers/featureflags/localfeatureflags.go
@@ -91,7 +91,7 @@ func (ff *localFeatureFlagsProvider) EnvProvide() error {
 		LocalFFService,
 	}
 
-	if err := providers.CachedMakeComponent(ff.Cache, objList, ff.Env, ff.Env, "featureflags", makeLocalFeatureFlags, false, ff.Env.IsNodePort()); err != nil {
+	if err := providers.CachedMakeComponent(ff, objList, ff.Env, "featureflags", makeLocalFeatureFlags, false); err != nil {
 		return err
 	}
 
@@ -100,7 +100,7 @@ func (ff *localFeatureFlagsProvider) EnvProvide() error {
 		LocalFFEdgeService,
 	}
 
-	if err := providers.CachedMakeComponent(ff.Cache, objList2, ff.Env, ff.Env, "featureflags-edge", makeLocalFeatureFlagsEdge, false, ff.Env.IsNodePort()); err != nil {
+	if err := providers.CachedMakeComponent(ff, objList2, ff.Env, "featureflags-edge", makeLocalFeatureFlagsEdge, false); err != nil {
 		return err
 	}
 

--- a/controllers/cloud.redhat.com/providers/inmemorydb/redis.go
+++ b/controllers/cloud.redhat.com/providers/inmemorydb/redis.go
@@ -86,7 +86,7 @@ func (r *localRedis) Provide(app *crd.ClowdApp) error {
 		RedisService,
 	}
 
-	return providers.CachedMakeComponent(r.Provider.Cache, objList, r.Env, app, "redis", makeLocalRedis, false, r.Env.IsNodePort())
+	return providers.CachedMakeComponent(r, objList, app, "redis", makeLocalRedis, false)
 }
 
 func makeLocalRedis(env *crd.ClowdEnvironment, o obj.ClowdObject, objMap providers.ObjectMap, _ bool, nodePort bool) error {

--- a/controllers/cloud.redhat.com/providers/inmemorydb/redis.go
+++ b/controllers/cloud.redhat.com/providers/inmemorydb/redis.go
@@ -86,10 +86,10 @@ func (r *localRedis) Provide(app *crd.ClowdApp) error {
 		RedisService,
 	}
 
-	return providers.CachedMakeComponent(r.Provider.Cache, objList, app, "redis", makeLocalRedis, false, r.Env.IsNodePort())
+	return providers.CachedMakeComponent(r.Provider.Cache, objList, r.Env, app, "redis", makeLocalRedis, false, r.Env.IsNodePort())
 }
 
-func makeLocalRedis(o obj.ClowdObject, objMap providers.ObjectMap, _ bool, nodePort bool) error {
+func makeLocalRedis(env *crd.ClowdEnvironment, o obj.ClowdObject, objMap providers.ObjectMap, _ bool, nodePort bool) error {
 	nn := providers.GetNamespacedName(o, "redis")
 
 	dd := objMap[RedisDeployment].(*apps.Deployment)
@@ -147,7 +147,7 @@ func makeLocalRedis(o obj.ClowdObject, objMap providers.ObjectMap, _ bool, nodeP
 
 	dd.Spec.Template.Spec.Containers = []core.Container{{
 		Name:  nn.Name,
-		Image: providerUtils.GetInMemoryDBImage(o),
+		Image: providerUtils.GetInMemoryDBImage(env),
 		Env:   []core.EnvVar{},
 		Ports: []core.ContainerPort{{
 			Name:          "redis",

--- a/controllers/cloud.redhat.com/providers/inmemorydb/redis_test.go
+++ b/controllers/cloud.redhat.com/providers/inmemorydb/redis_test.go
@@ -37,7 +37,7 @@ func TestLocalRedis(t *testing.T) {
 		RedisDeployment: &dd,
 		RedisService:    &svc,
 	}
-	_ = makeLocalRedis(&env, objMap, true, false)
+	_ = makeLocalRedis(&env, &env, objMap, true, false)
 
 	assert.Equal(t, "env-redis", dd.GetName(), "name was not set correctly")
 	assert.Len(t, svc.Spec.Ports, 1, "number of ports specified is wrong")
@@ -53,7 +53,7 @@ func TestLocalRedisImageOverride(t *testing.T) {
 		RedisDeployment: &dd,
 		RedisService:    &svc,
 	}
-	_ = makeLocalRedis(&env, objMap, true, false)
+	_ = makeLocalRedis(&env, &env, objMap, true, false)
 
 	assert.Equal(t, "env-redis", dd.GetName(), "name was not set correctly")
 	assert.Len(t, svc.Spec.Ports, 1, "number of ports specified is wrong")

--- a/controllers/cloud.redhat.com/providers/objectstore/minio.go
+++ b/controllers/cloud.redhat.com/providers/objectstore/minio.go
@@ -83,7 +83,7 @@ func NewMinIO(p *providers.Provider) (providers.ClowderProvider, error) {
 		minioCacheMap = append(minioCacheMap, MinioPVC)
 	}
 
-	err = providers.CachedMakeComponent(p.Cache, minioCacheMap, p.Env, p.Env, "minio", makeLocalMinIO, p.Env.Spec.Providers.ObjectStore.PVC, p.Env.IsNodePort())
+	err = providers.CachedMakeComponent(p, minioCacheMap, p.Env, "minio", makeLocalMinIO, p.Env.Spec.Providers.ObjectStore.PVC)
 
 	if err != nil {
 		raisedErr := errors.Wrap("Couldn't make component", err)

--- a/controllers/cloud.redhat.com/providers/objectstore/minio.go
+++ b/controllers/cloud.redhat.com/providers/objectstore/minio.go
@@ -83,7 +83,7 @@ func NewMinIO(p *providers.Provider) (providers.ClowderProvider, error) {
 		minioCacheMap = append(minioCacheMap, MinioPVC)
 	}
 
-	err = providers.CachedMakeComponent(p.Cache, minioCacheMap, p.Env, "minio", makeLocalMinIO, p.Env.Spec.Providers.ObjectStore.PVC, p.Env.IsNodePort())
+	err = providers.CachedMakeComponent(p.Cache, minioCacheMap, p.Env, p.Env, "minio", makeLocalMinIO, p.Env.Spec.Providers.ObjectStore.PVC, p.Env.IsNodePort())
 
 	if err != nil {
 		raisedErr := errors.Wrap("Couldn't make component", err)
@@ -278,7 +278,7 @@ func createNetworkPolicy(p *providers.Provider) error {
 	return p.Cache.Update(MinioNetworkPolicy, np)
 }
 
-func makeLocalMinIO(o obj.ClowdObject, objMap providers.ObjectMap, usePVC bool, nodePort bool) error {
+func makeLocalMinIO(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMap providers.ObjectMap, usePVC bool, nodePort bool) error {
 	nn := providers.GetNamespacedName(o, "minio")
 
 	dd := objMap[MinioDeployment].(*apps.Deployment)

--- a/controllers/cloud.redhat.com/providers/providers.go
+++ b/controllers/cloud.redhat.com/providers/providers.go
@@ -128,7 +128,7 @@ type ClowderProvider interface {
 	GetConfig() *config.AppConfig
 }
 
-type makeFnCache func(o obj.ClowdObject, objMap ObjectMap, usePVC bool, nodePort bool) error
+type makeFnCache func(env *crd.ClowdEnvironment, o obj.ClowdObject, objMap ObjectMap, usePVC bool, nodePort bool) error
 
 func createResource(cache *rc.ObjectCache, resourceIdent rc.ResourceIdent, nn types.NamespacedName) (client.Object, error) {
 	gvks, nok, err := cache.GetScheme().ObjectKinds(resourceIdent.GetType())
@@ -184,7 +184,7 @@ type ObjectMap map[rc.ResourceIdent]client.Object
 
 // CachedMakeComponent is a generalised function that, given a ClowdObject will make the given service,
 // deployment and PVC, based on the makeFn that is passed in.
-func CachedMakeComponent(cache *rc.ObjectCache, objList []rc.ResourceIdent, o obj.ClowdObject, suffix string, fn makeFnCache, usePVC bool, nodePort bool) error {
+func CachedMakeComponent(cache *rc.ObjectCache, objList []rc.ResourceIdent, env *crd.ClowdEnvironment, o obj.ClowdObject, suffix string, fn makeFnCache, usePVC bool, nodePort bool) error {
 	nn := GetNamespacedName(o, suffix)
 
 	makeFnMap := make(map[rc.ResourceIdent]client.Object)
@@ -200,7 +200,7 @@ func CachedMakeComponent(cache *rc.ObjectCache, objList []rc.ResourceIdent, o ob
 
 	}
 
-	err := fn(o, makeFnMap, usePVC, nodePort)
+	err := fn(env, o, makeFnMap, usePVC, nodePort)
 	if err != nil {
 		return fmt.Errorf("could not make component: %w", err)
 	}

--- a/controllers/cloud.redhat.com/providers/utils/utils.go
+++ b/controllers/cloud.redhat.com/providers/utils/utils.go
@@ -173,11 +173,9 @@ func MakeLocalDBPVC(pvc *core.PersistentVolumeClaim, nn types.NamespacedName, ba
 	utils.MakePVC(pvc, nn, providers.Labels{"service": "db", "app": baseResource.GetClowdName()}, capacity, baseResource)
 }
 
-func GetInMemoryDBImage(o obj.ClowdObject) string {
-	if env, ok := o.(*crd.ClowdEnvironment); ok {
-		if env.Spec.Providers.InMemoryDB.Image != "" {
-			return env.Spec.Providers.InMemoryDB.Image
-		}
+func GetInMemoryDBImage(env *crd.ClowdEnvironment) string {
+	if env.Spec.Providers.InMemoryDB.Image != "" {
+		return env.Spec.Providers.InMemoryDB.Image
 	}
 	if clowderconfig.LoadedConfig.Images.InMemoryDB != "" {
 		return clowderconfig.LoadedConfig.Images.InMemoryDB

--- a/controllers/cloud.redhat.com/providers/web/resources_caddygateway.go
+++ b/controllers/cloud.redhat.com/providers/web/resources_caddygateway.go
@@ -72,7 +72,7 @@ func configureWebGateway(web *localWebProvider) error {
 		WebGatewayService,
 	}
 
-	if err := providers.CachedMakeComponent(web.Cache, objList, web.Env, web.Env, "caddy-gateway", makeWebGatewayDeployment, false, web.Env.IsNodePort()); err != nil {
+	if err := providers.CachedMakeComponent(web, objList, web.Env, "caddy-gateway", makeWebGatewayDeployment, false); err != nil {
 		return err
 	}
 

--- a/controllers/cloud.redhat.com/providers/web/resources_caddygateway.go
+++ b/controllers/cloud.redhat.com/providers/web/resources_caddygateway.go
@@ -72,7 +72,7 @@ func configureWebGateway(web *localWebProvider) error {
 		WebGatewayService,
 	}
 
-	if err := providers.CachedMakeComponent(web.Cache, objList, web.Env, "caddy-gateway", makeWebGatewayDeployment, false, web.Env.IsNodePort()); err != nil {
+	if err := providers.CachedMakeComponent(web.Cache, objList, web.Env, web.Env, "caddy-gateway", makeWebGatewayDeployment, false, web.Env.IsNodePort()); err != nil {
 		return err
 	}
 
@@ -317,7 +317,7 @@ func makeWebGatewayConfigMap(p *providers.Provider) (string, error) {
 	return hash, p.Cache.Update(CoreCaddyConfigMap, cm)
 }
 
-func makeWebGatewayDeployment(o obj.ClowdObject, objMap providers.ObjectMap, _ bool, _ bool) error {
+func makeWebGatewayDeployment(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMap providers.ObjectMap, _ bool, _ bool) error {
 	nn := providers.GetNamespacedName(o, "caddy-gateway")
 
 	dd := objMap[WebGatewayDeployment].(*apps.Deployment)

--- a/controllers/cloud.redhat.com/providers/web/resources_keycloak.go
+++ b/controllers/cloud.redhat.com/providers/web/resources_keycloak.go
@@ -187,7 +187,7 @@ func configureKeycloak(web *localWebProvider) error {
 		WebKeycloakService,
 	}
 
-	if err := providers.CachedMakeComponent(web.Cache, objList, web.Env, web.Env, "keycloak", makeKeycloak, false, web.Env.IsNodePort()); err != nil {
+	if err := providers.CachedMakeComponent(web, objList, web.Env, "keycloak", makeKeycloak, false); err != nil {
 		return err
 	}
 

--- a/controllers/cloud.redhat.com/providers/web/resources_keycloak.go
+++ b/controllers/cloud.redhat.com/providers/web/resources_keycloak.go
@@ -187,7 +187,7 @@ func configureKeycloak(web *localWebProvider) error {
 		WebKeycloakService,
 	}
 
-	if err := providers.CachedMakeComponent(web.Cache, objList, web.Env, "keycloak", makeKeycloak, false, web.Env.IsNodePort()); err != nil {
+	if err := providers.CachedMakeComponent(web.Cache, objList, web.Env, web.Env, "keycloak", makeKeycloak, false, web.Env.IsNodePort()); err != nil {
 		return err
 	}
 
@@ -246,7 +246,7 @@ func baseProbeHandler(port int32, path string) core.ProbeHandler {
 	}
 }
 
-func makeKeycloak(o obj.ClowdObject, objMap providers.ObjectMap, _ bool, nodePort bool) error {
+func makeKeycloak(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMap providers.ObjectMap, _ bool, nodePort bool) error {
 	nn := providers.GetNamespacedName(o, "keycloak")
 
 	dd := objMap[WebKeycloakDeployment].(*apps.Deployment)

--- a/controllers/cloud.redhat.com/providers/web/resources_mbop.go
+++ b/controllers/cloud.redhat.com/providers/web/resources_mbop.go
@@ -39,7 +39,7 @@ func configureMBOP(web *localWebProvider) error {
 		WebBOPService,
 	}
 
-	if err := providers.CachedMakeComponent(web.Cache, objList, web.Env, web.Env, "mbop", makeBOP, false, web.Env.IsNodePort()); err != nil {
+	if err := providers.CachedMakeComponent(web, objList, web.Env, "mbop", makeBOP, false); err != nil {
 		return err
 	}
 

--- a/controllers/cloud.redhat.com/providers/web/resources_mbop.go
+++ b/controllers/cloud.redhat.com/providers/web/resources_mbop.go
@@ -39,7 +39,7 @@ func configureMBOP(web *localWebProvider) error {
 		WebBOPService,
 	}
 
-	if err := providers.CachedMakeComponent(web.Cache, objList, web.Env, "mbop", makeBOP, false, web.Env.IsNodePort()); err != nil {
+	if err := providers.CachedMakeComponent(web.Cache, objList, web.Env, web.Env, "mbop", makeBOP, false, web.Env.IsNodePort()); err != nil {
 		return err
 	}
 
@@ -171,7 +171,7 @@ func makeBOPIngress(p *providers.Provider) error {
 	return p.Cache.Update(WebBOPIngress, netobj)
 }
 
-func makeBOP(o obj.ClowdObject, objMap providers.ObjectMap, _ bool, nodePort bool) error {
+func makeBOP(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMap providers.ObjectMap, _ bool, nodePort bool) error {
 	snn := providers.GetNamespacedName(o, "keycloak")
 	nn := providers.GetNamespacedName(o, "mbop")
 

--- a/controllers/cloud.redhat.com/providers/web/resources_mocktitlements.go
+++ b/controllers/cloud.redhat.com/providers/web/resources_mocktitlements.go
@@ -39,7 +39,7 @@ func configureMocktitlements(web *localWebProvider) error {
 		WebMocktitlementsService,
 	}
 
-	if err := providers.CachedMakeComponent(web.Cache, objList, web.Env, web.Env, "mocktitlements", makeMocktitlements, false, web.Env.IsNodePort()); err != nil {
+	if err := providers.CachedMakeComponent(web, objList, web.Env, "mocktitlements", makeMocktitlements, false); err != nil {
 		return err
 	}
 

--- a/controllers/cloud.redhat.com/providers/web/resources_mocktitlements.go
+++ b/controllers/cloud.redhat.com/providers/web/resources_mocktitlements.go
@@ -39,7 +39,7 @@ func configureMocktitlements(web *localWebProvider) error {
 		WebMocktitlementsService,
 	}
 
-	if err := providers.CachedMakeComponent(web.Cache, objList, web.Env, "mocktitlements", makeMocktitlements, false, web.Env.IsNodePort()); err != nil {
+	if err := providers.CachedMakeComponent(web.Cache, objList, web.Env, web.Env, "mocktitlements", makeMocktitlements, false, web.Env.IsNodePort()); err != nil {
 		return err
 	}
 
@@ -158,7 +158,7 @@ func makeMocktitlementsIngress(p *providers.Provider) error {
 	return p.Cache.Update(WebMocktitlementsIngress, netobj)
 }
 
-func makeMocktitlements(o obj.ClowdObject, objMap providers.ObjectMap, _ bool, nodePort bool) error {
+func makeMocktitlements(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMap providers.ObjectMap, _ bool, nodePort bool) error {
 	snn := providers.GetNamespacedName(o, "keycloak")
 	nn := providers.GetNamespacedName(o, "mocktitlements")
 


### PR DESCRIPTION
* Redis was special in that it functions at the app level and the env level
* Most cached components will only ever be deployed at the env level and contain a function call to check for the presence of the env and bomb out if the o object is not an env
* In the case of Redis, it needed to be called at app  level with the problem being that the functions for getting default images required access to the env spec
* One option was to try to smuggle the env with every app, but this seemed counter intuitive
* The next option was to try to grab the env from the app during the makeLocalRedis() function
* This fails because it's necessary to also pass in context and a client object
* A third option was to make the functions that grab the default images hang off of the ClowdApp/ClowdEnvironment, but the problem here is that the ClowdApp would need the ClowdEnvironment, meaning it would also need a client/context.
* Final option landed upon is to always pass the Env to the CachedMakeComponent() call, as well as a ClowdObject, which can be a ClowdEnvironment, or a ClowdApp as before
* This does yield some redundancy because the Env is passed in twice in somecases

So....

* Too many args being passed in
* Several of those were objects that already hung off of the provider object
* So now we just pass the provider object in to allow it to provide the Cache, the NodePort option and the Env