### PR TITLE
Add back clowder-config ConfigMap to deploy-mutate.yml

### DIFF
--- a/deploy-mutate.yml
+++ b/deploy-mutate.yml
@@ -12869,6 +12869,25 @@ objects:
       resources:
       - clowdapps
     sideEffects: None
+- apiVersion: v1
+  data:
+    clowder_config.json: "{\n    \"debugOptions\": {\n        \"trigger\": {\n   \
+      \         \"diff\": ${DEBUG_TRIGGERS}\n        },\n        \"cache\": {\n  \
+      \          \"create\": ${DEBUG_CACHE_CREATE},\n            \"update\": ${DEBUG_CACHE_UPDATE},\n\
+      \            \"apply\": ${DEBUG_CACHE_APPLY}\n        },\n        \"pprof\"\
+      : {\n            \"enable\": ${DEBUG_PPROF_ENABLE}\n        }\n    },\n    \"\
+      features\": {\n        \"createServiceMonitor\": ${CREATE_SERVICE_MONITORS},\n\
+      \        \"watchStrimziResources\": ${WATCH_STRIMZI_RESOURCES},\n        \"\
+      enableKedaResources\": ${ENABLE_KEDA_RESOURCES},\n        \"perProviderMetrics\"\
+      : ${PER_PROVIDER_METRICS},\n        \"reconciliationMetrics\": ${RECONCILIATION_METRICS},\n\
+      \        \"enableDependencyMetrics\": ${ENABLE_DEPENDENCY_METRICS},\n      \
+      \  \"disableStrimziFinalizer\": ${DISABLE_STRIMZI_FINALIZER}\n    },\n    \"\
+      settings\": {\n        \"managedKafkaEphemDeleteRegex\": \"${MANAGED_EPHEM_DELETE_REGEX}\"\
+      \n    },\n    \"images\": {\n        \"objectStoreMinio\": \"${OBJECTSTORE_IMAGE}\"\
+      ,\n        \"featureFlagsUnleash\": \"${FEATUREFLAGS_IMAGE}\"\n    }\n}\n"
+  kind: ConfigMap
+  metadata:
+    name: clowder-config
 parameters:
 - name: IMAGE_TAG
   value: latest


### PR DESCRIPTION
## Summary

This PR adds back the `clowder-config` ConfigMap to `deploy-mutate.yml` that was removed in PR #1574.

## Details

- The ConfigMap contains the `clowder_config.json` configuration with debug options, feature flags, settings, and image references
- This ConfigMap is still present in `deploy.yml` and should also be in `deploy-mutate.yml` for consistency
- The removal appears to have been unintentional, as the ConfigMap provides important configuration for the Clowder operator

## Changes

- Re-added the `clowder-config` ConfigMap resource to `deploy-mutate.yml` at the end of the objects list (before the parameters section)
- The ConfigMap content is identical to what exists in `deploy.yml`

## References

- Related to PR #1574 which inadvertently removed this ConfigMap

🤖 Generated with [Claude Code](https://claude.com/claude-code)