### PR TITLE
Updated default cpu limit

### DIFF
--- a/controllers/cloud.redhat.com/providers/deployment/impl.go
+++ b/controllers/cloud.redhat.com/providers/deployment/impl.go
@@ -441,7 +441,7 @@ func ProcessResources(pod *crd.PodSpec, env *crd.ClowdEnvironment) core.Resource
 	if *pod.Resources.Limits.Cpu() != nullCPU {
 		lcpu = pod.Resources.Limits["cpu"]
 	} else {
-		lcpu = env.Spec.ResourceDefaults.Limits["cpu"]
+		lcpu = nullCPU
 	}
 
 	if *pod.Resources.Limits.Memory() != nullMemory {


### PR DESCRIPTION
The default cpu limit is now null. This is to remove the cpu limit when a limit is not specified. 