### PR TITLE
Updating Quay postgres image

### DIFF
--- a/controllers/cloud.redhat.com/providers/utils/utils.go
+++ b/controllers/cloud.redhat.com/providers/utils/utils.go
@@ -35,7 +35,7 @@ var defaultImageDatabasePG12 = "quay.io/cloudservices/postgresql-rds:12-2318dee"
 var defaultImageDatabasePG13 = "quay.io/cloudservices/postgresql-rds:13-2318dee"
 var defaultImageDatabasePG14 = "quay.io/cloudservices/postgresql-rds:14-2318dee"
 var defaultImageDatabasePG15 = "quay.io/cloudservices/postgresql-rds:15-2318dee"
-var defaultImageDatabasePG16 = "quay.io/cloudservices/postgresql-rds:16-759c25d"
+var defaultImageDatabasePG16 = "quay.io/cloudservices/postgresql-rds:16-f76fe84"
 var defaultImageInMemoryDB = "registry.redhat.io/rhel10/valkey-8:10.0"
 
 // GetDefaultDatabaseImage returns the default image for the given PostgreSQL version


### PR DESCRIPTION
## Change Details
* Updating image tag used for PostgreSQL 16 from Quay
  * This version should include the updated `shared_preload_libraries` config, which adds `pg_stat_statements` for metrics logging