### PR TITLE
Change status check URLs back to AWS CodeBuild console

### DIFF
--- a/.github/workflows/pr-e2e-codebuild.yml
+++ b/.github/workflows/pr-e2e-codebuild.yml
@@ -128,19 +128,12 @@ jobs:
 
             core.setFailed('This PR branch does not contain buildspec.yml. Please rebase with master.');
 
-      - name: Configure AWS credentials
-        if: steps.check-buildspec.outputs.has-buildspec == 'true'
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_CODEBUILD_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
       - name: Create pending status check
         if: steps.check-permissions.outputs.allowed == 'true' && steps.check-buildspec.outputs.has-buildspec == 'true'
         uses: actions/github-script@v7
         with:
           script: |
-            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${{ github.run_id }}`;
+            const projectUrl = 'https://us-east-1.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoiTHJVaVRGR05mWnExNnVLS3N1OWMrMGtFMEdYQnZ5VmVmMjJ6ZEFsYzdLQUc2WjViWTI2d3RLS21UalVWZHN3c2kwaytBMm1SaHZOVTd6elNGeGJaaEtnc0tKeUp0WTNOOUptOUIyMVBrZXRzIiwiaXZQYXJhbWV0ZXJTcGVjIjoiTS9ZYlZlTDA4M2F1cW1zMSIsIm1hdGVyaWFsU2V0U2VyaWFsIjoxfQ%3D%3D';
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
@@ -149,14 +142,22 @@ jobs:
               state: 'pending',
               context: 'CodeBuild / E2E Tests',
               description: 'Running E2E tests...',
-              target_url: runUrl
+              target_url: projectUrl
             });
+
+      - name: Configure AWS credentials
+        if: steps.check-buildspec.outputs.has-buildspec == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEBUILD_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Run CodeBuild
         if: steps.check-buildspec.outputs.has-buildspec == 'true'
         id: codebuild
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
+          hide-cloudwatch-logs: true
           project-name: clowder-pr-check
           source-version-override: ${{ steps.pr.outputs.sha }}
           env-vars-for-codebuild: |
@@ -172,12 +173,31 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_REPOSITORY: ${{ github.repository }}
 
+      - name: Update status check to in-progress
+        if: always() && steps.codebuild.outputs.aws-build-id
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const buildId = '${{ steps.codebuild.outputs.aws-build-id }}';
+            const buildUrl = `https://us-east-1.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoiTHJVaVRGR05mWnExNnVLS3N1OWMrMGtFMEdYQnZ5VmVmMjJ6ZEFsYzdLQUc2WjViWTI2d3RLS21UalVWZHN3c2kwaytBMm1SaHZOVTd6elNGeGJaaEtnc0tKeUp0WTNOOUptOUIyMVBrZXRzIiwiaXZQYXJhbWV0ZXJTcGVjIjoiTS9ZYlZlTDA4M2F1cW1zMSIsIm1hdGVyaWFsU2V0U2VyaWFsIjoxfQ%3D%3D/build/${buildId}`;
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ steps.pr.outputs.sha }}',
+              state: 'pending',
+              context: 'CodeBuild / E2E Tests',
+              description: 'E2E tests in progress...',
+              target_url: buildUrl
+            });
+
       - name: Update status check on success
         if: success()
         uses: actions/github-script@v7
         with:
           script: |
-            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${{ github.run_id }}`;
+            const buildId = '${{ steps.codebuild.outputs.aws-build-id }}';
+            const buildUrl = `https://us-east-1.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoiTHJVaVRGR05mWnExNnVLS3N1OWMrMGtFMEdYQnZ5VmVmMjJ6ZEFsYzdLQUc2WjViWTI2d3RLS21UalVWZHN3c2kwaytBMm1SaHZOVTd6elNGeGJaaEtnc0tKeUp0WTNOOUptOUIyMVBrZXRzIiwiaXZQYXJhbWV0ZXJTcGVjIjoiTS9ZYlZlTDA4M2F1cW1zMSIsIm1hdGVyaWFsU2V0U2VyaWFsIjoxfQ%3D%3D/build/${buildId}`;
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
@@ -186,7 +206,7 @@ jobs:
               state: 'success',
               context: 'CodeBuild / E2E Tests',
               description: 'E2E tests passed',
-              target_url: runUrl
+              target_url: buildUrl
             });
 
       - name: Update status check on failure
@@ -194,9 +214,19 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${{ github.run_id }}`;
             const buildId = '${{ steps.codebuild.outputs.aws-build-id }}';
-            const description = buildId ? 'E2E tests failed' : 'Failed to start E2E tests';
+            const baseUrl = 'https://us-east-1.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoiTHJVaVRGR05mWnExNnVLS3N1OWMrMGtFMEdYQnZ5VmVmMjJ6ZEFsYzdLQUc2WjViWTI2d3RLS21UalVWZHN3c2kwaytBMm1SaHZOVTd6elNGeGJaaEtnc0tKeUp0WTNOOUptOUIyMVBrZXRzIiwiaXZQYXJhbWV0ZXJTcGVjIjoiTS9ZYlZlTDA4M2F1cW1zMSIsIm1hdGVyaWFsU2V0U2VyaWFsIjoxfQ%3D%3D';
+
+            let buildUrl;
+            let description;
+
+            if (buildId) {
+              buildUrl = `${baseUrl}/build/${buildId}`;
+              description = 'E2E tests failed';
+            } else {
+              buildUrl = baseUrl;
+              description = 'Failed to start E2E tests';
+            }
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
@@ -205,5 +235,5 @@ jobs:
               state: 'failure',
               context: 'CodeBuild / E2E Tests',
               description: description,
-              target_url: runUrl
+              target_url: buildUrl
             });


### PR DESCRIPTION
Point status checks to CodeBuild console instead of GitHub Actions:
- Pending status: Points to project page (no build ID yet)
- Success/Failure: Points to specific build in CodeBuild console

Also, do not bother sending cloudwatch log stream to the GH action