### PR TITLE
Use GitHub Actions URL in status checks instead of CodeBuild console

### DIFF
--- a/.github/workflows/pr-e2e-codebuild.yml
+++ b/.github/workflows/pr-e2e-codebuild.yml
@@ -128,26 +128,29 @@ jobs:
 
             core.setFailed('This PR branch does not contain buildspec.yml. Please rebase with master.');
 
-      - name: Create pending status check
-        if: steps.check-permissions.outputs.allowed == 'true' && steps.check-buildspec.outputs.has-buildspec == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: '${{ steps.pr.outputs.sha }}',
-              state: 'pending',
-              context: 'CodeBuild / E2E Tests',
-              description: 'Starting E2E tests...'
-            });
-
       - name: Configure AWS credentials
         if: steps.check-buildspec.outputs.has-buildspec == 'true'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Create pending status check
+        if: steps.check-permissions.outputs.allowed == 'true' && steps.check-buildspec.outputs.has-buildspec == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${{ github.run_id }}`;
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ steps.pr.outputs.sha }}',
+              state: 'pending',
+              context: 'CodeBuild / E2E Tests',
+              description: 'Running E2E tests...',
+              target_url: runUrl
+            });
 
       - name: Run CodeBuild
         if: steps.check-buildspec.outputs.has-buildspec == 'true'
@@ -169,35 +172,12 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_REPOSITORY: ${{ github.repository }}
 
-      - name: Update status check to in-progress
-        if: always() && steps.codebuild.outputs.aws-build-id
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const buildId = '${{ steps.codebuild.outputs.aws-build-id }}';
-            const region = '${{ secrets.AWS_REGION }}';
-            const encodedBuildId = encodeURIComponent(buildId);
-            const consoleUrl = `https://${region}.console.aws.amazon.com/codesuite/codebuild/projects/clowder-pr-check/build/${encodedBuildId}/`;
-
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: '${{ steps.pr.outputs.sha }}',
-              state: 'pending',
-              context: 'CodeBuild / E2E Tests',
-              description: 'E2E tests in progress...',
-              target_url: consoleUrl
-            });
-
       - name: Update status check on success
         if: success()
         uses: actions/github-script@v7
         with:
           script: |
-            const buildId = '${{ steps.codebuild.outputs.aws-build-id }}';
-            const region = '${{ secrets.AWS_REGION }}';
-            const encodedBuildId = encodeURIComponent(buildId);
-            const consoleUrl = `https://${region}.console.aws.amazon.com/codesuite/codebuild/projects/clowder-pr-check/build/${encodedBuildId}/`;
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${{ github.run_id }}`;
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
@@ -206,7 +186,7 @@ jobs:
               state: 'success',
               context: 'CodeBuild / E2E Tests',
               description: 'E2E tests passed',
-              target_url: consoleUrl
+              target_url: runUrl
             });
 
       - name: Update status check on failure
@@ -214,18 +194,9 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${{ github.run_id }}`;
             const buildId = '${{ steps.codebuild.outputs.aws-build-id }}';
-            const region = '${{ secrets.AWS_REGION }}';
-
-            let consoleUrl = null;
-            let description = 'E2E tests failed';
-
-            if (buildId) {
-              const encodedBuildId = encodeURIComponent(buildId);
-              consoleUrl = `https://${region}.console.aws.amazon.com/codesuite/codebuild/projects/clowder-pr-check/build/${encodedBuildId}/`;
-            } else {
-              description = 'Failed to start E2E tests';
-            }
+            const description = buildId ? 'E2E tests failed' : 'Failed to start E2E tests';
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
@@ -234,5 +205,5 @@ jobs:
               state: 'failure',
               context: 'CodeBuild / E2E Tests',
               description: description,
-              target_url: consoleUrl
+              target_url: runUrl
             });


### PR DESCRIPTION
Since the CodeBuild action streams all logs to GitHub Actions output, point the status check URL to the GitHub Actions run rather than the AWS CodeBuild console. This allows users to view logs without needing AWS console access.