### PR TITLE
RHCLOUD-41037: Allow to configure otelCollector sidecar to use a shared config map

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
@@ -517,6 +517,8 @@ type OtelCollectorConfig struct {
 	Enabled bool `json:"enabled"`
 	// Configurable image
 	Image string `json:"image,omitempty"`
+	// Configurable shared ConfigMap name (optional)
+	ConfigMap string `json:"configMap,omitempty"`
 }
 type Sidecars struct {
 	// Sets up Token Refresher configuration

--- a/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
@@ -534,6 +534,9 @@ spec:
                       otelCollector:
                         description: Sets up OpenTelemetry collector configuration
                         properties:
+                          configMap:
+                            description: Configurable shared ConfigMap name (optional)
+                            type: string
                           enabled:
                             description: Enable or disable otel collector sidecar
                             type: boolean

--- a/controllers/cloud.redhat.com/providers/sidecar/default.go
+++ b/controllers/cloud.redhat.com/providers/sidecar/default.go
@@ -51,13 +51,14 @@ func (sc *sidecarProvider) Provide(app *crd.ClowdApp) error {
 				if sidecar.Enabled && sc.Env.Spec.Providers.Sidecars.OtelCollector.Enabled {
 					cont := getOtelCollector(app.Name, sc.Env)
 					if cont != nil {
+						configMapName := GetOtelCollectorConfigMap(sc.Env, app.Name)
 						d.Spec.Template.Spec.InitContainers = append(d.Spec.Template.Spec.InitContainers, *cont)
 						d.Spec.Template.Spec.Volumes = append(d.Spec.Template.Spec.Volumes, core.Volume{
 							Name: fmt.Sprintf("%s-otel-config", app.Name),
 							VolumeSource: core.VolumeSource{
 								ConfigMap: &core.ConfigMapVolumeSource{
 									LocalObjectReference: core.LocalObjectReference{
-										Name: fmt.Sprintf("%s-otel-config", app.Name),
+										Name: configMapName,
 									},
 									Optional: utils.TruePtr(),
 								},
@@ -99,13 +100,14 @@ func (sc *sidecarProvider) Provide(app *crd.ClowdApp) error {
 				if sidecar.Enabled && sc.Env.Spec.Providers.Sidecars.OtelCollector.Enabled {
 					cont := getOtelCollector(app.Name, sc.Env)
 					if cont != nil {
+						configMapName := GetOtelCollectorConfigMap(sc.Env, app.Name)
 						cj.Spec.JobTemplate.Spec.Template.Spec.InitContainers = append(cj.Spec.JobTemplate.Spec.Template.Spec.InitContainers, *cont)
 						cj.Spec.JobTemplate.Spec.Template.Spec.Volumes = append(cj.Spec.JobTemplate.Spec.Template.Spec.Volumes, core.Volume{
 							Name: fmt.Sprintf("%s-otel-config", app.Name),
 							VolumeSource: core.VolumeSource{
 								ConfigMap: &core.ConfigMapVolumeSource{
 									LocalObjectReference: core.LocalObjectReference{
-										Name: fmt.Sprintf("%s-otel-config", app.Name),
+										Name: configMapName,
 									},
 									Optional: utils.TruePtr(),
 								},

--- a/controllers/cloud.redhat.com/providers/sidecar/provider.go
+++ b/controllers/cloud.redhat.com/providers/sidecar/provider.go
@@ -1,6 +1,8 @@
 package sidecar
 
 import (
+	"fmt"
+
 	crd "github.com/RedHatInsights/clowder/apis/cloud.redhat.com/v1alpha1"
 	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/clowderconfig"
 	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/providers"
@@ -27,6 +29,13 @@ func GetOtelCollectorSidecar(env *crd.ClowdEnvironment) string {
 		return clowderconfig.LoadedConfig.Images.OtelCollector
 	}
 	return DefaultImageSideCarOtelCollector
+}
+
+func GetOtelCollectorConfigMap(env *crd.ClowdEnvironment, appName string) string {
+	if env.Spec.Providers.Sidecars.OtelCollector.ConfigMap != "" {
+		return env.Spec.Providers.Sidecars.OtelCollector.ConfigMap
+	}
+	return fmt.Sprintf("%s-otel-config", appName)
 }
 
 // ProvName sets the provider name identifier

--- a/deploy-mutate.yml
+++ b/deploy-mutate.yml
@@ -9364,6 +9364,9 @@ objects:
                         otelCollector:
                           description: Sets up OpenTelemetry collector configuration
                           properties:
+                            configMap:
+                              description: Configurable shared ConfigMap name (optional)
+                              type: string
                             enabled:
                               description: Enable or disable otel collector sidecar
                               type: boolean

--- a/deploy.yml
+++ b/deploy.yml
@@ -9364,6 +9364,9 @@ objects:
                         otelCollector:
                           description: Sets up OpenTelemetry collector configuration
                           properties:
+                            configMap:
+                              description: Configurable shared ConfigMap name (optional)
+                              type: string
                             enabled:
                               description: Enable or disable otel collector sidecar
                               type: boolean

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1158,6 +1158,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `enabled` _boolean_ | Enable or disable otel collector sidecar |  |  |
 | `image` _string_ | Configurable image |  |  |
+| `configMap` _string_ | Configurable shared ConfigMap name (optional) |  |  |
 
 
 #### PodSpec

--- a/tests/kuttl/test-sidecars-shared-config-map/00-install.yaml
+++ b/tests/kuttl/test-sidecars-shared-config-map/00-install.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-sidecars-shared-config-map
+spec:
+  finalizers:
+  - kubernetes 

--- a/tests/kuttl/test-sidecars-shared-config-map/01-assert.yaml
+++ b/tests/kuttl/test-sidecars-shared-config-map/01-assert.yaml
@@ -1,0 +1,121 @@
+---
+# Verify that the shared ConfigMap exists
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shared-otel-config
+  namespace: test-sidecars-shared-config-map
+---
+# Verify that app-one uses the shared ConfigMap
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-one-processor
+  namespace: test-sidecars-shared-config-map
+spec:
+  template:
+    spec:
+      containers:
+      - name: app-one-processor
+      initContainers:
+      - name: otel-collector
+        image: ghcr.io/os-observability/redhat-opentelemetry-collector/redhat-opentelemetry-collector:0.107.0
+        restartPolicy: Always
+        volumeMounts:
+        - mountPath: /etc/otelcol/
+          name: app-one-otel-config
+      volumes:
+      - name: config-secret
+        secret:
+          defaultMode: 420
+          secretName: app-one
+      - configMap:
+          defaultMode: 420
+          name: shared-otel-config
+        name: app-one-otel-config
+---
+# Verify that app-two deployment uses the shared ConfigMap
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-two-worker
+  namespace: test-sidecars-shared-config-map
+spec:
+  template:
+    spec:
+      containers:
+      - name: app-two-worker
+      initContainers:
+      - name: otel-collector
+        image: ghcr.io/os-observability/redhat-opentelemetry-collector/redhat-opentelemetry-collector:0.107.0
+        restartPolicy: Always
+        volumeMounts:
+        - mountPath: /etc/otelcol/
+          name: app-two-otel-config
+      volumes:
+      - name: config-secret
+        secret:
+          defaultMode: 420
+          secretName: app-two
+      - configMap:
+          defaultMode: 420
+          name: shared-otel-config
+        name: app-two-otel-config
+---
+# Verify that app-two cronjob uses the shared ConfigMap
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: app-two-batch-job
+  namespace: test-sidecars-shared-config-map
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: app-two-batch-job
+          initContainers:
+          - name: otel-collector
+            image: ghcr.io/os-observability/redhat-opentelemetry-collector/redhat-opentelemetry-collector:0.107.0
+            restartPolicy: Always
+            volumeMounts:
+            - mountPath: /etc/otelcol/
+              name: app-two-otel-config
+          volumes:
+          - name: config-secret
+            secret:
+              defaultMode: 420
+              secretName: app-two
+          - name: app-two-otel-config
+            configMap:
+              defaultMode: 420
+              name: shared-otel-config
+---
+# Verify that app-three uses the shared ConfigMap
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-three-api
+  namespace: test-sidecars-shared-config-map
+spec:
+  template:
+    spec:
+      containers:
+      - name: app-three-api
+      initContainers:
+      - name: otel-collector
+        image: ghcr.io/os-observability/redhat-opentelemetry-collector/redhat-opentelemetry-collector:0.107.0
+        restartPolicy: Always
+        volumeMounts:
+        - mountPath: /etc/otelcol/
+          name: app-three-otel-config
+      volumes:
+      - name: config-secret
+        secret:
+          defaultMode: 420
+          secretName: app-three
+      - configMap:
+          defaultMode: 420
+          name: shared-otel-config
+        name: app-three-otel-config 

--- a/tests/kuttl/test-sidecars-shared-config-map/01-pods.yaml
+++ b/tests/kuttl/test-sidecars-shared-config-map/01-pods.yaml
@@ -1,0 +1,131 @@
+---
+# Shared ConfigMap for OpenTelemetry
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shared-otel-config
+  namespace: test-sidecars-shared-config-map
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    processors:
+      batch:
+      memory_limiter:
+        check_interval: 1s
+        limit_mib: 1024
+    exporters:
+      logging:
+        loglevel: info
+      prometheus:
+        endpoint: "0.0.0.0:9999"
+        namespace: shared_otel
+        metric_expiration: 30m
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch, memory_limiter]
+          exporters: [logging]
+        metrics:
+          receivers: [otlp]
+          processors: [batch, memory_limiter]
+          exporters: [prometheus, logging]
+---
+# ClowdEnvironment with shared ConfigMap
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdEnvironment
+metadata:
+  name: test-sidecars-shared-config-map
+spec:
+  targetNamespace: test-sidecars-shared-config-map
+  providers:
+    web:
+      port: 8000
+      mode: operator
+    metrics:
+      port: 9000
+      mode: operator
+      path: "/metrics"
+    kafka:
+      mode: none
+    db:
+      mode: none
+    logging:
+      mode: none
+    objectStore:
+      mode: none
+    inMemoryDb:
+      mode: none
+    sidecars:
+      otelCollector:
+        enabled: true
+        configMap: shared-otel-config
+  resourceDefaults:
+    limits:
+      cpu: 400m
+      memory: 1024Mi
+    requests:
+      cpu: 30m
+      memory: 512Mi
+---
+# First application using the shared ConfigMap
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: app-one
+  namespace: test-sidecars-shared-config-map
+spec:
+  envName: test-sidecars-shared-config-map
+  deployments:
+  - name: processor
+    podSpec:
+      image: quay.io/psav/clowder-hello
+      sidecars:
+        - name: otel-collector
+          enabled: true
+---
+# Second application using the shared ConfigMap
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: app-two
+  namespace: test-sidecars-shared-config-map
+spec:
+  envName: test-sidecars-shared-config-map
+  deployments:
+  - name: worker
+    podSpec:
+      image: quay.io/psav/clowder-hello
+      sidecars:
+        - name: otel-collector
+          enabled: true
+  jobs:
+    - name: batch-job
+      schedule: "*/5 * * * *"
+      podSpec:
+        image: quay.io/psav/clowder-hello
+        sidecars:
+          - name: otel-collector
+            enabled: true
+---
+# Third application using the shared ConfigMap
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: app-three
+  namespace: test-sidecars-shared-config-map
+spec:
+  envName: test-sidecars-shared-config-map
+  deployments:
+  - name: api
+    podSpec:
+      image: quay.io/psav/clowder-hello
+      sidecars:
+        - name: otel-collector
+          enabled: true 

--- a/tests/kuttl/test-sidecars-shared-config-map/02-delete.yaml
+++ b/tests/kuttl/test-sidecars-shared-config-map/02-delete.yaml
@@ -1,0 +1,44 @@
+---
+# Delete ClowdApps
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: app-one
+  namespace: test-sidecars-shared-config-map
+$delete: true
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: app-two
+  namespace: test-sidecars-shared-config-map
+$delete: true
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: app-three
+  namespace: test-sidecars-shared-config-map
+$delete: true
+---
+# Delete ClowdEnvironment
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdEnvironment
+metadata:
+  name: test-sidecars-shared-config-map
+$delete: true
+---
+# Delete shared ConfigMap
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shared-otel-config
+  namespace: test-sidecars-shared-config-map
+$delete: true
+---
+# Delete Namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-sidecars-shared-config-map
+$delete: true 


### PR DESCRIPTION
Currently, each ClowdApp with an otel-collector sidecar requires its own dedicated ConfigMap with a hardcoded naming pattern "<appName>-otel-config". This creates configuration duplication and management overhead when multiple services need the same OpenTelemetry configuration.

Now, we can extend ClowdEnvironment configuration with a new "configMap" property:
```
apiVersion: cloud.redhat.com/v1alpha1
kind: ClowdEnvironment
metadata:
  name: env-rhsm
spec:
  providers:
    sidecars:
      otelCollector:
        enabled: true
        image: "custom-otel-image:latest"
        configMap: "shared-otel-config"  # NEW: Optional shared ConfigMap name
```

And always use the "shared-otel-config" config map if sets. Otherwise, keep using the clowder app name based resolution strategy as it does today.