### PR TITLE
Add in-progress status check with CodeBuild URL

### DIFF
--- a/.github/workflows/pr-e2e-codebuild.yml
+++ b/.github/workflows/pr-e2e-codebuild.yml
@@ -122,6 +122,26 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_REPOSITORY: ${{ github.repository }}
 
+      - name: Update status check to in-progress
+        if: always() && steps.codebuild.outputs.aws-build-id
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const buildId = '${{ steps.codebuild.outputs.aws-build-id }}';
+            const region = '${{ secrets.AWS_REGION }}';
+            const encodedBuildId = encodeURIComponent(buildId);
+            const consoleUrl = `https://${region}.console.aws.amazon.com/codesuite/codebuild/projects/clowder-pr-check/build/${encodedBuildId}/`;
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ steps.pr.outputs.sha }}',
+              state: 'pending',
+              context: 'CodeBuild / E2E Tests',
+              description: 'E2E tests in progress...',
+              target_url: consoleUrl
+            });
+
       - name: Update status check on success
         if: success()
         uses: actions/github-script@v7


### PR DESCRIPTION
Updates the GitHub Actions workflow to report an in-progress status check once the CodeBuild job has started, providing a clickable link to view the running build in the AWS console.