### PR TITLE
Set default topic replication factor

### DIFF
--- a/controllers/cloud.redhat.com/providers/kafka/strimzi.go
+++ b/controllers/cloud.redhat.com/providers/kafka/strimzi.go
@@ -199,9 +199,11 @@ func (s *strimziProvider) configureKafkaCluster() error {
 	var entityTopicLimits, entityTopicRequests apiextensions.JSON
 	var entityTLSLimits, entityTLSRequests apiextensions.JSON
 
+	replicasAsStr := strconv.Itoa(int(replicas))
 	err = kafConfig.UnmarshalJSON([]byte(fmt.Sprintf(`{
-		"offsets.topic.replication.factor": %s
-	}`, strconv.Itoa(int(replicas)))))
+		"offsets.topic.replication.factor": %s,
+		"default.replication.factor": %s
+	}`, replicasAsStr, replicasAsStr)))
 	if err != nil {
 		return fmt.Errorf("could not unmarshal kConfig: %w", err)
 	}

--- a/tests/kuttl/test-kafka-msk/01-pods.yaml
+++ b/tests/kuttl/test-kafka-msk/01-pods.yaml
@@ -19,6 +19,7 @@ spec:
       type: simple
     config:
       offsets.topic.replication.factor: 1
+      default.replication.factor: 1
     jvmOptions: {}
     listeners:
     - authentication:


### PR DESCRIPTION
This sets the default topic replication factor to match the number of replicas when kafka is provisioned using the strimzi provider.