### PR TITLE
Use WriteNow for env pull secret provider secrets

### DIFF
--- a/controllers/cloud.redhat.com/providers/pullsecrets/default.go
+++ b/controllers/cloud.redhat.com/providers/pullsecrets/default.go
@@ -18,7 +18,7 @@ import (
 )
 
 // CoreEnvPullSecrets is the pull_secrets for the app.
-var CoreEnvPullSecrets = rc.NewMultiResourceIdent(ProvName, "core_env_pull_secrets", &core.Secret{})
+var CoreEnvPullSecrets = rc.NewMultiResourceIdent(ProvName, "core_env_pull_secrets", &core.Secret{}, rc.ResourceOptions{WriteNow: true})
 
 type pullsecretProvider struct {
 	providers.Provider


### PR DESCRIPTION
This should get the pull secrets into the namespace immediately, even if providers have errored out early.