### PR TITLE
Fix webhook validation

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdapp_webhook.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdapp_webhook.go
@@ -45,10 +45,14 @@ func (i *ClowdApp) SetupWebhookWithManager(mgr ctrl.Manager) error {
 //+kubebuilder:webhook:path=/mutate-pod,mutating=true,failurePolicy=ignore,sideEffects=None,groups="",resources=pods,verbs=create;update,versions=v1,name=vclowdmutatepod.kb.io,admissionReviewVersions={v1}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (i *ClowdApp) ValidateCreate(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
-	clowdapplog.Info("validate create", "name", i.Name)
+func (i *ClowdApp) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	clowdApp, ok := obj.(*ClowdApp)
+	if !ok {
+		return nil, fmt.Errorf("expected ClowdApp but got %T", obj)
+	}
+	clowdapplog.Info("validate create", "name", clowdApp.Name)
 
-	return []string{}, i.processValidations(i,
+	return []string{}, i.processValidations(clowdApp,
 		validateDatabase,
 		validateSidecars,
 		validateInit,
@@ -57,10 +61,14 @@ func (i *ClowdApp) ValidateCreate(_ context.Context, _ runtime.Object) (admissio
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (i *ClowdApp) ValidateUpdate(_ context.Context, _ runtime.Object, _ runtime.Object) (admission.Warnings, error) {
-	clowdapplog.Info("validate update", "name", i.Name)
+func (i *ClowdApp) ValidateUpdate(_ context.Context, _ runtime.Object, newObj runtime.Object) (admission.Warnings, error) {
+	clowdApp, ok := newObj.(*ClowdApp)
+	if !ok {
+		return nil, fmt.Errorf("expected ClowdApp but got %T", newObj)
+	}
+	clowdapplog.Info("validate update", "name", clowdApp.Name)
 
-	return []string{}, i.processValidations(i,
+	return []string{}, i.processValidations(clowdApp,
 		validateDatabase,
 		validateSidecars,
 		validateInit,


### PR DESCRIPTION
After some recent changes to this file, the code here was validating an empty object instead of validating the actual `runtime.Object`. This was causing the webhook's AdmissionReview response to always return with `"allowed":true`