### PR TITLE
removing reference to run-e2e-tests

### DIFF
--- a/.tekton/clowder-push.yaml
+++ b/.tekton/clowder-push.yaml
@@ -287,7 +287,6 @@ spec:
         - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
       runAfter:
       - run-unit-tests
-      - run-e2e-tests
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
**Description**

Delete reference to removed `run-e2e-tests` task. 