### PR TITLE
Add new minio container env vars

### DIFF
--- a/controllers/cloud.redhat.com/providers/objectstore/minio.go
+++ b/controllers/cloud.redhat.com/providers/objectstore/minio.go
@@ -333,6 +333,8 @@ func makeLocalMinIO(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMap providers
 	envVars = provutils.AppendEnvVarsFromSecret(envVars, nn.Name,
 		provutils.NewSecretEnvVar("MINIO_ACCESS_KEY", "accessKey"),
 		provutils.NewSecretEnvVar("MINIO_SECRET_KEY", "secretKey"),
+		provutils.NewSecretEnvVar("MINIO_ROOT_USER", "accessKey"),
+		provutils.NewSecretEnvVar("MINIO_ROOT_PASSWORD", "secretKey"),
 	)
 
 	ports := []core.ContainerPort{{

--- a/tests/kuttl/test-clowdapp-watcher-minio/01-assert.yaml
+++ b/tests/kuttl/test-clowdapp-watcher-minio/01-assert.yaml
@@ -72,6 +72,16 @@ spec:
             secretKeyRef:
               key: secretKey
               name: test-clowdapp-watcher-minio-minio
+        - name: MINIO_ROOT_USER
+          valueFrom:
+            secretKeyRef:
+              key: accessKey
+              name: test-clowdapp-watcher-minio-minio
+        - name: MINIO_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: secretKey
+              name: test-clowdapp-watcher-minio-minio
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -132,7 +142,7 @@ spec:
     env-app: test-clowdapp-watcher-minio-minio
   sessionAffinity: None
   type: ClusterIP
---- 
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/tests/kuttl/test-minio-app/01-assert.yaml
+++ b/tests/kuttl/test-minio-app/01-assert.yaml
@@ -72,6 +72,16 @@ spec:
             secretKeyRef:
               key: secretKey
               name: test-minio-app-minio
+        - name: MINIO_ROOT_USER
+          valueFrom:
+            secretKeyRef:
+              key: accessKey
+              name: test-clowdapp-watcher-minio-minio
+        - name: MINIO_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: secretKey
+              name: test-clowdapp-watcher-minio-minio
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -132,7 +142,7 @@ spec:
     env-app: test-minio-app-minio
   sessionAffinity: None
   type: ClusterIP
---- 
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:


### PR DESCRIPTION
Adding additional env vars to the minio container to resolve this error:

```
FATAL Unable to start MinIO: Missing credential environment variable, "MINIO_ACCESS_KEY"
      > Environment variables "MINIO_ACCESS_KEY" and "MINIO_SECRET_KEY" are deprecated
      HINT:
        Root user name (access key) and root password (secret key) are expected to be specified via environment variables MINIO_ROOT_USER and MINIO_ROOT_PASSWORD respectively
 ```