### PR TITLE
Run E2E tests through provisioned on-demand EC2 instances

### DIFF
--- a/.tekton/clowder-pull-request.yaml
+++ b/.tekton/clowder-pull-request.yaml
@@ -323,76 +323,29 @@ spec:
           workingDir: /opt/app-root/src
         - computeResources: {}
           env:
-          # AWS Configuration for dynamic EC2 provisioning from pre-built AMI
-          - name: AWS_REGION
+          - name: MINIKUBE_HOST
             valueFrom:
               secretKeyRef:
-                key: AWS_REGION
-                name: aws-ec2-config
-          - name: EC2_AMI_ID
+                key: MINIKUBE_HOST
+                name: minikube-ssh-key
+          - name: MINIKUBE_USER
             valueFrom:
               secretKeyRef:
-                key: EC2_AMI_ID
-                name: aws-ec2-config
-          - name: EC2_KEY_PAIR_NAME
+                key: MINIKUBE_USER
+                name: minikube-ssh-key
+          - name: MINIKUBE_SSH_KEY
             valueFrom:
               secretKeyRef:
-                key: EC2_KEY_PAIR_NAME
-                name: aws-ec2-config
-          - name: EC2_SECURITY_GROUP_ID
+                key: MINIKUBE_SSH_KEY
+                name: minikube-ssh-key
+          - name: MINIKUBE_ROOTDIR
             valueFrom:
               secretKeyRef:
-                key: EC2_SECURITY_GROUP_ID
-                name: aws-ec2-config
-          - name: EC2_SUBNET_ID
-            valueFrom:
-              secretKeyRef:
-                key: EC2_SUBNET_ID
-                name: aws-ec2-config
-          - name: EC2_PRIVATE_KEY_CONTENT
-            valueFrom:
-              secretKeyRef:
-                key: EC2_PRIVATE_KEY_CONTENT
-                name: aws-ec2-config
-          # Optional configurations (can be omitted to use defaults)
-          - name: EC2_INSTANCE_TYPE
-            value: "m5.2xlarge"
-          - name: KUBERNETES_VERSION
-            value: "1.30"
-          # AWS credentials (if not using IAM roles)
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                key: AWS_ACCESS_KEY_ID
-                name: aws-ec2-config
-                optional: true
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                key: AWS_SECRET_ACCESS_KEY
-                name: aws-ec2-config
-                optional: true
+                key: MINIKUBE_ROOTDIR
+                name: minikube-ssh-key
           image: registry.access.redhat.com/ubi8/ubi:8.10-1756195303
           name: e2e-tests
-          script: |
-            set -ex
-            
-            # Install required packages including AWS CLI
-            dnf install -y git openssh-clients python3.12 make jq diffutils unzip curl
-            
-            # Install AWS CLI v2
-            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-            unzip awscliv2.zip
-            ./aws/install
-            
-            # Verify AWS CLI installation
-            aws --version
-            
-            # Test AWS credentials
-            aws sts get-caller-identity || echo "Warning: AWS credentials may not be configured"
-            
-            # Run the dynamic E2E tests with pre-built AMI
-            ci/konflux_minikube_e2e_tests_dynamic.sh
+          script: set -ex && dnf install -y git openssh-clients python3.12 make jq diffutils && ci/konflux_minikube_e2e_tests.sh
           workingDir: /var/workdir/source
         volumes:
         - emptyDir: {}

--- a/.tekton/clowder-pull-request.yaml
+++ b/.tekton/clowder-pull-request.yaml
@@ -345,7 +345,7 @@ spec:
                 name: minikube-ssh-key
           image: registry.access.redhat.com/ubi8/ubi:8.10-1756195303
           name: e2e-tests
-          script: set -ex && dnf install -y git openssh-clients python3.12 make jq diffutils && ci/konflux_minikube_e2e_tests.sh
+          script: set -ex && dnf install -y git openssh-clients python3.12 make jq diffutils && ci/konflux_minikube_e2e_tests_dynamic.sh
           workingDir: /var/workdir/source
         volumes:
         - emptyDir: {}

--- a/.tekton/clowder-pull-request.yaml
+++ b/.tekton/clowder-pull-request.yaml
@@ -323,29 +323,76 @@ spec:
           workingDir: /opt/app-root/src
         - computeResources: {}
           env:
-          - name: MINIKUBE_HOST
+          # AWS Configuration for dynamic EC2 provisioning from pre-built AMI
+          - name: AWS_REGION
             valueFrom:
               secretKeyRef:
-                key: MINIKUBE_HOST
-                name: minikube-ssh-key
-          - name: MINIKUBE_USER
+                key: AWS_REGION
+                name: aws-ec2-config
+          - name: EC2_AMI_ID
             valueFrom:
               secretKeyRef:
-                key: MINIKUBE_USER
-                name: minikube-ssh-key
-          - name: MINIKUBE_SSH_KEY
+                key: EC2_AMI_ID
+                name: aws-ec2-config
+          - name: EC2_KEY_PAIR_NAME
             valueFrom:
               secretKeyRef:
-                key: MINIKUBE_SSH_KEY
-                name: minikube-ssh-key
-          - name: MINIKUBE_ROOTDIR
+                key: EC2_KEY_PAIR_NAME
+                name: aws-ec2-config
+          - name: EC2_SECURITY_GROUP_ID
             valueFrom:
               secretKeyRef:
-                key: MINIKUBE_ROOTDIR
-                name: minikube-ssh-key
+                key: EC2_SECURITY_GROUP_ID
+                name: aws-ec2-config
+          - name: EC2_SUBNET_ID
+            valueFrom:
+              secretKeyRef:
+                key: EC2_SUBNET_ID
+                name: aws-ec2-config
+          - name: EC2_PRIVATE_KEY_CONTENT
+            valueFrom:
+              secretKeyRef:
+                key: EC2_PRIVATE_KEY_CONTENT
+                name: aws-ec2-config
+          # Optional configurations (can be omitted to use defaults)
+          - name: EC2_INSTANCE_TYPE
+            value: "m5.2xlarge"
+          - name: KUBERNETES_VERSION
+            value: "1.30"
+          # AWS credentials (if not using IAM roles)
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                key: AWS_ACCESS_KEY_ID
+                name: aws-ec2-config
+                optional: true
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                key: AWS_SECRET_ACCESS_KEY
+                name: aws-ec2-config
+                optional: true
           image: registry.access.redhat.com/ubi8/ubi:8.10-1756195303
           name: e2e-tests
-          script: set -ex && dnf install -y git openssh-clients python3.12 make jq diffutils && ci/konflux_minikube_e2e_tests.sh
+          script: |
+            set -ex
+            
+            # Install required packages including AWS CLI
+            dnf install -y git openssh-clients python3.12 make jq diffutils unzip curl
+            
+            # Install AWS CLI v2
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+            unzip awscliv2.zip
+            ./aws/install
+            
+            # Verify AWS CLI installation
+            aws --version
+            
+            # Test AWS credentials
+            aws sts get-caller-identity || echo "Warning: AWS credentials may not be configured"
+            
+            # Run the dynamic E2E tests with pre-built AMI
+            ci/konflux_minikube_e2e_tests_dynamic.sh
           workingDir: /var/workdir/source
         volumes:
         - emptyDir: {}

--- a/.tekton/clowder-pull-request.yaml
+++ b/.tekton/clowder-pull-request.yaml
@@ -343,6 +343,11 @@ spec:
               secretKeyRef:
                 key: MINIKUBE_ROOTDIR
                 name: minikube-ssh-key
+          - name: MINIKUBE_EC2_AMI_ID
+            valueFrom:
+              secretKeyRef:
+                key: EC2_AMI_ID
+                name: minikube-ec2-ami-id
           image: registry.access.redhat.com/ubi8/ubi:8.10-1756195303
           name: e2e-tests
           script: set -ex && dnf install -y git openssh-clients python3.12 make jq diffutils && ci/konflux_minikube_e2e_tests_dynamic.sh

--- a/.tekton/clowder-pull-request.yaml
+++ b/.tekton/clowder-pull-request.yaml
@@ -346,7 +346,7 @@ spec:
           - name: MINIKUBE_EC2_AMI_ID
             valueFrom:
               secretKeyRef:
-                key: EC2_AMI_ID
+                key: MINIKUBE_EC2_AMI_ID
                 name: minikube-ec2-ami-id
           image: registry.access.redhat.com/ubi8/ubi:8.10-1756195303
           name: e2e-tests

--- a/ci/README_dynamic_e2e.md
+++ b/ci/README_dynamic_e2e.md
@@ -30,7 +30,7 @@ Main E2E test script that integrates provisioning, testing, and cleanup using th
 AWS_REGION="us-east-1"
 
 # Pre-built AMI with Minikube installed
-EC2_AMI_ID="ami-xxxxxxxxx"
+MINIKUBE_EC2_AMI_ID="ami-xxxxxxxxx"
 
 # EC2 instance configuration
 EC2_KEY_PAIR_NAME="your-key-pair-name"
@@ -144,7 +144,7 @@ The AWS credentials used must have permissions for:
 ```bash
 # Set up environment variables
 export AWS_REGION="us-east-1"
-export EC2_AMI_ID="ami-xxxxxxxxx"
+export MINIKUBE_EC2_AMI_ID="ami-xxxxxxxxx"
 export EC2_KEY_PAIR_NAME="my-key-pair"
 export EC2_SECURITY_GROUP_ID="sg-xxxxxxxxx"
 export EC2_SUBNET_ID="subnet-xxxxxxxxx"
@@ -166,7 +166,7 @@ metadata:
 type: Opaque
 stringData:
   AWS_REGION: "us-east-1"
-  EC2_AMI_ID: "ami-xxxxxxxxx"
+  MINIKUBE_EC2_AMI_ID: "ami-xxxxxxxxx"
   EC2_KEY_PAIR_NAME: "clowder-ci-key"
   EC2_SECURITY_GROUP_ID: "sg-xxxxxxxxx"
   EC2_SUBNET_ID: "subnet-xxxxxxxxx"

--- a/ci/README_dynamic_e2e.md
+++ b/ci/README_dynamic_e2e.md
@@ -1,0 +1,232 @@
+# Dynamic EC2 E2E Testing with Pre-built AMI
+
+This directory contains scripts for running Clowder E2E tests on dynamically provisioned EC2 instances using a pre-built AMI with Minikube already installed.
+
+## Overview
+
+The new setup provides:
+- **Fresh environment** for each test run using pre-built AMI
+- **Faster provisioning** since Minikube is pre-installed
+- **Better isolation** between test runs
+- **Automatic cleanup** to prevent resource leaks
+- **Cost optimization** by only running instances when needed
+
+## Scripts
+
+### `provision_ec2_minikube.sh`
+Provisions a new EC2 instance from a pre-built AMI with Minikube already installed and configured.
+
+### `cleanup_ec2_minikube.sh`
+Terminates EC2 instances created for E2E testing with multiple cleanup methods.
+
+### `konflux_minikube_e2e_tests_dynamic.sh`
+Main E2E test script that integrates provisioning, testing, and cleanup using the pre-built AMI.
+
+## Required Environment Variables
+
+### AWS Configuration
+```bash
+# AWS region for EC2 instances
+AWS_REGION="us-east-1"
+
+# Pre-built AMI with Minikube installed
+EC2_AMI_ID="ami-xxxxxxxxx"
+
+# EC2 instance configuration
+EC2_KEY_PAIR_NAME="your-key-pair-name"
+EC2_SECURITY_GROUP_ID="sg-xxxxxxxxx"
+EC2_SUBNET_ID="subnet-xxxxxxxxx"
+
+# For Tekton/CI environments, use this instead of EC2_PRIVATE_KEY_PATH
+EC2_PRIVATE_KEY_CONTENT="-----BEGIN RSA PRIVATE KEY-----\n..."
+
+# For local testing
+EC2_PRIVATE_KEY_PATH="/path/to/your/private/key.pem"
+```
+
+### Optional Configuration
+```bash
+# EC2 instance type (default: m5.2xlarge)
+EC2_INSTANCE_TYPE="m5.2xlarge"
+
+# Kubernetes version (default: 1.30)
+KUBERNETES_VERSION="1.30"
+
+# Whether to wait for instance termination during cleanup (default: true)
+WAIT_FOR_TERMINATION="true"
+```
+
+## Pre-built AMI Requirements
+
+The AMI must have the following pre-installed:
+- **Docker** (latest stable version)
+- **Minikube** (v1.34.0 or compatible)
+- **kubectl** (compatible with Kubernetes 1.30)
+- **conntrack** (required for minikube)
+- **Basic utilities**: curl, wget, unzip, git
+
+### Recommended AMI Setup
+```bash
+# Base: Amazon Linux 2 or Ubuntu 20.04+
+# Install Docker
+sudo yum install -y docker  # Amazon Linux 2
+sudo systemctl start docker
+sudo systemctl enable docker
+sudo usermod -aG docker ec2-user
+
+# Install kubectl
+curl -LO "https://dl.k8s.io/release/v1.30.0/bin/linux/amd64/kubectl"
+chmod +x kubectl
+sudo mv kubectl /usr/local/bin/
+
+# Install Minikube
+curl -LO https://storage.googleapis.com/minikube/releases/v1.34.0/minikube-linux-amd64
+chmod +x minikube-linux-amd64
+sudo mv minikube-linux-amd64 /usr/local/bin/minikube
+
+# Install conntrack
+sudo yum install -y conntrack  # Amazon Linux 2
+
+# Prepare minikube directory
+mkdir -p /home/ec2-user/.minikube
+chown -R ec2-user:ec2-user /home/ec2-user/.minikube
+```
+
+## AWS Infrastructure Requirements
+
+### 1. VPC and Networking
+- A VPC with internet gateway
+- A public subnet with auto-assign public IP enabled
+- Route table configured for internet access
+
+### 2. Security Group
+Create a security group with the following rules:
+```
+Inbound Rules:
+- SSH (22): Your IP or CI/CD IP ranges
+- Custom TCP (8443): Your IP or CI/CD IP ranges (for Kubernetes API)
+
+Outbound Rules:
+- All traffic (0.0.0.0/0) - for downloading packages and images
+```
+
+### 3. EC2 Key Pair
+- Create an EC2 key pair in your target region
+- Store the private key securely (for CI/CD, use secrets management)
+
+### 4. IAM Permissions
+The AWS credentials used must have permissions for:
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:RunInstances",
+                "ec2:TerminateInstances",
+                "ec2:DescribeInstances",
+                "ec2:DescribeInstanceStatus",
+                "ec2:CreateTags",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeKeyPairs"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+## Usage
+
+### Local Testing
+```bash
+# Set up environment variables
+export AWS_REGION="us-east-1"
+export EC2_AMI_ID="ami-xxxxxxxxx"
+export EC2_KEY_PAIR_NAME="my-key-pair"
+export EC2_SECURITY_GROUP_ID="sg-xxxxxxxxx"
+export EC2_SUBNET_ID="subnet-xxxxxxxxx"
+export EC2_PRIVATE_KEY_PATH="/path/to/key.pem"
+
+# Run the dynamic E2E tests
+./ci/konflux_minikube_e2e_tests_dynamic.sh
+```
+
+### CI/CD Integration (Tekton)
+Update your Tekton pipeline to use the new script and provide the required environment variables through secrets.
+
+Example secret configuration:
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-ec2-config
+type: Opaque
+stringData:
+  AWS_REGION: "us-east-1"
+  EC2_AMI_ID: "ami-xxxxxxxxx"
+  EC2_KEY_PAIR_NAME: "clowder-ci-key"
+  EC2_SECURITY_GROUP_ID: "sg-xxxxxxxxx"
+  EC2_SUBNET_ID: "subnet-xxxxxxxxx"
+  EC2_PRIVATE_KEY_CONTENT: |
+    -----BEGIN RSA PRIVATE KEY-----
+    ...
+    -----END RSA PRIVATE KEY-----
+```
+
+## Migration from Static Instance
+
+### Tekton Pipeline Changes
+1. Replace environment variables:
+   - Remove: `MINIKUBE_HOST`, `MINIKUBE_USER`, `MINIKUBE_SSH_KEY`, `MINIKUBE_ROOTDIR`
+   - Add: AWS configuration variables listed above
+
+2. Update the script reference:
+   ```bash
+   # Old
+   ci/konflux_minikube_e2e_tests.sh
+   
+   # New
+   ci/konflux_minikube_e2e_tests_dynamic.sh
+   ```
+
+3. Update secret references in your pipeline configuration
+
+### Benefits of Migration
+- **Consistency**: Each test run starts with a clean environment
+- **Speed**: Faster provisioning with pre-built AMI
+- **Reliability**: No accumulated state issues
+- **Cost Efficiency**: Only pay for compute time during test runs
+- **Scalability**: Can run multiple tests in parallel
+
+## Troubleshooting
+
+### Common Issues
+
+1. **AMI Validation**: Ensure Minikube is properly installed on the AMI
+2. **AWS Permissions**: Ensure IAM user/role has required EC2 permissions
+3. **Network Configuration**: Verify security group and subnet settings
+4. **Key Pair**: Ensure EC2 key pair exists in the target region
+5. **Instance Limits**: Check AWS service limits for EC2 instances
+
+### Getting Help
+
+- Check the logs in `/var/workdir/artifacts/` for detailed error information
+- Verify AMI has all required components installed
+- Review the cleanup logs to ensure instances are properly terminated
+
+## Cost Considerations
+
+The dynamic approach with pre-built AMI provides optimal cost efficiency:
+- Instances only run during test execution (~20-30 minutes with pre-built AMI)
+- No idle time costs for long-running instances
+- Automatic cleanup prevents forgotten instances
+- Faster provisioning reduces overall test time
+
+Estimated cost comparison (us-east-1, m5.2xlarge):
+- **Static Instance**: $0.384/hour × 24 hours × 30 days = ~$276/month
+- **Dynamic Instance (pre-built AMI)**: $0.384/hour × 0.5 hour × 30 test runs = ~$6/month
+
+*Actual costs may vary based on usage patterns and AWS pricing changes.*

--- a/ci/cleanup_ec2_minikube.sh
+++ b/ci/cleanup_ec2_minikube.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# EC2 Minikube Instance Cleanup Script
+# This script terminates the EC2 instance created for E2E testing
+
+# Function to cleanup instance by ID
+cleanup_instance() {
+    local instance_id="$1"
+    local region="$2"
+    
+    echo "*** Terminating EC2 instance: $instance_id in region: $region"
+    
+    # Check if instance exists and is not already terminated
+    INSTANCE_STATE=$(aws ec2 describe-instances \
+        --region "$region" \
+        --instance-ids "$instance_id" \
+        --query 'Reservations[0].Instances[0].State.Name' \
+        --output text 2>/dev/null || echo "not-found")
+    
+    if [ "$INSTANCE_STATE" = "not-found" ]; then
+        echo "*** Instance $instance_id not found, may have been already terminated"
+        return 0
+    elif [ "$INSTANCE_STATE" = "terminated" ] || [ "$INSTANCE_STATE" = "terminating" ]; then
+        echo "*** Instance $instance_id is already $INSTANCE_STATE"
+        return 0
+    fi
+    
+    echo "*** Instance $instance_id is in state: $INSTANCE_STATE"
+    
+    # Terminate the instance
+    aws ec2 terminate-instances \
+        --region "$region" \
+        --instance-ids "$instance_id" \
+        --output text
+    
+    echo "*** Termination request sent for instance: $instance_id"
+    
+    # Optionally wait for termination (can be disabled for faster cleanup)
+    if [ "${WAIT_FOR_TERMINATION:-true}" = "true" ]; then
+        echo "*** Waiting for instance to terminate..."
+        aws ec2 wait instance-terminated --region "$region" --instance-ids "$instance_id" || {
+            echo "*** Warning: Timeout waiting for instance termination, but termination was requested"
+        }
+        echo "*** Instance $instance_id has been terminated"
+    fi
+}
+
+# Method 1: Use environment variables if available
+if [ -n "${MINIKUBE_INSTANCE_ID:-}" ] && [ -n "${AWS_REGION:-}" ]; then
+    echo "*** Using environment variables for cleanup"
+    cleanup_instance "$MINIKUBE_INSTANCE_ID" "$AWS_REGION"
+    exit 0
+fi
+
+# Method 2: Use instance info file if available
+if [ -f "/tmp/minikube-instance-info" ]; then
+    echo "*** Loading instance info from /tmp/minikube-instance-info"
+    source /tmp/minikube-instance-info
+    
+    if [ -n "${MINIKUBE_INSTANCE_ID:-}" ] && [ -n "${AWS_REGION:-}" ]; then
+        cleanup_instance "$MINIKUBE_INSTANCE_ID" "$AWS_REGION"
+        rm -f /tmp/minikube-instance-info
+        exit 0
+    else
+        echo "*** Error: Instance info file exists but missing required variables"
+        exit 1
+    fi
+fi
+
+# Method 3: Use command line arguments
+if [ $# -eq 2 ]; then
+    INSTANCE_ID="$1"
+    REGION="$2"
+    echo "*** Using command line arguments for cleanup"
+    cleanup_instance "$INSTANCE_ID" "$REGION"
+    exit 0
+fi
+
+# Method 4: Find instances by tags (fallback)
+echo "*** No instance ID provided, searching for clowder E2E instances..."
+: ${AWS_REGION:="us-east-1"}
+
+# Find instances tagged for clowder E2E testing that are not terminated
+INSTANCE_IDS=$(aws ec2 describe-instances \
+    --region "$AWS_REGION" \
+    --filters \
+        "Name=tag:Purpose,Values=clowder-e2e-testing" \
+        "Name=tag:AutoDelete,Values=true" \
+        "Name=instance-state-name,Values=pending,running,shutting-down,stopping,stopped" \
+    --query 'Reservations[].Instances[].InstanceId' \
+    --output text)
+
+if [ -z "$INSTANCE_IDS" ]; then
+    echo "*** No clowder E2E instances found to cleanup"
+    exit 0
+fi
+
+echo "*** Found instances to cleanup: $INSTANCE_IDS"
+
+# Cleanup each found instance
+for instance_id in $INSTANCE_IDS; do
+    cleanup_instance "$instance_id" "$AWS_REGION"
+done
+
+echo "*** Cleanup completed!"

--- a/ci/konflux_minikube_e2e_tests_dynamic.sh
+++ b/ci/konflux_minikube_e2e_tests_dynamic.sh
@@ -25,8 +25,8 @@ trap cleanup_on_exit EXIT INT TERM
 : ${AWS_REGION:="us-east-1"}
 : ${MINIKUBE_EC2_AMI_ID:?"MINIKUBE_EC2_AMI_ID must be set (pre-built AMI with Minikube)"}
 # : ${EC2_KEY_PAIR_NAME:?"EC2_KEY_PAIR_NAME must be set"}
-: ${EC2_SECURITY_GROUP_ID:?"EC2_SECURITY_GROUP_ID must be set"}
-: ${EC2_SUBNET_ID:?"EC2_SUBNET_ID must be set"}
+# : ${EC2_SECURITY_GROUP_ID:?"EC2_SECURITY_GROUP_ID must be set"}
+# : ${EC2_SUBNET_ID:?"EC2_SUBNET_ID must be set"}
 
 # Handle private key - either as file path or content
 if [ -n "${EC2_PRIVATE_KEY_CONTENT:-}" ]; then

--- a/ci/konflux_minikube_e2e_tests_dynamic.sh
+++ b/ci/konflux_minikube_e2e_tests_dynamic.sh
@@ -23,7 +23,7 @@ trap cleanup_on_exit EXIT INT TERM
 
 # Validate required AWS environment variables
 : ${AWS_REGION:="us-east-1"}
-: ${EC2_AMI_ID:?"EC2_AMI_ID must be set (pre-built AMI with Minikube)"}
+: ${MINIKUBE_EC2_AMI_ID:?"MINIKUBE_EC2_AMI_ID must be set (pre-built AMI with Minikube)"}
 : ${EC2_KEY_PAIR_NAME:?"EC2_KEY_PAIR_NAME must be set"}
 : ${EC2_SECURITY_GROUP_ID:?"EC2_SECURITY_GROUP_ID must be set"}
 : ${EC2_SUBNET_ID:?"EC2_SUBNET_ID must be set"}

--- a/ci/konflux_minikube_e2e_tests_dynamic.sh
+++ b/ci/konflux_minikube_e2e_tests_dynamic.sh
@@ -29,24 +29,24 @@ trap cleanup_on_exit EXIT INT TERM
 # : ${EC2_SUBNET_ID:?"EC2_SUBNET_ID must be set"}
 
 # Handle private key - either as file path or content
-if [ -n "${EC2_PRIVATE_KEY_CONTENT:-}" ]; then
-    # For CI/CD environments, create key file from content
-    export EC2_PRIVATE_KEY_PATH="/tmp/ec2-private-key.pem"
-    echo -e "$EC2_PRIVATE_KEY_CONTENT" > "$EC2_PRIVATE_KEY_PATH"
-    chmod 600 "$EC2_PRIVATE_KEY_PATH"
-    echo "*** Created private key file from EC2_PRIVATE_KEY_CONTENT"
-elif [ -n "${EC2_PRIVATE_KEY_PATH:-}" ]; then
-    # For local environments, use existing file path
-    if [ ! -f "$EC2_PRIVATE_KEY_PATH" ]; then
-        echo "*** Error: Private key file not found at $EC2_PRIVATE_KEY_PATH"
-        exit 1
-    fi
-    chmod 600 "$EC2_PRIVATE_KEY_PATH"
-    echo "*** Using existing private key file at $EC2_PRIVATE_KEY_PATH"
-else
-    echo "*** Error: Either EC2_PRIVATE_KEY_PATH or EC2_PRIVATE_KEY_CONTENT must be set"
-    exit 1
-fi
+# if [ -n "${EC2_PRIVATE_KEY_CONTENT:-}" ]; then
+#     # For CI/CD environments, create key file from content
+#     export EC2_PRIVATE_KEY_PATH="/tmp/ec2-private-key.pem"
+#     echo -e "$EC2_PRIVATE_KEY_CONTENT" > "$EC2_PRIVATE_KEY_PATH"
+#     chmod 600 "$EC2_PRIVATE_KEY_PATH"
+#     echo "*** Created private key file from EC2_PRIVATE_KEY_CONTENT"
+# elif [ -n "${EC2_PRIVATE_KEY_PATH:-}" ]; then
+#     # For local environments, use existing file path
+#     if [ ! -f "$EC2_PRIVATE_KEY_PATH" ]; then
+#         echo "*** Error: Private key file not found at $EC2_PRIVATE_KEY_PATH"
+#         exit 1
+#     fi
+#     chmod 600 "$EC2_PRIVATE_KEY_PATH"
+#     echo "*** Using existing private key file at $EC2_PRIVATE_KEY_PATH"
+# else
+#     echo "*** Error: Either EC2_PRIVATE_KEY_PATH or EC2_PRIVATE_KEY_CONTENT must be set"
+#     exit 1
+# fi
 
 echo "*** Starting Clowder E2E tests with dynamic EC2 provisioning (pre-built AMI) ***"
 
@@ -98,8 +98,8 @@ echo "*** Using Minikube instance: $MINIKUBE_INSTANCE_ID at $MINIKUBE_HOST"
 set +x
 
 # Create SSH key file for connecting to the instance (copy from the validated key file)
-cp "$EC2_PRIVATE_KEY_PATH" minikube-ssh-ident
-chmod 600 minikube-ssh-ident
+# cp "$EC2_PRIVATE_KEY_PATH" minikube-ssh-ident
+# chmod 600 minikube-ssh-ident
 
 # Get minikube IP (Minikube is already started by the provisioning script)
 export MINIKUBE_IP=$(ssh -o StrictHostKeyChecking=no $MINIKUBE_USER@$MINIKUBE_HOST -i minikube-ssh-ident "minikube ip")

--- a/ci/konflux_minikube_e2e_tests_dynamic.sh
+++ b/ci/konflux_minikube_e2e_tests_dynamic.sh
@@ -24,7 +24,7 @@ trap cleanup_on_exit EXIT INT TERM
 # Validate required AWS environment variables
 : ${AWS_REGION:="us-east-1"}
 : ${MINIKUBE_EC2_AMI_ID:?"MINIKUBE_EC2_AMI_ID must be set (pre-built AMI with Minikube)"}
-: ${EC2_KEY_PAIR_NAME:?"EC2_KEY_PAIR_NAME must be set"}
+# : ${EC2_KEY_PAIR_NAME:?"EC2_KEY_PAIR_NAME must be set"}
 : ${EC2_SECURITY_GROUP_ID:?"EC2_SECURITY_GROUP_ID must be set"}
 : ${EC2_SUBNET_ID:?"EC2_SUBNET_ID must be set"}
 

--- a/ci/konflux_minikube_e2e_tests_dynamic.sh
+++ b/ci/konflux_minikube_e2e_tests_dynamic.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+
+set -exv
+
+# Dynamic EC2 Minikube E2E Testing Script (Pre-built AMI)
+# This script provisions a new EC2 instance from a pre-built AMI, runs E2E tests, and cleans up
+
+# Trap to ensure cleanup happens even on script failure
+cleanup_on_exit() {
+    local exit_code=$?
+    echo "*** Script exiting with code: $exit_code"
+    
+    if [ -n "${MINIKUBE_INSTANCE_ID:-}" ]; then
+        echo "*** Running cleanup due to script exit..."
+        # Run cleanup in background to avoid hanging the script
+        timeout 300 ./ci/cleanup_ec2_minikube.sh || echo "*** Warning: Cleanup may have timed out"
+    fi
+    
+    exit $exit_code
+}
+
+trap cleanup_on_exit EXIT INT TERM
+
+# Validate required AWS environment variables
+: ${AWS_REGION:="us-east-1"}
+: ${EC2_AMI_ID:?"EC2_AMI_ID must be set (pre-built AMI with Minikube)"}
+: ${EC2_KEY_PAIR_NAME:?"EC2_KEY_PAIR_NAME must be set"}
+: ${EC2_SECURITY_GROUP_ID:?"EC2_SECURITY_GROUP_ID must be set"}
+: ${EC2_SUBNET_ID:?"EC2_SUBNET_ID must be set"}
+
+# Handle private key - either as file path or content
+if [ -n "${EC2_PRIVATE_KEY_CONTENT:-}" ]; then
+    # For CI/CD environments, create key file from content
+    export EC2_PRIVATE_KEY_PATH="/tmp/ec2-private-key.pem"
+    echo -e "$EC2_PRIVATE_KEY_CONTENT" > "$EC2_PRIVATE_KEY_PATH"
+    chmod 600 "$EC2_PRIVATE_KEY_PATH"
+    echo "*** Created private key file from EC2_PRIVATE_KEY_CONTENT"
+elif [ -n "${EC2_PRIVATE_KEY_PATH:-}" ]; then
+    # For local environments, use existing file path
+    if [ ! -f "$EC2_PRIVATE_KEY_PATH" ]; then
+        echo "*** Error: Private key file not found at $EC2_PRIVATE_KEY_PATH"
+        exit 1
+    fi
+    chmod 600 "$EC2_PRIVATE_KEY_PATH"
+    echo "*** Using existing private key file at $EC2_PRIVATE_KEY_PATH"
+else
+    echo "*** Error: Either EC2_PRIVATE_KEY_PATH or EC2_PRIVATE_KEY_CONTENT must be set"
+    exit 1
+fi
+
+echo "*** Starting Clowder E2E tests with dynamic EC2 provisioning (pre-built AMI) ***"
+
+# Setup local environment (same as original script)
+mkdir -p /var/workdir/bin
+cd /var/workdir/bin
+
+export KUBEBUILDER_ASSETS=/var/workdir/testbin/bin
+
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"
+echo "$(cat kubectl.sha256)  ./kubectl" | sha256sum --check
+chmod +x kubectl
+
+export ARTIFACT_PATH=/var/workdir/artifacts
+mkdir -p $ARTIFACT_PATH
+
+export PATH="/var/workdir/bin:$PATH"
+cd /var/workdir/source
+
+# Install krew (same as original script)
+(
+  cd "$(mktemp -d)" &&
+  OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
+  ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
+  KREW="krew-${OS}_${ARCH}" &&
+  curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
+  tar zxvf "${KREW}.tar.gz" &&
+  ./"${KREW}" install krew
+)
+
+export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
+export PATH="/bins:$PATH"
+
+# Provision new EC2 instance with pre-built AMI
+echo "*** Provisioning new EC2 instance from pre-built AMI..."
+source ./ci/provision_ec2_minikube.sh
+
+# Load instance information
+if [ -f "/tmp/minikube-instance-info" ]; then
+    source /tmp/minikube-instance-info
+else
+    echo "*** Error: Instance information not found"
+    exit 1
+fi
+
+echo "*** Using Minikube instance: $MINIKUBE_INSTANCE_ID at $MINIKUBE_HOST"
+
+set +x
+
+# Create SSH key file for connecting to the instance (copy from the validated key file)
+cp "$EC2_PRIVATE_KEY_PATH" minikube-ssh-ident
+chmod 600 minikube-ssh-ident
+
+# Get minikube IP (Minikube is already started by the provisioning script)
+export MINIKUBE_IP=$(ssh -o StrictHostKeyChecking=no $MINIKUBE_USER@$MINIKUBE_HOST -i minikube-ssh-ident "minikube ip")
+
+set -x
+
+# Copy certificates from the remote minikube instance
+scp -o StrictHostKeyChecking=no -i minikube-ssh-ident $MINIKUBE_USER@$MINIKUBE_HOST:$MINIKUBE_ROOTDIR/.minikube/profiles/minikube/client.key ./
+scp -i minikube-ssh-ident $MINIKUBE_USER@$MINIKUBE_HOST:$MINIKUBE_ROOTDIR/.minikube/profiles/minikube/client.crt ./
+scp -i minikube-ssh-ident $MINIKUBE_USER@$MINIKUBE_HOST:$MINIKUBE_ROOTDIR/.minikube/ca.crt ./
+
+# Setup SSH port forwarding for kubectl access
+ssh -o ExitOnForwardFailure=yes -f -N -L 127.0.0.1:8444:$MINIKUBE_IP:8443 -i minikube-ssh-ident $MINIKUBE_USER@$MINIKUBE_HOST
+
+# Create kubeconfig for accessing the remote cluster
+cat > kube-config <<- EOM
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: $PWD/ca.crt
+    server: https://127.0.0.1:8444
+  name: 127-0-0-1:8444
+contexts:
+- context:
+    cluster: 127-0-0-1:8444
+    user: remote-minikube
+  name: remote-minikube
+users:
+- name: remote-minikube
+  user:
+    client-certificate: $PWD/client.crt
+    client-key: $PWD/client.key
+current-context: remote-minikube
+kind: Config
+preferences: {}
+EOM
+
+export PATH="$KUBEBUILDER_ASSETS:$PATH"
+
+export KUBECONFIG=$PWD/kube-config
+export KUBECTL_CMD="kubectl "
+$KUBECTL_CMD config use-context remote-minikube
+$KUBECTL_CMD get pods --all-namespaces=true
+
+# Setup Kubernetes environment (same as original script)
+source build/kube_setup.sh
+
+export IMAGE_TAG=$(git rev-parse --short=8 HEAD)
+
+$KUBECTL_CMD create namespace clowder-system
+
+$KUBECTL_CMD apply -f ../manifest.yaml --validate=false -n clowder-system
+
+## The default generated config isn't quite right for our tests - so we'll create a new one and restart clowder
+$KUBECTL_CMD apply -f clowder-config.yaml -n clowder-system
+$KUBECTL_CMD delete pod -n clowder-system -l operator-name=clowder
+
+# Wait for operator deployment...
+$KUBECTL_CMD rollout status deployment clowder-controller-manager -n clowder-system
+$KUBECTL_CMD krew install kuttl
+
+set +e
+
+$KUBECTL_CMD get env
+
+# Run the actual E2E tests
+source build/run_kuttl.sh --report xml
+KUTTL_RESULT=$?
+mv kuttl-report.xml $ARTIFACT_PATH/junit-kuttl.xml
+
+# Collect logs and metrics (same as original script)
+CLOWDER_PODS=$($KUBECTL_CMD get pod -n clowder-system -o jsonpath='{.items[*].metadata.name}')
+for pod in $CLOWDER_PODS; do
+    $KUBECTL_CMD logs $pod -n clowder-system > $ARTIFACT_PATH/$pod.log
+    $KUBECTL_CMD logs $pod -n clowder-system | ./parse-controller-logs > $ARTIFACT_PATH/$pod-parsed-controller-logs.log
+done
+
+# Grab the metrics
+$KUBECTL_CMD port-forward svc/clowder-controller-manager-metrics-service-non-auth -n clowder-system 8080 &
+sleep 5
+curl 127.0.0.1:8080/metrics > $ARTIFACT_PATH/clowder-metrics
+
+STRIMZI_PODS=$($KUBECTL_CMD get pod -n strimzi -o jsonpath='{.items[*].metadata.name}')
+for pod in $STRIMZI_PODS; do
+    $KUBECTL_CMD logs $pod -n strimzi > $ARTIFACT_PATH/$pod.log
+done
+
+set -e
+
+echo "*** E2E tests completed with result: $KUTTL_RESULT"
+
+# Cleanup will happen automatically via the trap
+echo "*** Test script finished, cleanup will be triggered by trap"
+
+exit $KUTTL_RESULT

--- a/ci/provision_ec2_minikube.sh
+++ b/ci/provision_ec2_minikube.sh
@@ -23,35 +23,23 @@ echo "Instance Type: $EC2_INSTANCE_TYPE"
 echo "AMI ID: $MINIKUBE_EC2_AMI_ID"
 echo "Region: $AWS_REGION"
 
-# Check if unzip is installed, install if not
-echo "*** Checking unzip installation..."
-if ! command -v unzip &> /dev/null; then
+# Note: We'll use tar instead of unzip for extracting AWS CLI
+echo "*** Using tar for zip extraction (avoiding unzip dependency)"
+
+# Check if AWS CLI is installed, install if not
+echo "*** Checking AWS CLI installation..."
+if ! command -v aws &> /dev/null; then
+    echo "*** AWS CLI not found, installing..."
+        
+    # Install AWS CLI on Linux using tar instead of unzip
+    curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+
+    tar -xf awscliv2.zip
     
-    # Create a local bin directory if it doesn't exist
-    mkdir -p "$HOME/bin"
+
     
-    # Download and install unzip statically linked binary
-    echo "*** Downloading unzip binary for Linux..."
-    
-    # Try to download a statically linked unzip binary
-    UNZIP_URL="http://archive.ubuntu.com/ubuntu/pool/main/u/unzip/unzip_6.0-25ubuntu1_amd64.deb"
-    
-    # Create temporary directory
-    TEMP_DIR=$(mktemp -d)
-    cd "$TEMP_DIR"
-    
-    # Download and extract unzip from deb package
-    curl -s "$UNZIP_URL" -o unzip.deb
-    ar x unzip.deb
-    tar -xf data.tar.xz
-    
-    # Copy unzip binary to user's bin directory
-    cp usr/bin/unzip "$HOME/bin/"
-    chmod +x "$HOME/bin/unzip"
-    
-    # Clean up
-    cd - > /dev/null
-    rm -rf "$TEMP_DIR"
+    # Install AWS CLI to user directory instead of system-wide
+    ./aws/install --install-dir "$HOME/.local/aws-cli" --bin-dir "$HOME/bin"
     
     # Add $HOME/bin to PATH if not already there
     if [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
@@ -59,26 +47,6 @@ if ! command -v unzip &> /dev/null; then
         echo "*** Added $HOME/bin to PATH"
     fi
     
-    # Verify unzip installation
-    if command -v unzip &> /dev/null; then
-        echo "*** unzip installation completed successfully"
-    else
-        echo "*** Error: unzip installation failed"
-        exit 1
-    fi
-else
-    echo "*** unzip is already installed"
-fi
-
-# Check if AWS CLI is installed, install if not
-echo "*** Checking AWS CLI installation..."
-if ! command -v aws &> /dev/null; then
-    echo "*** AWS CLI not found, installing..."
-        
-    # Install AWS CLI on Linux
-    curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-    unzip -q awscliv2.zip
-    sudo ./aws/install
     rm -rf awscliv2.zip aws/
     
     echo "*** AWS CLI installation completed"

--- a/ci/provision_ec2_minikube.sh
+++ b/ci/provision_ec2_minikube.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # Required environment variables
 : ${AWS_REGION:="us-east-1"}
 : ${EC2_INSTANCE_TYPE:="m5.2xlarge"}  # 8 vCPUs, 32 GB RAM
-: ${EC2_AMI_ID:?"EC2_AMI_ID must be set (pre-built AMI with Minikube)"}
+: ${MINIKUBE_EC2_AMI_ID:?"MINIKUBE_EC2_AMI_ID must be set (pre-built AMI with Minikube)"}
 : ${EC2_KEY_PAIR_NAME:?"EC2_KEY_PAIR_NAME must be set"}
 : ${EC2_SECURITY_GROUP_ID:?"EC2_SECURITY_GROUP_ID must be set"}
 : ${EC2_SUBNET_ID:?"EC2_SUBNET_ID must be set"}
@@ -20,14 +20,14 @@ set -euo pipefail
 echo "*** Provisioning EC2 instance for Clowder E2E tests ***"
 echo "Instance Name: $EC2_INSTANCE_NAME"
 echo "Instance Type: $EC2_INSTANCE_TYPE"
-echo "AMI ID: $EC2_AMI_ID"
+echo "AMI ID: $MINIKUBE_EC2_AMI_ID"
 echo "Region: $AWS_REGION"
 
 # Launch EC2 instance from pre-built AMI
 echo "*** Launching EC2 instance from pre-built AMI..."
 INSTANCE_ID=$(aws ec2 run-instances \
     --region "$AWS_REGION" \
-    --image-id "$EC2_AMI_ID" \
+    --image-id "$MINIKUBE_EC2_AMI_ID" \
     --instance-type "$EC2_INSTANCE_TYPE" \
     --key-name "$EC2_KEY_PAIR_NAME" \
     --security-group-ids "$EC2_SECURITY_GROUP_ID" \

--- a/ci/provision_ec2_minikube.sh
+++ b/ci/provision_ec2_minikube.sh
@@ -23,6 +23,40 @@ echo "Instance Type: $EC2_INSTANCE_TYPE"
 echo "AMI ID: $MINIKUBE_EC2_AMI_ID"
 echo "Region: $AWS_REGION"
 
+# Check if AWS CLI is installed, install if not
+echo "*** Checking AWS CLI installation..."
+if ! command -v aws &> /dev/null; then
+    echo "*** AWS CLI not found, installing..."
+    
+    if [[ "$ARCH" == "x86_64" ]]; then
+        AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+    elif [[ "$ARCH" == "aarch64" ]]; then
+        AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
+    else
+        echo "*** Error: Unsupported Linux architecture: $ARCH"
+        exit 1
+    fi
+        
+    # Install AWS CLI on Linux
+    curl -s "$AWS_CLI_URL" -o "awscliv2.zip"
+    unzip -q awscliv2.zip
+    sudo ./aws/install
+    rm -rf awscliv2.zip aws/
+    
+    echo "*** AWS CLI installation completed"
+else
+    echo "*** AWS CLI is already installed"
+fi
+
+# Verify AWS CLI installation and version
+echo "*** Verifying AWS CLI installation..."
+if aws --version; then
+    echo "*** AWS CLI verification successful"
+else
+    echo "*** Error: AWS CLI installation verification failed"
+    exit 1
+fi
+
 # Launch EC2 instance from pre-built AMI
 echo "*** Launching EC2 instance from pre-built AMI..."
 INSTANCE_ID=$(aws ec2 run-instances \

--- a/ci/provision_ec2_minikube.sh
+++ b/ci/provision_ec2_minikube.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# EC2 Minikube Instance Provisioning Script (Pre-built AMI)
+# This script provisions a new EC2 instance from a pre-built AMI with Minikube already installed
+
+# Required environment variables
+: ${AWS_REGION:="us-east-1"}
+: ${EC2_INSTANCE_TYPE:="m5.2xlarge"}  # 8 vCPUs, 32 GB RAM
+: ${EC2_AMI_ID:?"EC2_AMI_ID must be set (pre-built AMI with Minikube)"}
+: ${EC2_KEY_PAIR_NAME:?"EC2_KEY_PAIR_NAME must be set"}
+: ${EC2_SECURITY_GROUP_ID:?"EC2_SECURITY_GROUP_ID must be set"}
+: ${EC2_SUBNET_ID:?"EC2_SUBNET_ID must be set"}
+
+# Optional environment variables
+: ${EC2_INSTANCE_NAME:="clowder-e2e-$(date +%Y%m%d-%H%M%S)-$(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')"}
+: ${KUBERNETES_VERSION:="1.30"}
+
+echo "*** Provisioning EC2 instance for Clowder E2E tests ***"
+echo "Instance Name: $EC2_INSTANCE_NAME"
+echo "Instance Type: $EC2_INSTANCE_TYPE"
+echo "AMI ID: $EC2_AMI_ID"
+echo "Region: $AWS_REGION"
+
+# Launch EC2 instance from pre-built AMI
+echo "*** Launching EC2 instance from pre-built AMI..."
+INSTANCE_ID=$(aws ec2 run-instances \
+    --region "$AWS_REGION" \
+    --image-id "$EC2_AMI_ID" \
+    --instance-type "$EC2_INSTANCE_TYPE" \
+    --key-name "$EC2_KEY_PAIR_NAME" \
+    --security-group-ids "$EC2_SECURITY_GROUP_ID" \
+    --subnet-id "$EC2_SUBNET_ID" \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=$EC2_INSTANCE_NAME},{Key=Purpose,Value=clowder-e2e-testing},{Key=AutoDelete,Value=true},{Key=CreatedBy,Value=clowder-ci}]" \
+    --query 'Instances[0].InstanceId' \
+    --output text)
+
+if [ -z "$INSTANCE_ID" ] || [ "$INSTANCE_ID" = "None" ]; then
+    echo "*** Error: Failed to launch EC2 instance"
+    exit 1
+fi
+
+echo "*** Instance launched with ID: $INSTANCE_ID"
+
+# Wait for instance to be running
+echo "*** Waiting for instance to be running..."
+aws ec2 wait instance-running --region "$AWS_REGION" --instance-ids "$INSTANCE_ID"
+
+# Get instance public IP
+PUBLIC_IP=$(aws ec2 describe-instances \
+    --region "$AWS_REGION" \
+    --instance-ids "$INSTANCE_ID" \
+    --query 'Reservations[0].Instances[0].PublicIpAddress' \
+    --output text)
+
+if [ -z "$PUBLIC_IP" ] || [ "$PUBLIC_IP" = "None" ]; then
+    echo "*** Error: Failed to get public IP for instance $INSTANCE_ID"
+    echo "*** Cleaning up failed instance..."
+    aws ec2 terminate-instances --region "$AWS_REGION" --instance-ids "$INSTANCE_ID" || true
+    exit 1
+fi
+
+echo "*** Instance is running at IP: $PUBLIC_IP"
+
+# Wait for SSH to be available
+echo "*** Waiting for SSH to be available..."
+SSH_READY=false
+for i in {1..30}; do
+    if ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -i "$EC2_PRIVATE_KEY_PATH" ec2-user@"$PUBLIC_IP" echo "SSH is ready" 2>/dev/null; then
+        echo "*** SSH is available"
+        SSH_READY=true
+        break
+    fi
+    echo "Attempt $i/30: SSH not ready, waiting 10 seconds..."
+    sleep 10
+done
+
+if [ "$SSH_READY" != "true" ]; then
+    echo "*** Error: SSH connection failed after 30 attempts"
+    echo "*** Cleaning up failed instance: $INSTANCE_ID"
+    aws ec2 terminate-instances --region "$AWS_REGION" --instance-ids "$INSTANCE_ID" || true
+    exit 1
+fi
+
+# Verify Minikube is available on the AMI
+echo "*** Verifying Minikube is available on the AMI..."
+if ! ssh -o StrictHostKeyChecking=no -i "$EC2_PRIVATE_KEY_PATH" ec2-user@"$PUBLIC_IP" "which minikube" 2>/dev/null; then
+    echo "*** Error: Minikube not found on AMI. Please ensure the AMI has Minikube pre-installed."
+    echo "*** Cleaning up failed instance: $INSTANCE_ID"
+    aws ec2 terminate-instances --region "$AWS_REGION" --instance-ids "$INSTANCE_ID" || true
+    exit 1
+fi
+
+# Start Minikube on the pre-built AMI
+echo "*** Starting Minikube on EC2 instance..."
+if ! ssh -o StrictHostKeyChecking=no -i "$EC2_PRIVATE_KEY_PATH" ec2-user@"$PUBLIC_IP" << EOF
+    set -euo pipefail
+    
+    # Clean up any existing minikube state
+    minikube delete || true
+    
+    # Start Minikube with the same configuration as the original script
+    minikube start \
+        --cpus 6 \
+        --disk-size 10GB \
+        --memory 16000MB \
+        --kubernetes-version=$KUBERNETES_VERSION \
+        --addons=metrics-server \
+        --disable-optimizations \
+        --driver=docker
+    
+    # Verify Minikube is running
+    minikube status
+    
+    echo "Minikube started successfully at \$(date)"
+EOF
+then
+    echo "*** Error: Minikube startup failed"
+    echo "*** Cleaning up failed instance: $INSTANCE_ID"
+    aws ec2 terminate-instances --region "$AWS_REGION" --instance-ids "$INSTANCE_ID" || true
+    exit 1
+fi
+
+echo "*** EC2 instance with Minikube is ready!"
+echo "Instance ID: $INSTANCE_ID"
+echo "Public IP: $PUBLIC_IP"
+
+# Export environment variables for the main test script
+export MINIKUBE_INSTANCE_ID="$INSTANCE_ID"
+export MINIKUBE_HOST="$PUBLIC_IP"
+export MINIKUBE_USER="ec2-user"
+export MINIKUBE_ROOTDIR="/home/ec2-user"
+
+# Save instance info to file for cleanup script
+cat > /tmp/minikube-instance-info << EOF
+MINIKUBE_INSTANCE_ID=$INSTANCE_ID
+MINIKUBE_HOST=$PUBLIC_IP
+MINIKUBE_USER=ec2-user
+MINIKUBE_ROOTDIR=/home/ec2-user
+AWS_REGION=$AWS_REGION
+EOF
+
+echo "*** Instance information saved to /tmp/minikube-instance-info"
+echo "*** Provisioning completed successfully!"

--- a/ci/provision_ec2_minikube.sh
+++ b/ci/provision_ec2_minikube.sh
@@ -9,9 +9,9 @@ set -euo pipefail
 : ${AWS_REGION:="us-east-1"}
 : ${EC2_INSTANCE_TYPE:="m5.2xlarge"}  # 8 vCPUs, 32 GB RAM
 : ${MINIKUBE_EC2_AMI_ID:?"MINIKUBE_EC2_AMI_ID must be set (pre-built AMI with Minikube)"}
-: ${EC2_KEY_PAIR_NAME:?"EC2_KEY_PAIR_NAME must be set"}
-: ${EC2_SECURITY_GROUP_ID:?"EC2_SECURITY_GROUP_ID must be set"}
-: ${EC2_SUBNET_ID:?"EC2_SUBNET_ID must be set"}
+# : ${EC2_KEY_PAIR_NAME:?"EC2_KEY_PAIR_NAME must be set"}
+# : ${EC2_SECURITY_GROUP_ID:?"EC2_SECURITY_GROUP_ID must be set"}
+# : ${EC2_SUBNET_ID:?"EC2_SUBNET_ID must be set"}
 
 # Optional environment variables
 : ${EC2_INSTANCE_NAME:="clowder-e2e-$(date +%Y%m%d-%H%M%S)-$(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')"}
@@ -29,9 +29,9 @@ INSTANCE_ID=$(aws ec2 run-instances \
     --region "$AWS_REGION" \
     --image-id "$MINIKUBE_EC2_AMI_ID" \
     --instance-type "$EC2_INSTANCE_TYPE" \
-    --key-name "$EC2_KEY_PAIR_NAME" \
-    --security-group-ids "$EC2_SECURITY_GROUP_ID" \
-    --subnet-id "$EC2_SUBNET_ID" \
+    # --key-name "$EC2_KEY_PAIR_NAME" \
+    # --security-group-ids "$EC2_SECURITY_GROUP_ID" \
+    # --subnet-id "$EC2_SUBNET_ID" \
     --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=$EC2_INSTANCE_NAME},{Key=Purpose,Value=clowder-e2e-testing},{Key=AutoDelete,Value=true},{Key=CreatedBy,Value=clowder-ci}]" \
     --query 'Instances[0].InstanceId' \
     --output text)

--- a/ci/provision_ec2_minikube.sh
+++ b/ci/provision_ec2_minikube.sh
@@ -23,6 +23,19 @@ echo "Instance Type: $EC2_INSTANCE_TYPE"
 echo "AMI ID: $MINIKUBE_EC2_AMI_ID"
 echo "Region: $AWS_REGION"
 
+# Check if unzip is installed, install if not
+echo "*** Checking unzip installation..."
+if ! command -v unzip &> /dev/null; then
+    echo "*** unzip not found, installing..."
+    
+    sudo apt-get update -qq
+    sudo apt-get install -y unzip
+    
+    echo "*** unzip installation completed"
+else
+    echo "*** unzip is already installed"
+fi
+
 # Check if AWS CLI is installed, install if not
 echo "*** Checking AWS CLI installation..."
 if ! command -v aws &> /dev/null; then

--- a/ci/provision_ec2_minikube.sh
+++ b/ci/provision_ec2_minikube.sh
@@ -26,12 +26,46 @@ echo "Region: $AWS_REGION"
 # Check if unzip is installed, install if not
 echo "*** Checking unzip installation..."
 if ! command -v unzip &> /dev/null; then
-    echo "*** unzip not found, installing..."
     
-    sudo apt-get update -qq
-    sudo apt-get install -y unzip
+    # Create a local bin directory if it doesn't exist
+    mkdir -p "$HOME/bin"
     
-    echo "*** unzip installation completed"
+    # Download and install unzip statically linked binary
+    echo "*** Downloading unzip binary for Linux..."
+    
+    # Try to download a statically linked unzip binary
+    UNZIP_URL="http://archive.ubuntu.com/ubuntu/pool/main/u/unzip/unzip_6.0-25ubuntu1_amd64.deb"
+    
+    # Create temporary directory
+    TEMP_DIR=$(mktemp -d)
+    cd "$TEMP_DIR"
+    
+    # Download and extract unzip from deb package
+    curl -s "$UNZIP_URL" -o unzip.deb
+    ar x unzip.deb
+    tar -xf data.tar.xz
+    
+    # Copy unzip binary to user's bin directory
+    cp usr/bin/unzip "$HOME/bin/"
+    chmod +x "$HOME/bin/unzip"
+    
+    # Clean up
+    cd - > /dev/null
+    rm -rf "$TEMP_DIR"
+    
+    # Add $HOME/bin to PATH if not already there
+    if [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
+        export PATH="$HOME/bin:$PATH"
+        echo "*** Added $HOME/bin to PATH"
+    fi
+    
+    # Verify unzip installation
+    if command -v unzip &> /dev/null; then
+        echo "*** unzip installation completed successfully"
+    else
+        echo "*** Error: unzip installation failed"
+        exit 1
+    fi
 else
     echo "*** unzip is already installed"
 fi

--- a/ci/provision_ec2_minikube.sh
+++ b/ci/provision_ec2_minikube.sh
@@ -27,18 +27,9 @@ echo "Region: $AWS_REGION"
 echo "*** Checking AWS CLI installation..."
 if ! command -v aws &> /dev/null; then
     echo "*** AWS CLI not found, installing..."
-    
-    if [[ "$ARCH" == "x86_64" ]]; then
-        AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
-    elif [[ "$ARCH" == "aarch64" ]]; then
-        AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
-    else
-        echo "*** Error: Unsupported Linux architecture: $ARCH"
-        exit 1
-    fi
         
     # Install AWS CLI on Linux
-    curl -s "$AWS_CLI_URL" -o "awscliv2.zip"
+    curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
     unzip -q awscliv2.zip
     sudo ./aws/install
     rm -rf awscliv2.zip aws/


### PR DESCRIPTION
## Purpose

This PR changes our E2E testing to provision an EC2 from a pre-built AMI that has minikube installed. This will enable us to run our E2E testing in parallel since an EC2 instance will be created for each test run. I also added a script that will clean up instances after the job concludes. 

---
Assisted with Cursor / claude-4-sonnet