### PR TITLE
Always populate tlsCAPath if TLS ports are defined in environment

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
@@ -125,10 +125,10 @@ type TLS struct {
 	// Determines whether TLS is enabled for ClowdApp deployments by default
 	Enabled bool `json:"enabled,omitempty"`
 
-	// Sets the port exposed for ClowdApp deployments' TLS connections
+	// Sets the port exposed for ClowdApp deployments' TLS connections. If unset, TLS is disabled in the environment.
 	Port int32 `json:"port,omitempty"`
 
-	// Sets the private port exposed for ClowdApp deployments' TLS connections
+	// Sets the private port exposed for ClowdApp deployments' TLS connections. If unset, TLS is disabled in the environment.
 	PrivatePort int32 `json:"privatePort,omitempty"`
 }
 

--- a/config/crd/bases/cloud.redhat.com_clowdapprefs.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdapprefs.yaml
@@ -205,12 +205,12 @@ spec:
                         type: boolean
                       port:
                         description: Sets the port exposed for ClowdApp deployments'
-                          TLS connections
+                          TLS connections. If unset, TLS is disabled in the environment.
                         format: int32
                         type: integer
                       privatePort:
                         description: Sets the private port exposed for ClowdApp deployments'
-                          TLS connections
+                          TLS connections. If unset, TLS is disabled in the environment.
                         format: int32
                         type: integer
                     type: object

--- a/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
@@ -969,12 +969,13 @@ spec:
                             type: boolean
                           port:
                             description: Sets the port exposed for ClowdApp deployments'
-                              TLS connections
+                              TLS connections. If unset, TLS is disabled in the environment.
                             format: int32
                             type: integer
                           privatePort:
                             description: Sets the private port exposed for ClowdApp
-                              deployments' TLS connections
+                              deployments' TLS connections. If unset, TLS is disabled
+                              in the environment.
                             format: int32
                             type: integer
                         type: object

--- a/controllers/cloud.redhat.com/providers/utils/utils.go
+++ b/controllers/cloud.redhat.com/providers/utils/utils.go
@@ -398,8 +398,16 @@ func AppendEnvVarsFromSecret(envvars []core.EnvVar, secName string, inputs ...Se
 	return envvars
 }
 
+// IsTLSConfiguredForEnv returns true if the public and private TLS ports are defined on the ClowdEnvironment
+func IsTLSConfiguredForEnv(envTLSConfig *crd.TLS) bool {
+	return envTLSConfig.Port != 0 && envTLSConfig.PrivatePort != 0
+}
+
 // IsPublicTLSEnabled returns true if public TLS is enabled at the ClowdApp deployment level or at the ClowdEnvironment web provider level
 func IsPublicTLSEnabled(deploymentWebConfig *crd.WebServices, envTLSConfig *crd.TLS) bool {
+	if !IsTLSConfiguredForEnv(envTLSConfig) {
+		return false
+	}
 	if deploymentWebConfig.Public.TLS != nil {
 		return *deploymentWebConfig.Public.TLS
 	}
@@ -408,6 +416,9 @@ func IsPublicTLSEnabled(deploymentWebConfig *crd.WebServices, envTLSConfig *crd.
 
 // IsPrivateTLSEnabled returns true if private TLS is enabled at the ClowdApp deployment level or at the ClowdEnvironment web provider level
 func IsPrivateTLSEnabled(deploymentWebConfig *crd.WebServices, envTLSConfig *crd.TLS) bool {
+	if !IsTLSConfiguredForEnv(envTLSConfig) {
+		return false
+	}
 	if deploymentWebConfig.Private.TLS != nil {
 		return *deploymentWebConfig.Private.TLS
 	}

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1669,8 +1669,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `enabled` _boolean_ | Determines whether TLS is enabled for ClowdApp deployments by default |  |  |
-| `port` _integer_ | Sets the port exposed for ClowdApp deployments' TLS connections |  |  |
-| `privatePort` _integer_ | Sets the private port exposed for ClowdApp deployments' TLS connections |  |  |
+| `port` _integer_ | Sets the port exposed for ClowdApp deployments' TLS connections. If unset, TLS is disabled in the environment. |  |  |
+| `privatePort` _integer_ | Sets the private port exposed for ClowdApp deployments' TLS connections. If unset, TLS is disabled in the environment. |  |  |
 
 
 #### TestingConfig

--- a/tests/kuttl/test-tls-web-services-app-overrides/01-assert.yaml
+++ b/tests/kuttl/test-tls-web-services-app-overrides/01-assert.yaml
@@ -122,7 +122,11 @@ spec:
         secret:
           defaultMode: 420
           secretName: clowdapp-tls-disabled
-      # Should NOT have caddy-config, caddy-tls, or tls-ca volumes
+      - configMap:
+          defaultMode: 420
+          name: openshift-service-ca.crt
+        name: tls-ca
+      # Should NOT have caddy-config or caddy-tls volumes
 ---
 # Assert that clowdapp-tls-disabled does NOT have TLS ports in its service
 apiVersion: v1

--- a/tests/kuttl/test-tls-web-services-app-overrides/02-json-asserts.yaml
+++ b/tests/kuttl/test-tls-web-services-app-overrides/02-json-asserts.yaml
@@ -35,8 +35,8 @@ commands:
 - script: jq -r '.endpoints[] | select(.name == "processor" and .app == "clowdapp-tls-disabled") | .tlsPort == 0' < /tmp/test-tls-disabled-json
 - script: jq -r '.privateEndpoints[] | select(.name == "processor" and .app == "clowdapp-tls-disabled") | .tlsPort == 0' < /tmp/test-tls-disabled-json
 
-# TLS CA path should not be set when TLS is disabled
-- script: jq -r '.tlsCAPath' < /tmp/test-tls-disabled-json | grep -q "null"
+# TLS CA path should be set on all ClowdApps, ensure it is also set on this ClowdApp
+- script: jq -r '.tlsCAPath == "/cdapp/certs/service-ca.crt"' -e < /tmp/test-tls-disabled-json
 
 # Verify dependencies are properly configured in clowdapp-tls-disabled
 # It should have clowdapp-tls-enabled as a dependency with TLS ports


### PR DESCRIPTION
As a follow-up to #1387 -- we need to always provide apps with the TlsCAPath if we have the ClowdEnvironment TLS ports configured.

As an example, if 'app B' depends on 'app A' and 'app A' has TLS enabled, then app B needs the CA certificate. Rather than iterating through app B's dependencies to see if any have TLS enabled, we'll just go ahead and set the TLS CA path whether it is going to use TLS to connect to app A or not.

We will assume that if a ClowdEnvironment has the TLS port/privatePort configured then the cluster has been set up with the Service CA Operator, and so it is safe to assume the `openshift-service-ca.crt` ConfigMap is available in every namespace.