### PR TITLE
Adds the `user_id` claim to Keycloak JWTs

### DIFF
--- a/jsons/redhat-external-realm.json
+++ b/jsons/redhat-external-realm.json
@@ -870,6 +870,22 @@
             "claim.name": "is_org_admin",
             "jsonType.label": "boolean"
           }
+        },
+        {
+          "id": "fc187ec5-d723-4d1a-9ebb-e0db2256f40e",
+          "name": "user_id",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "user_id",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "user_id",
+            "jsonType.label": "String"
+          }
         }
       ],
       "defaultClientScopes": [
@@ -2392,6 +2408,9 @@
           "12345"
         ],
         "org_id": [
+          "12345"
+        ],
+        "user_id": [
           "12345"
         ],
         "newEntitlements": [


### PR DESCRIPTION
This adds the missing `user_id` claim for the `cloud-services` client in Keycloak for ephemeral. Since this value is required in the `x-rh-identity` schema [1], some services will expect/require this to be populated on the identity. When it's not an attribute on the client/users, it will not be included in the JWT and thus cause issues for upstream services relying on this.

This change ensures that it exists on the token for the `jdoe` user, meaning the gateway (will require an update to crcauthlib) will pass the value along on the identity header [2].

[1] https://github.com/RedHatInsights/identity-schemas/blob/main/3scale/schema.json#L103
[2] https://github.com/RedHatInsights/crcauthlib/blob/master/crcauthlib.go#L30