### PR TITLE
fix: add generation field to ClowdApp status in deploy templates

### DIFF
--- a/deploy-mutate.yml
+++ b/deploy-mutate.yml
@@ -10120,6 +10120,9 @@ objects:
                   - managedDeployments
                   - readyDeployments
                   type: object
+                generation:
+                  format: int64
+                  type: integer
                 ready:
                   type: boolean
               required:

--- a/deploy.yml
+++ b/deploy.yml
@@ -10120,6 +10120,9 @@ objects:
                   - managedDeployments
                   - readyDeployments
                   type: object
+                generation:
+                  format: int64
+                  type: integer
                 ready:
                   type: boolean
               required:


### PR DESCRIPTION
Add the missing generation field to the ClowdApp status schema in deploy.yml and deploy-mutate.yml. Without this, the API server silently prunes the field during status updates, making the generation tracking from PR #1742 ineffective.