### PR TITLE
Revert "Always populate tlsCAPath if TLS ports are defined in environment"

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdenvironment_types.go
@@ -125,10 +125,10 @@ type TLS struct {
 	// Determines whether TLS is enabled for ClowdApp deployments by default
 	Enabled bool `json:"enabled,omitempty"`
 
-	// Sets the port exposed for ClowdApp deployments' TLS connections. If unset, TLS is disabled in the environment.
+	// Sets the port exposed for ClowdApp deployments' TLS connections
 	Port int32 `json:"port,omitempty"`
 
-	// Sets the private port exposed for ClowdApp deployments' TLS connections. If unset, TLS is disabled in the environment.
+	// Sets the private port exposed for ClowdApp deployments' TLS connections
 	PrivatePort int32 `json:"privatePort,omitempty"`
 }
 

--- a/config/crd/bases/cloud.redhat.com_clowdapprefs.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdapprefs.yaml
@@ -205,12 +205,12 @@ spec:
                         type: boolean
                       port:
                         description: Sets the port exposed for ClowdApp deployments'
-                          TLS connections. If unset, TLS is disabled in the environment.
+                          TLS connections
                         format: int32
                         type: integer
                       privatePort:
                         description: Sets the private port exposed for ClowdApp deployments'
-                          TLS connections. If unset, TLS is disabled in the environment.
+                          TLS connections
                         format: int32
                         type: integer
                     type: object

--- a/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdenvironments.yaml
@@ -969,13 +969,12 @@ spec:
                             type: boolean
                           port:
                             description: Sets the port exposed for ClowdApp deployments'
-                              TLS connections. If unset, TLS is disabled in the environment.
+                              TLS connections
                             format: int32
                             type: integer
                           privatePort:
                             description: Sets the private port exposed for ClowdApp
-                              deployments' TLS connections. If unset, TLS is disabled
-                              in the environment.
+                              deployments' TLS connections
                             format: int32
                             type: integer
                         type: object

--- a/controllers/cloud.redhat.com/providers/utils/utils.go
+++ b/controllers/cloud.redhat.com/providers/utils/utils.go
@@ -398,16 +398,8 @@ func AppendEnvVarsFromSecret(envvars []core.EnvVar, secName string, inputs ...Se
 	return envvars
 }
 
-// IsTLSConfiguredForEnv returns true if the public and private TLS ports are defined on the ClowdEnvironment
-func IsTLSConfiguredForEnv(envTLSConfig *crd.TLS) bool {
-	return envTLSConfig.Port != 0 && envTLSConfig.PrivatePort != 0
-}
-
 // IsPublicTLSEnabled returns true if public TLS is enabled at the ClowdApp deployment level or at the ClowdEnvironment web provider level
 func IsPublicTLSEnabled(deploymentWebConfig *crd.WebServices, envTLSConfig *crd.TLS) bool {
-	if !IsTLSConfiguredForEnv(envTLSConfig) {
-		return false
-	}
 	if deploymentWebConfig.Public.TLS != nil {
 		return *deploymentWebConfig.Public.TLS
 	}
@@ -416,9 +408,6 @@ func IsPublicTLSEnabled(deploymentWebConfig *crd.WebServices, envTLSConfig *crd.
 
 // IsPrivateTLSEnabled returns true if private TLS is enabled at the ClowdApp deployment level or at the ClowdEnvironment web provider level
 func IsPrivateTLSEnabled(deploymentWebConfig *crd.WebServices, envTLSConfig *crd.TLS) bool {
-	if !IsTLSConfiguredForEnv(envTLSConfig) {
-		return false
-	}
 	if deploymentWebConfig.Private.TLS != nil {
 		return *deploymentWebConfig.Private.TLS
 	}

--- a/controllers/cloud.redhat.com/providers/web/local.go
+++ b/controllers/cloud.redhat.com/providers/web/local.go
@@ -104,7 +104,8 @@ func (web *localWebProvider) Provide(app *crd.ClowdApp) error {
 	}
 	web.Config.PrivatePort = utils.IntPtr(int(privatePort))
 
-	envTLSConfig := &web.Env.Spec.Providers.Web.TLS
+	// 'true' if TLS is enabled for 1 or more deployments on this ClowdApp
+	var tlsEnabled bool
 
 	for _, deployment := range app.Spec.Deployments {
 		innerDeployment := deployment
@@ -152,7 +153,10 @@ func (web *localWebProvider) Provide(app *crd.ClowdApp) error {
 			return err
 		}
 
-		if provutils.IsTLSConfiguredForEnv(envTLSConfig) {
+		deploymentWebConfig := &innerDeployment.WebServices
+		envTLSConfig := &web.Env.Spec.Providers.Web.TLS
+		if provutils.IsAnyTLSEnabled(deploymentWebConfig, envTLSConfig) {
+			tlsEnabled = true
 			provutils.AddCertVolume(&d.Spec.Template.Spec, dnn.Name)
 		}
 
@@ -169,9 +173,10 @@ func (web *localWebProvider) Provide(app *crd.ClowdApp) error {
 		if err := web.Cache.Update(WebSecret, sec); err != nil {
 			return err
 		}
+
 	}
 
-	if provutils.IsTLSConfiguredForEnv(envTLSConfig) {
+	if tlsEnabled {
 		web.populateCA()
 	}
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1669,8 +1669,8 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `enabled` _boolean_ | Determines whether TLS is enabled for ClowdApp deployments by default |  |  |
-| `port` _integer_ | Sets the port exposed for ClowdApp deployments' TLS connections. If unset, TLS is disabled in the environment. |  |  |
-| `privatePort` _integer_ | Sets the private port exposed for ClowdApp deployments' TLS connections. If unset, TLS is disabled in the environment. |  |  |
+| `port` _integer_ | Sets the port exposed for ClowdApp deployments' TLS connections |  |  |
+| `privatePort` _integer_ | Sets the private port exposed for ClowdApp deployments' TLS connections |  |  |
 
 
 #### TestingConfig

--- a/tests/kuttl/test-tls-web-services-app-overrides/01-assert.yaml
+++ b/tests/kuttl/test-tls-web-services-app-overrides/01-assert.yaml
@@ -122,11 +122,7 @@ spec:
         secret:
           defaultMode: 420
           secretName: clowdapp-tls-disabled
-      - configMap:
-          defaultMode: 420
-          name: openshift-service-ca.crt
-        name: tls-ca
-      # Should NOT have caddy-config or caddy-tls volumes
+      # Should NOT have caddy-config, caddy-tls, or tls-ca volumes
 ---
 # Assert that clowdapp-tls-disabled does NOT have TLS ports in its service
 apiVersion: v1

--- a/tests/kuttl/test-tls-web-services-app-overrides/02-json-asserts.yaml
+++ b/tests/kuttl/test-tls-web-services-app-overrides/02-json-asserts.yaml
@@ -35,8 +35,8 @@ commands:
 - script: jq -r '.endpoints[] | select(.name == "processor" and .app == "clowdapp-tls-disabled") | .tlsPort == 0' < /tmp/test-tls-disabled-json
 - script: jq -r '.privateEndpoints[] | select(.name == "processor" and .app == "clowdapp-tls-disabled") | .tlsPort == 0' < /tmp/test-tls-disabled-json
 
-# TLS CA path should be set on all ClowdApps, ensure it is also set on this ClowdApp
-- script: jq -r '.tlsCAPath == "/cdapp/certs/service-ca.crt"' -e < /tmp/test-tls-disabled-json
+# TLS CA path should not be set when TLS is disabled
+- script: jq -r '.tlsCAPath' < /tmp/test-tls-disabled-json | grep -q "null"
 
 # Verify dependencies are properly configured in clowdapp-tls-disabled
 # It should have clowdapp-tls-enabled as a dependency with TLS ports


### PR DESCRIPTION
Reverts RedHatInsights/clowder#1411

We can't roll this out yet due to some app teams using the presence of 'tlsCAPath' as an "on/off switch" for using TLS across the whole environment.