### PR TITLE
Adds otel sidecar as an initContainer with the restartPolicy to always

### DIFF
--- a/ci/konflux_minikube_e2e_tests.sh
+++ b/ci/konflux_minikube_e2e_tests.sh
@@ -37,7 +37,7 @@ echo "$MINIKUBE_SSH_KEY" > minikube-ssh-ident
 chmod 600 minikube-ssh-ident
 
 ssh -o StrictHostKeyChecking=no $MINIKUBE_USER@$MINIKUBE_HOST -i minikube-ssh-ident "minikube delete"
-ssh -o StrictHostKeyChecking=no $MINIKUBE_USER@$MINIKUBE_HOST -i minikube-ssh-ident "minikube start --cpus 6 --disk-size 10GB --memory 16000MB --kubernetes-version=1.28.8 --addons=metrics-server --disable-optimizations"
+ssh -o StrictHostKeyChecking=no $MINIKUBE_USER@$MINIKUBE_HOST -i minikube-ssh-ident "minikube start --cpus 6 --disk-size 10GB --memory 16000MB --kubernetes-version=1.30 --addons=metrics-server --disable-optimizations"
 
 export MINIKUBE_IP=`ssh -o StrictHostKeyChecking=no $MINIKUBE_USER@$MINIKUBE_HOST -i minikube-ssh-ident "minikube ip"`
 

--- a/controllers/cloud.redhat.com/providers/sidecar/default.go
+++ b/controllers/cloud.redhat.com/providers/sidecar/default.go
@@ -200,13 +200,14 @@ func getOtelCollector(appName string) *core.Container {
 
 	cont := core.Container{}
 
+	restartPolicy := core.ContainerRestartPolicyAlways
 	cont.Name = "otel-collector"
 	cont.Image = DefaultImageSideCarOtelCollector
 	cont.Args = []string{}
 	cont.TerminationMessagePath = "/dev/termination-log"
 	cont.TerminationMessagePolicy = core.TerminationMessageReadFile
 	cont.ImagePullPolicy = core.PullIfNotPresent
-	cont.RestartPolicy = (*core.ContainerRestartPolicy)(utils.StringPtr(string(core.ContainerRestartPolicyAlways)))
+	cont.RestartPolicy = &restartPolicy
 	cont.Resources = core.ResourceRequirements{
 		Limits: core.ResourceList{
 			"cpu":    resource.MustParse("500m"),

--- a/controllers/cloud.redhat.com/providers/sidecar/default.go
+++ b/controllers/cloud.redhat.com/providers/sidecar/default.go
@@ -14,6 +14,7 @@ import (
 	batch "k8s.io/api/batch/v1"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 type sidecarProvider struct {
@@ -50,7 +51,7 @@ func (sc *sidecarProvider) Provide(app *crd.ClowdApp) error {
 				if sidecar.Enabled && sc.Env.Spec.Providers.Sidecars.OtelCollector.Enabled {
 					cont := getOtelCollector(app.Name)
 					if cont != nil {
-						d.Spec.Template.Spec.Containers = append(d.Spec.Template.Spec.Containers, *cont)
+						d.Spec.Template.Spec.InitContainers = append(d.Spec.Template.Spec.InitContainers, *cont)
 						d.Spec.Template.Spec.Volumes = append(d.Spec.Template.Spec.Volumes, core.Volume{
 							Name: fmt.Sprintf("%s-otel-config", app.Name),
 							VolumeSource: core.VolumeSource{
@@ -98,7 +99,7 @@ func (sc *sidecarProvider) Provide(app *crd.ClowdApp) error {
 				if sidecar.Enabled && sc.Env.Spec.Providers.Sidecars.OtelCollector.Enabled {
 					cont := getOtelCollector(app.Name)
 					if cont != nil {
-						cj.Spec.JobTemplate.Spec.Template.Spec.Containers = append(cj.Spec.JobTemplate.Spec.Template.Spec.Containers, *cont)
+						cj.Spec.JobTemplate.Spec.Template.Spec.InitContainers = append(cj.Spec.JobTemplate.Spec.Template.Spec.InitContainers, *cont)
 						cj.Spec.JobTemplate.Spec.Template.Spec.Volumes = append(cj.Spec.JobTemplate.Spec.Template.Spec.Volumes, core.Volume{
 							Name: fmt.Sprintf("%s-otel-config", app.Name),
 							VolumeSource: core.VolumeSource{
@@ -169,6 +170,34 @@ func getTokenRefresher(appName string) *core.Container {
 }
 
 func getOtelCollector(appName string) *core.Container {
+	port := int32(13133)
+	probeHandler := core.ProbeHandler{
+		HTTPGet: &core.HTTPGetAction{
+			Path: "/",
+			Port: intstr.IntOrString{
+				Type:   intstr.Int,
+				IntVal: port,
+			},
+		},
+	}
+
+	livenessProbe := core.Probe{
+		ProbeHandler:        probeHandler,
+		InitialDelaySeconds: 20,
+		TimeoutSeconds:      4,
+		PeriodSeconds:       10,
+		SuccessThreshold:    1,
+		FailureThreshold:    3,
+	}
+	readinessProbe := core.Probe{
+		ProbeHandler:        probeHandler,
+		InitialDelaySeconds: 40,
+		TimeoutSeconds:      4,
+		PeriodSeconds:       10,
+		SuccessThreshold:    1,
+		FailureThreshold:    3,
+	}
+
 	cont := core.Container{}
 
 	cont.Name = "otel-collector"
@@ -177,19 +206,23 @@ func getOtelCollector(appName string) *core.Container {
 	cont.TerminationMessagePath = "/dev/termination-log"
 	cont.TerminationMessagePolicy = core.TerminationMessageReadFile
 	cont.ImagePullPolicy = core.PullIfNotPresent
+	cont.RestartPolicy = (*core.ContainerRestartPolicy)(utils.StringPtr(string(core.ContainerRestartPolicyAlways)))
 	cont.Resources = core.ResourceRequirements{
 		Limits: core.ResourceList{
 			"cpu":    resource.MustParse("500m"),
-			"memory": resource.MustParse("2048Mi"),
+			"memory": resource.MustParse("1024Mi"),
 		},
 		Requests: core.ResourceList{
 			"cpu":    resource.MustParse("250m"),
-			"memory": resource.MustParse("1024Mi"),
+			"memory": resource.MustParse("512Mi"),
 		},
 	}
 	cont.VolumeMounts = []core.VolumeMount{{
 		Name:      fmt.Sprintf("%s-otel-config", appName),
 		MountPath: "/etc/otelcol/",
 	}}
+	cont.LivenessProbe = &livenessProbe
+	cont.ReadinessProbe = &readinessProbe
+
 	return &cont
 }

--- a/docs/providers/sidecars.md
+++ b/docs/providers/sidecars.md
@@ -41,34 +41,6 @@ spec:
 
 ## Sidecar configuration
 
-### Splunk
-The Splunk sidecar requires two resources to be created and added to the k8s cluster.
-
-* ``Secret/<appName>-splunk`` - This secret must contain the field called ``splunk.pem`` and contain the cert to connect to splunk.
-* ``ConfigMap/<appName>-splunk`` - This ConfigMap contains the ``inputs.conf`` file using the format similar to that shown below
-
-```
-[default]
-_meta = namespace::rhsm-ci
-host = $decideOnStartup
-
-[monitor:///var/log/app/access.log]
-index = rh_rhsm
-sourcetype = springboot_access
-ignoreOlderThan = 5d
-recursive = false
-disabled = false
-
-[monitor:///var/log/app/server.log]
-index = rh_rhsm
-sourcetype = springboot_server
-ignoreOlderThan = 5d
-recursive = false
-disabled = false
-```
-
-The namespace will be filled in automatically from an environment variable
-
 ### Token Refresher
 The token refreser sidecar requires a secret to be created with the following variables:
 
@@ -76,3 +48,16 @@ The token refreser sidecar requires a secret to be created with the following va
 * ``CLIENT_SECRET``
 * ``ISSUER_URL``
 * ``URL``
+
+### Otel Collector
+The Otel Collector sidecar requires a configmap to be present in the namespace of the app,
+called `<app-name>-otel-config`. This will bind to a volume on the side and should contain the
+following configuration to allow the health checks to work:
+
+```yaml
+extensions:
+  health_check:
+  health_check/1:
+    endpoint: "localhost:13133"
+    path: "/"
+```

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/RedHatInsights/crc-caddy-plugin v0.4.0
 	github.com/RedHatInsights/cyndi-operator v0.1.13
 	github.com/RedHatInsights/go-difflib v1.0.0
-	github.com/RedHatInsights/rhc-osdk-utils v0.12.0
+	github.com/RedHatInsights/rhc-osdk-utils v0.13.0
 	github.com/RedHatInsights/strimzi-client-go v0.38.0
 	github.com/caddyserver/caddy/v2 v2.8.4
 	github.com/cert-manager/cert-manager v1.12.14

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/RedHatInsights/cyndi-operator v0.1.13 h1:8xn6z04Bl8A6DG9v8xnb5RGOobZI
 github.com/RedHatInsights/cyndi-operator v0.1.13/go.mod h1:+14znST9XtWHg5iWPdUjcM2cfO/jIZ9344OxiWyLyWA=
 github.com/RedHatInsights/go-difflib v1.0.0 h1:BoruyjZfxO81sEynhkG6c4SMAQOjuBWezcJxtGK8dyw=
 github.com/RedHatInsights/go-difflib v1.0.0/go.mod h1:UMKOFdypYfrKT1B1nbGodM09nhOiAmcjes8qWP7Myrs=
-github.com/RedHatInsights/rhc-osdk-utils v0.12.0 h1:hjJ+U7a+/BCXQb7Y/CIpERv5Cm9wIY1VaPkQkBATWW8=
-github.com/RedHatInsights/rhc-osdk-utils v0.12.0/go.mod h1:5UYiKYXToQB1KN2Pxr27p6Y10w+XrJYzCoMcIOhQBl8=
+github.com/RedHatInsights/rhc-osdk-utils v0.13.0 h1:K1245gkBF4sbHzW3JphC3Rr4B1Wav9FgZLOFjpSg2f0=
+github.com/RedHatInsights/rhc-osdk-utils v0.13.0/go.mod h1:RnCyA/gKtSlDy4Aie/2snMLxKS8qI0+FJcZYFXSwkrc=
 github.com/RedHatInsights/strimzi-client-go v0.38.0 h1:p6TMI2Cg9dkHyw4uV3hsMpBNuFn+RAlT85IJpGRgMY8=
 github.com/RedHatInsights/strimzi-client-go v0.38.0/go.mod h1:aOsHx9Lu4ZvS3KR+j6/X+uiyweX594098CYDEdg8kYM=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=

--- a/tests/kuttl/test-sidecars/01-assert.yaml
+++ b/tests/kuttl/test-sidecars/01-assert.yaml
@@ -27,6 +27,7 @@ spec:
       initContainers:
       - name: otel-collector
         image: ghcr.io/os-observability/redhat-opentelemetry-collector/redhat-opentelemetry-collector:0.107.0
+        restartPolicy: Always
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -47,6 +48,7 @@ spec:
             volumeMounts:
             - mountPath: /etc/otelcol/
               name: puptoo-otel-config
+            restartPolicy: Always
           volumes:
           - name: config-secret
             secret:

--- a/tests/kuttl/test-sidecars/01-assert.yaml
+++ b/tests/kuttl/test-sidecars/01-assert.yaml
@@ -24,6 +24,7 @@ spec:
       containers:
       - name: puptoo-processor
       - name: token-refresher
+      initContainers:
       - name: otel-collector
         image: ghcr.io/os-observability/redhat-opentelemetry-collector/redhat-opentelemetry-collector:0.107.0
 ---
@@ -40,6 +41,7 @@ spec:
           containers:
           - name: puptoo-cron
           - name: token-refresher
+          initContainers:
           - name: otel-collector
             image: ghcr.io/os-observability/redhat-opentelemetry-collector/redhat-opentelemetry-collector:0.107.0
             volumeMounts:


### PR DESCRIPTION
* Previously otel was deployed as a normal container but this had a negative impact when pods were restarted
* As a result we have moved this to an init container to ensure that it is running before the main service and shutdown AFTER