### PR TITLE
RHCLOUD-41392: Add support for fieldRef environment variables in Clowder otel-collector sidecars

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
@@ -551,6 +551,12 @@ type EnvVarSource struct {
 	// Selects a key of a secret in the pod's namespace
 	// +optional
 	SecretKeyRef *SecretKeySelector `json:"secretKeyRef,omitempty"`
+
+	// Selects a field of the pod: supports metadata.name, metadata.namespace,
+	// metadata.labels['<KEY>'], metadata.annotations['<KEY>'], spec.nodeName,
+	// spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+	// +optional
+	FieldRef *core.ObjectFieldSelector `json:"fieldRef,omitempty"`
 }
 
 // ConfigMapKeySelector selects a key from a ConfigMap.

--- a/config/crd/bases/cloud.redhat.com_clowdapps.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdapps.yaml
@@ -1402,6 +1402,25 @@ spec:
                                           required:
                                           - key
                                           type: object
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace,
+                                            metadata.labels['<KEY>'], metadata.annotations['<KEY>'], spec.nodeName,
+                                            spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           description: Selects a key of a secret in
                                             the pod's namespace
@@ -4420,6 +4439,25 @@ spec:
                                           required:
                                           - key
                                           type: object
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace,
+                                            metadata.labels['<KEY>'], metadata.annotations['<KEY>'], spec.nodeName,
+                                            spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
                                         secretKeyRef:
                                           description: Selects a key of a secret in
                                             the pod's namespace

--- a/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
@@ -580,6 +580,24 @@ spec:
                                       required:
                                       - key
                                       type: object
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace,
+                                        metadata.labels['<KEY>'], metadata.annotations['<KEY>'], spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
                                     secretKeyRef:
                                       description: Selects a key of a secret in the
                                         pod's namespace

--- a/controllers/cloud.redhat.com/providers/sidecar/provider.go
+++ b/controllers/cloud.redhat.com/providers/sidecar/provider.go
@@ -71,6 +71,17 @@ func ConvertEnvVars(envVars []crd.EnvVar) []core.EnvVar {
 					Optional: envVar.ValueFrom.SecretKeyRef.Optional,
 				}
 			}
+
+			if envVar.ValueFrom.FieldRef != nil {
+				coreEnvVar.ValueFrom.FieldRef = &core.ObjectFieldSelector{
+					APIVersion: envVar.ValueFrom.FieldRef.APIVersion,
+					FieldPath:  envVar.ValueFrom.FieldRef.FieldPath,
+				}
+				// Set default API version if not specified
+				if coreEnvVar.ValueFrom.FieldRef.APIVersion == "" {
+					coreEnvVar.ValueFrom.FieldRef.APIVersion = "v1"
+				}
+			}
 		}
 
 		coreEnvVars = append(coreEnvVars, coreEnvVar)

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -590,6 +590,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `configMapKeyRef` _[ConfigMapKeySelector](#configmapkeyselector)_ | Selects a key of a ConfigMap. |  |  |
 | `secretKeyRef` _[SecretKeySelector](#secretkeyselector)_ | Selects a key of a secret in the pod's namespace |  |  |
+| `fieldRef` _[ObjectFieldSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#objectfieldselector-v1-core)_ | Selects a field of the pod: supports metadata.name, metadata.namespace,<br />metadata.labels['<KEY>'], metadata.annotations['<KEY>'], spec.nodeName,<br />spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs. |  |  |
 
 
 #### FeatureFlagsConfig
@@ -1309,7 +1310,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `deploy` _boolean_ | Determines whether to deploy prometheus in operator mode |  |  |
-| `appInterfaceHostname` _string_ | Specify prometheus hostname when in app-interface mode |  |  |
+| `appInterfaceInternalURL` _string_ | Specify prometheus internal URL when in app-interface mode |  |  |
 
 
 #### PrometheusStatus
@@ -1325,26 +1326,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `hostname` _string_ |  |  |  |
-| `port` _integer_ |  |  |  |
-| `scheme` _[ProtocolScheme](#protocolscheme)_ |  |  |  |
-
-
-#### ProtocolScheme
-
-_Underlying type:_ _string_
-
-
-
-
-
-_Appears in:_
-- [PrometheusStatus](#prometheusstatus)
-
-| Field | Description |
-| --- | --- |
-| `http` |  |
-| `https` |  |
+| `serverAddress` _string_ |  |  |  |
 
 
 #### ProvidersConfig

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -45,3 +45,28 @@ Lastly, run the make target `deploy-minikube-quick` that will build the image lo
 CLOWDER_BUILD_TAG=boop334 make deploy-minikube-quick
 ```
 
+Virtualbox or HyperKit were previously recommended, but Podman or Docker are becoming a popular option. Hyperkit has been deprecated due to lack of upstream maintenance. Podman support is "experimental" at this time, but works reliably enough for locally reproducing issues. Once you have Podman installed, you can establish it as the driver with something like this (adjust your parameters accordingly):
+
+``minikube start --cpus 4 --disk-size 36GB --memory 16000MB --driver=podman --addons registry --addons ingress  --addons=metrics-server --disable-optimizations``
+
+## Docker Driver for Minikube
+
+If you have Docker Desktop installed, you will need to update the memory in the resources section of the settings:
+
+``minikube start --cpus 4 --disk-size 36GB --memory 16000MB --driver=docker --addons registry --addons ingress  --addons=metrics-server --disable-optimizations``
+
+## Virtualbox or Hyperkit (deprecated)
+
+``brew install hyperkit`` (you will see a warning about the project being deprecated)
+
+or 
+
+Install VirtualBox from [the VirtualBox site](https://www.virtualbox.org/wiki/Downloads)
+
+
+## Running
+
+Minikube can now be run the same way as the rest of the documentation suggests. 
+Setting the config will also make the minikube experience less verbose.
+
+``minikube config set vm-driver podman``

--- a/tests/kuttl/test-sidecars-env-vars/00-install.yaml
+++ b/tests/kuttl/test-sidecars-env-vars/00-install.yaml
@@ -88,6 +88,44 @@ data:
           processors: [batch]
           exporters: [logging]
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-app-env-fieldref-otel-config
+  namespace: test-sidecars-env-vars
+data:
+  otel-collector.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+    processors:
+      batch:
+      resource/add_pod_metadata:
+        attributes:
+        - action: insert
+          key: k8s.pod.name
+          value: ${K8S_POD_NAME}
+        - action: insert
+          key: k8s.pod.ip
+          value: ${K8S_POD_IP}
+        - action: insert
+          key: k8s.namespace.name
+          value: ${K8S_NAMESPACE}
+        - action: insert
+          key: k8s.node.name
+          value: ${K8S_NODE_NAME}
+    exporters:
+      logging:
+        loglevel: debug
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch, resource/add_pod_metadata]
+          exporters: [logging]
+---
 apiVersion: cloud.redhat.com/v1alpha1
 kind: ClowdEnvironment
 metadata:

--- a/tests/kuttl/test-sidecars-env-vars/01-pods.yaml
+++ b/tests/kuttl/test-sidecars-env-vars/01-pods.yaml
@@ -64,3 +64,39 @@ spec:
                   configMapKeyRef:
                     name: test-app-env-secret-otel-config
                     key: otel-collector.yaml
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: test-app-env-fieldref
+  namespace: test-sidecars-env-vars
+spec:
+  envName: test-sidecars-env-vars
+  deployments:
+    - name: api
+      podSpec:
+        image: quay.io/cloudservices/iqe-tests:latest
+        sidecars:
+          - name: otel-collector
+            enabled: true
+            envVars:
+              - name: OTEL_SERVICE_NAME
+                value: "test-app-env-fieldref"
+              - name: K8S_POD_NAME
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.name
+              - name: K8S_POD_IP
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: status.podIP
+              - name: K8S_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              - name: K8S_NODE_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: spec.nodeName

--- a/tests/kuttl/test-sidecars-env-vars/02-assert.yaml
+++ b/tests/kuttl/test-sidecars-env-vars/02-assert.yaml
@@ -120,4 +120,61 @@ spec:
         - name: test-app-env-secret-otel-config
           configMap:
             name: test-app-env-secret-otel-config
-            optional: true 
+            optional: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app-env-fieldref-api
+  namespace: test-sidecars-env-vars
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: otel-collector
+          image: ghcr.io/os-observability/redhat-opentelemetry-collector/redhat-opentelemetry-collector:0.107.0
+          env:
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "https://otel-collector.test.example.com:4317"
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              valueFrom:
+                secretKeyRef:
+                  name: otel-auth
+                  key: headers
+            - name: OTEL_SERVICE_NAME
+              value: "test-app-env-fieldref"  # Overridden by app
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "environment=test,region=us-east-1"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: K8S_POD_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: test-app-env-fieldref-otel-config
+              mountPath: /etc/otelcol/
+          restartPolicy: Always
+      volumes:
+        - name: config-secret
+          secret:
+            defaultMode: 420
+            secretName: test-app-env-fieldref
+        - name: test-app-env-fieldref-otel-config
+          configMap:
+            name: test-app-env-fieldref-otel-config
+            optional: true


### PR DESCRIPTION
This PR adds support for fieldRef environment variables in otel-collector sidecars, enabling access to pod metadata (e.g., status.podIP, metadata.name, spec.nodeName) without complex workarounds.

## Changes
- API Types: Added FieldRef *core.ObjectFieldSelector to EnvVarSource struct
- Runtime Logic: Extended ConvertEnvVars() function to handle fieldRef conversion with default API version
- CRDs: Updated both ClowdEnvironment and ClowdApp CRDs to include fieldRef schema validation
- Tests: Added comprehensive test case demonstrating fieldRef usage in otel-collector sidecar

## Usage
```
sidecars:
  - name: otel-collector
    enabled: true
    envVars:
      - name: K8S_POD_IP
        valueFrom:
          fieldRef:
            fieldPath: status.podIP
```
