### PR TITLE
Clowder local development for MacOS users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,5 +225,4 @@ $(KUSTOMIZE): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.17
-
+    GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.17

--- a/Makefile
+++ b/Makefile
@@ -226,3 +226,4 @@ $(KUSTOMIZE): $(LOCALBIN)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.17
+

--- a/Makefile
+++ b/Makefile
@@ -225,4 +225,4 @@ $(KUSTOMIZE): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-    GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.17
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.17

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ CLOWDER_BUILD_TAG ?= $(shell git rev-parse HEAD)
 
 GO_CMD ?= go
 
+OS := $(shell uname -s)
+
 TEMPLATE_KUSTOMIZE ?= "deploy-kustomize.yaml"
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
@@ -148,9 +150,16 @@ docker-build-no-test:
 docker-push:
 	$(RUNTIME) push ${IMG}
 
-# Push the docker image
+
+# For folks using Darwin for their OS, they need to use Docker for pushing a local Clowder image
+# to Minikube.
+ifeq ($(OS),Darwin)
+docker-push-minikube:
+	docker push ${IMG}
+else
 docker-push-minikube:
 	$(RUNTIME) push ${IMG} $(shell minikube ip):5000/clowder:$(CLOWDER_BUILD_TAG) --tls-verify=false
+endif
 
 deploy-minikube: docker-build-no-test docker-push-minikube deploy
 

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -25,6 +25,8 @@ kube start \
 ```
     
 ## Configure Minikube for Local Testing
+
+Run script to setup Minikube cluster.
 ```
 build/setup_kube.sh
 ```
@@ -32,7 +34,6 @@ build/setup_kube.sh
 ## Setup Network Proxy
 
 Next start an Alpine docker container that will act as a proxy that will connect your local machine's port 5000 to the registry running in the Minikube cluster at port 5000. You'll find more on this in the Minikube documentation for running [docker on macOS](https://minikube.sigs.k8s.io/docs/handbook/registry/#enabling-insecure-registries).
-
 ```
 docker run --rm -it -d --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000"
 ```

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -7,24 +7,40 @@
 If you do not use ``brew``, you can follow [this guide](https://v1-18.docs.kubernetes.io/docs/tasks/tools/install-minikube/)
 
 
-## Install Podman
+## Run minikube
 
-Virtualbox or HyperKit were previously recommended, but Podman is becoming a popular option. Hyperkit has been deprecated due to lack of upstream maintenance. Podman support is "experimental" at this time, but works reliably enough for locally reproducing issues. Once you have Podman installed, you can establish it as the driver with something like this (adjust your parameters accordingly):
+```
+kube start \
+    --cpus 4 \
+    --disk-size 36GB \
+    --memory 16000MB \
+    --driver=docker \
+    --addons=registry \
+    --addons=ingress \
+    --addons=metrics-server \
+    --disable-optimizations \
+    --container-runtime=containerd \
+    --kubernetes-version=v1.32.6 \
+    --insecure-registry "10.0.0.0/24"
+```
+    
+## Configure Minikube for Local Testing
+```
+build/setup_kube.sh
+```
 
-``minikube start --cpus 4 --disk-size 36GB --memory 16000MB --driver=podman --addons registry --addons ingress  --addons=metrics-server --disable-optimizations``
+## Setup Network Proxy
 
-## Virtualbox or Hyperkit (deprecated)
+Next start an Alpine docker container that will act as a proxy that will connect your local machine's port 5000 to the registry running in the Minikube cluster at port 5000. You'll find more on this in the Minikube documentation for running [docker on macOS](https://minikube.sigs.k8s.io/docs/handbook/registry/#enabling-insecure-registries).
 
-``brew install hyperkit`` (you will see a warning about the project being deprecated)
+```
+docker run --rm -it -d --network=host alpine ash -c "apk add socat && socat TCP-LISTEN:5000,reuseaddr,fork TCP:$(minikube ip):5000"
+```
 
-or 
+## Run
 
-Install VirtualBox from [the VirtualBox site](https://www.virtualbox.org/wiki/Downloads)
+Lastly, run the make target `deploy-minikube-quick` that will build the image locally, push the image to the registry running in Minikube, and start the pod. This command also sets a tag that will need to be updated each time you make a change locally to Clowder. This will ensure that the new pod comes up with your changes. 
+```
+CLOWDER_BUILD_TAG=boop334 make deploy-minikube-quick
+```
 
-
-## Running
-
-Minikube can now be run the same way as the rest of the documentation suggests. 
-Setting the config will also make the minikube experience less verbose.
-
-``minikube config set vm-driver podman``

--- a/docs/site-readme.md
+++ b/docs/site-readme.md
@@ -56,21 +56,6 @@ Clowder currently supports the following features:
 - CronJob support
 - Jobs Support
 
-## Roadmap
-
-Our current roadmap looks like this:
-
-* Autoscaling (possibly via [Keda](https://github.com/kedacore/keda))
-* Dynamic routing for public web sevices
-* Automatic metrics configuration
-* Automatic network policy configuration
-* Standard, configurable alerting: Error rate, latency, Kafka topic lag, etc
-* Canary deployments (possibly via [Flagger](https://github.com/weaveworks/flagger))
-* Operational remediations
-* Observe service status from a `ClowdApp` `status`, based on sevice dependencies.
-* Istio integration
-* Advanced logging configurations (e.g. logging messages to kafka topics)
-
 ## Updating E2E Test Golang Deps
 
 Clowder's E2E tests require a few golang dependecies that are not included in the root `go.mod` file. These will need to be updated regularly as a separate process. You can run the following script to update these:


### PR DESCRIPTION
# Purpose

This PR will add a new make target for pushing the built clowder image to the local registry in Minikube. At the time of writing this, Docker is the recommended way of handling this on MacOS. 

Additionally, this PR adds documentation regarding how to get Clowder working in Minikube on MacOS. 

Also removing the roadmap section of the docs. 