### PR TITLE
Update tekton trigger config for clowder-e2e-tests

### DIFF
--- a/.tekton/clowder-e2e-tests-pull-request.yaml
+++ b/.tekton/clowder-e2e-tests-pull-request.yaml
@@ -8,9 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "master" && ( "./tests/rh_clowder_ci/***".pathChanged() || ".tekton/clowder-e2e-tests-pull-request.yaml".pathChanged()
-      || "tests/rh_clowder_ci/Dockerfile".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: clowder

--- a/.tekton/clowder-e2e-tests-push.yaml
+++ b/.tekton/clowder-e2e-tests-push.yaml
@@ -7,9 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "master" && ( "./tests/rh_clowder_ci/***".pathChanged() || ".tekton/clowder-e2e-tests-push.yaml".pathChanged()
-      || "tests/rh_clowder_ci/Dockerfile".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "master"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: clowder


### PR DESCRIPTION
We want both the 'clowder' and 'clowder-e2e-tests' image to build with the same image tags, so we will trigger the clowder-e2e-tests build for all repo updates