### PR TITLE
updating go toolset to go version 1.23

### DIFF
--- a/.tekton/clowder-pull-request.yaml
+++ b/.tekton/clowder-pull-request.yaml
@@ -268,7 +268,7 @@ spec:
           image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
           name: use-trusted-artifact
         - computeResources: {}
-          image: registry.access.redhat.com/ubi8/go-toolset:1.22.9-3.1741575697
+          image: registry.access.redhat.com/ubi9/go-toolset:1.23.6-1745328278
           name: unit-tests
           script: set -xe && git config --global --add safe.directory /var/workdir/source
             && ls -l && pwd && make -dn test
@@ -308,7 +308,7 @@ spec:
             value: /tmp/bin
           - name: IMG
             value: $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
-          image: registry.access.redhat.com/ubi8/go-toolset:1.22.9-3.1741575697
+            image: registry.access.redhat.com/ubi9/go-toolset:1.23.6-1745328278
           name: make-template
           script: |
             set -xe && cp /var/workdir/source/* /opt/app-root/src -Rv && make release && make build-template-kustomize && cp manifest.yaml /var/workdir/ && cp deploy-kustomize.yaml /var/workdir/

--- a/.tekton/clowder-pull-request.yaml
+++ b/.tekton/clowder-pull-request.yaml
@@ -308,7 +308,7 @@ spec:
             value: /tmp/bin
           - name: IMG
             value: $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
-            image: registry.access.redhat.com/ubi9/go-toolset:1.23.6-1745328278
+          image: registry.access.redhat.com/ubi9/go-toolset:1.23.6-1745328278
           name: make-template
           script: |
             set -xe && cp /var/workdir/source/* /opt/app-root/src -Rv && make release && make build-template-kustomize && cp manifest.yaml /var/workdir/ && cp deploy-kustomize.yaml /var/workdir/

--- a/.tekton/clowder-push.yaml
+++ b/.tekton/clowder-push.yaml
@@ -265,7 +265,7 @@ spec:
           image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
           name: use-trusted-artifact
         - computeResources: {}
-          image: registry.access.redhat.com/ubi8/go-toolset:1.22.9-3.1741575697
+          image: registry.access.redhat.com/ubi9/go-toolset:1.23.6-1745328278
           name: unit-tests
           script: set -xe && git config --global --add safe.directory /var/workdir/source
             && ls -l && pwd && make -dn test


### PR DESCRIPTION
# Purpose

The version of go-toolset were accidentally reverted back to UBI8 Go version 1.22 (from UBI9 Go version 1.23). This PR will upgrade the version back.