### PR TITLE
fix: bypass informer cache for ClowdApp read in CJI controller

### DIFF
--- a/controllers/cloud.redhat.com/clowdjobinvocation_controller.go
+++ b/controllers/cloud.redhat.com/clowdjobinvocation_controller.go
@@ -48,9 +48,10 @@ import (
 // ClowdJobInvocationReconciler reconciles a ClowdJobInvocation object
 type ClowdJobInvocationReconciler struct {
 	client.Client
-	Log      logr.Logger
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
+	APIReader client.Reader
+	Log       logr.Logger
+	Scheme    *runtime.Scheme
+	Recorder  record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=cloud.redhat.com,resources=clowdjobinvocations,verbs=get;list;watch;create;update;patch;delete
@@ -123,9 +124,12 @@ func (r *ClowdJobInvocationReconciler) Reconcile(ctx context.Context, req ctrl.R
 		ctx = context.WithValue(ctx, errors.ClowdKey("obj"), &cji)
 	}
 
-	// Get the ClowdApp. Used to find definition of job being invoked
+	// Get the ClowdApp directly from the API server, bypassing the informer
+	// cache. When a ClowdApp update and CJI creation are applied together,
+	// the cache may still serve the old ClowdApp spec, causing the job to
+	// use a stale image or env vars.
 	app := crd.ClowdApp{}
-	appErr := r.Get(ctx, types.NamespacedName{
+	appErr := r.APIReader.Get(ctx, types.NamespacedName{
 		Name:      cji.Spec.AppName,
 		Namespace: req.Namespace,
 	}, &app)

--- a/controllers/cloud.redhat.com/clowdjobinvocation_controller_test.go
+++ b/controllers/cloud.redhat.com/clowdjobinvocation_controller_test.go
@@ -1,0 +1,376 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	crd "github.com/RedHatInsights/clowder/apis/cloud.redhat.com/v1alpha1"
+)
+
+func TestCJIGenerationCheck(t *testing.T) {
+	tests := []struct {
+		name             string
+		appGeneration    int64
+		statusGeneration int64
+		expectGenError   bool
+	}{
+		{
+			name:             "generation matches - should pass generation check",
+			appGeneration:    5,
+			statusGeneration: 5,
+			expectGenError:   false,
+		},
+		{
+			name:             "generation mismatch with statusGeneration > 0 - should requeue",
+			appGeneration:    6,
+			statusGeneration: 5,
+			expectGenError:   true,
+		},
+		{
+			name:             "statusGeneration 0 (backward compat) - should skip check",
+			appGeneration:    5,
+			statusGeneration: 0,
+			expectGenError:   false,
+		},
+		{
+			name:             "large generation gap - should requeue",
+			appGeneration:    100,
+			statusGeneration: 95,
+			expectGenError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns := "test-gen-check"
+
+			cji := &crd.ClowdJobInvocation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cji",
+					Namespace: ns,
+				},
+				Spec: crd.ClowdJobInvocationSpec{
+					AppName:       "test-app",
+					RunOnNotReady: true,
+					Jobs:          []string{"test-job"},
+				},
+			}
+
+			app := &crd.ClowdApp{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-app",
+					Namespace:  ns,
+					Generation: tt.appGeneration,
+				},
+				Spec: crd.ClowdAppSpec{
+					EnvName: "test-env",
+					Jobs: []crd.Job{
+						{
+							Name: "test-job",
+							PodSpec: crd.PodSpec{
+								Image: "busybox:latest",
+							},
+						},
+					},
+				},
+				Status: crd.ClowdAppStatus{
+					Generation: tt.statusGeneration,
+				},
+			}
+
+			cachedClient := fake.NewClientBuilder().
+				WithScheme(Scheme).
+				WithObjects(cji).
+				WithStatusSubresource(&crd.ClowdJobInvocation{}).
+				Build()
+
+			apiReader := fake.NewClientBuilder().
+				WithScheme(Scheme).
+				WithObjects(app).
+				Build()
+
+			recorder := record.NewFakeRecorder(100)
+
+			reconciler := &ClowdJobInvocationReconciler{
+				Client:    cachedClient,
+				APIReader: apiReader,
+				Log:       ctrl.Log.WithName("test"),
+				Scheme:    Scheme,
+				Recorder:  recorder,
+			}
+
+			_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "test-cji",
+					Namespace: ns,
+				},
+			})
+
+			assert.Error(t, err)
+
+			if tt.expectGenError {
+				assert.Contains(t, err.Error(), "has not been reconciled with the current generation",
+					"expected generation mismatch error, got: %s", err.Error())
+			} else {
+				assert.NotContains(t, err.Error(), "has not been reconciled with the current generation",
+					"did not expect generation mismatch error, got: %s", err.Error())
+			}
+		})
+	}
+}
+
+func TestCJIUsesAPIReaderNotCache(t *testing.T) {
+	ns := "test-apireader"
+
+	cji := &crd.ClowdJobInvocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cji",
+			Namespace: ns,
+		},
+		Spec: crd.ClowdJobInvocationSpec{
+			AppName:       "test-app",
+			RunOnNotReady: true,
+			Jobs:          []string{"test-job"},
+		},
+	}
+
+	newApp := &crd.ClowdApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-app",
+			Namespace:  ns,
+			Generation: 10,
+		},
+		Spec: crd.ClowdAppSpec{
+			EnvName: "test-env",
+			Jobs: []crd.Job{
+				{
+					Name: "test-job",
+					PodSpec: crd.PodSpec{
+						Image: "busybox:v2-new",
+					},
+				},
+			},
+		},
+		Status: crd.ClowdAppStatus{
+			Generation: 9,
+		},
+	}
+
+	staleApp := &crd.ClowdApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-app",
+			Namespace:  ns,
+			Generation: 9,
+		},
+		Spec: crd.ClowdAppSpec{
+			EnvName: "test-env",
+			Jobs: []crd.Job{
+				{
+					Name: "test-job",
+					PodSpec: crd.PodSpec{
+						Image: "busybox:v1-old",
+					},
+				},
+			},
+		},
+		Status: crd.ClowdAppStatus{
+			Generation: 9,
+		},
+	}
+
+	// Cached client has the CJI and the STALE ClowdApp (simulates
+	// informer cache lag). The controller must NOT use this.
+	cachedClient := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(cji, staleApp).
+		WithStatusSubresource(&crd.ClowdJobInvocation{}).
+		Build()
+
+	// APIReader has the NEW ClowdApp (simulates direct etcd read).
+	// Generation 10 != status.generation 9, so the controller should
+	// detect the mismatch and requeue rather than using the stale data.
+	apiReader := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(newApp).
+		Build()
+
+	recorder := record.NewFakeRecorder(100)
+
+	reconciler := &ClowdJobInvocationReconciler{
+		Client:    cachedClient,
+		APIReader: apiReader,
+		Log:       ctrl.Log.WithName("test"),
+		Scheme:    Scheme,
+		Recorder:  recorder,
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "test-cji",
+			Namespace: ns,
+		},
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "has not been reconciled with the current generation")
+	assert.Contains(t, err.Error(), "spec: 10, status: 9")
+}
+
+func TestCJIAppNotFound(t *testing.T) {
+	ns := "test-app-not-found"
+
+	cji := &crd.ClowdJobInvocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cji",
+			Namespace: ns,
+		},
+		Spec: crd.ClowdJobInvocationSpec{
+			AppName:       "missing-app",
+			RunOnNotReady: true,
+			Jobs:          []string{"test-job"},
+		},
+	}
+
+	cachedClient := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(cji).
+		WithStatusSubresource(&crd.ClowdJobInvocation{}).
+		Build()
+
+	apiReader := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		Build()
+
+	recorder := record.NewFakeRecorder(100)
+
+	reconciler := &ClowdJobInvocationReconciler{
+		Client:    cachedClient,
+		APIReader: apiReader,
+		Log:       ctrl.Log.WithName("test"),
+		Scheme:    Scheme,
+		Recorder:  recorder,
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "test-cji",
+			Namespace: ns,
+		},
+	})
+
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "has not been reconciled with the current generation")
+}
+
+func TestCJICompletedSkipsReconciliation(t *testing.T) {
+	ns := "test-completed"
+
+	cji := &crd.ClowdJobInvocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cji",
+			Namespace: ns,
+		},
+		Spec: crd.ClowdJobInvocationSpec{
+			AppName: "test-app",
+			Jobs:    []string{"test-job"},
+		},
+		Status: crd.ClowdJobInvocationStatus{
+			Completed: true,
+		},
+	}
+
+	cachedClient := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(cji).
+		WithStatusSubresource(&crd.ClowdJobInvocation{}).
+		Build()
+
+	apiReader := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		Build()
+
+	recorder := record.NewFakeRecorder(100)
+
+	reconciler := &ClowdJobInvocationReconciler{
+		Client:    cachedClient,
+		APIReader: apiReader,
+		Log:       ctrl.Log.WithName("test"),
+		Scheme:    Scheme,
+		Recorder:  recorder,
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "test-cji",
+			Namespace: ns,
+		},
+	})
+
+	assert.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
+}
+
+func TestCJIExistingJobMapSkipsReconciliation(t *testing.T) {
+	ns := "test-existing-jobmap"
+
+	cji := &crd.ClowdJobInvocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cji",
+			Namespace: ns,
+		},
+		Spec: crd.ClowdJobInvocationSpec{
+			AppName: "test-app",
+			Jobs:    []string{"test-job"},
+		},
+		Status: crd.ClowdJobInvocationStatus{
+			JobMap: map[string]crd.JobConditionState{
+				"some-job": crd.JobInvoked,
+			},
+		},
+	}
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-job",
+			Namespace: ns,
+		},
+	}
+
+	cachedClient := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(cji, job).
+		WithStatusSubresource(&crd.ClowdJobInvocation{}).
+		Build()
+
+	apiReader := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		Build()
+
+	recorder := record.NewFakeRecorder(100)
+
+	reconciler := &ClowdJobInvocationReconciler{
+		Client:    cachedClient,
+		APIReader: apiReader,
+		Log:       ctrl.Log.WithName("test"),
+		Scheme:    Scheme,
+		Recorder:  recorder,
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "test-cji",
+			Namespace: ns,
+		},
+	})
+
+	assert.NoError(t, err)
+	assert.Zero(t, result.RequeueAfter)
+}

--- a/controllers/cloud.redhat.com/run.go
+++ b/controllers/cloud.redhat.com/run.go
@@ -164,9 +164,10 @@ func addControllersToManager(mgr manager.Manager) error {
 		return err
 	}
 	if err := (&ClowdJobInvocationReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("ClowdJobInvocation"),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		APIReader: mgr.GetAPIReader(),
+		Log:       ctrl.Log.WithName("controllers").WithName("ClowdJobInvocation"),
+		Scheme:    mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClowdJobInvocation")
 		return err

--- a/tests/kuttl/test-runonnotready-cji/02-json-asserts.sh
+++ b/tests/kuttl/test-runonnotready-cji/02-json-asserts.sh
@@ -12,16 +12,17 @@ mkdir -p "${TMP_DIR}"
 
 set -x
 
-# Test commands from original yaml file
 # Retry finding the pod
 for i in {1..100}; do
-  kubectl get pod -l app=puptoo -l job=puptoo-hello-cji -n test-runonnotready-cji -o json | jq -e '.items[] | select(.status.phase != "Pending" and .status.phase != "Unknown")' && break
+  kubectl get pod -l app=puptoo -l job=puptoo-hello-cji -n test-runonnotready-jobs -o json | jq -e '.items[] | select(.status.phase != "Pending" and .status.phase != "Unknown")' && break
   sleep 1
 done
 
 # Verify it exists, fail if not
-kubectl get pod -l app=puptoo -l job=puptoo-hello-cji -n test-runonnotready-cji -o json | jq -e '.items[] | select(.status.phase != "Pending" and .status.phase != "Unknown")' > /dev/null || { echo "Pod was not successfully started"; exit 1; }
+kubectl get pod -l app=puptoo -l job=puptoo-hello-cji -n test-runonnotready-jobs -o json | jq -e '.items[] | select(.status.phase != "Pending" and .status.phase != "Unknown")' > /dev/null || { echo "Pod was not successfully started"; exit 1; }
 
-kubectl get pod -l app=puptoo -l job=puptoo-hello-cji -n test-runonnotready-cji -o json > ${TMP_DIR}/kuttl/test-runonnotready-cji/test-runonnotready-cji
-kubectl logs `jq -r '.items[0].metadata.name' < ${TMP_DIR}/kuttl/test-runonnotready-cji/test-runonnotready-cji` -n test-runonnotready-cji > ${TMP_DIR}/kuttl/test-runonnotready-cji/test-runonnotready-cji-output-hello-cji-runner
-grep "Hello!" ${TMP_DIR}/test-runonnotready-cji-output-hello-cji-runner
+# Get pod details and verify the output
+kubectl get pod -l app=puptoo -l job=puptoo-hello-cji -n test-runonnotready-jobs -o json > "${TMP_DIR}/pod-list.json"
+POD_NAME=$(jq -r '.items[0].metadata.name' < "${TMP_DIR}/pod-list.json")
+kubectl logs "${POD_NAME}" -n test-runonnotready-jobs > "${TMP_DIR}/output-hello-cji-runner"
+grep "Hello!" "${TMP_DIR}/output-hello-cji-runner"


### PR DESCRIPTION
## Problem

PR #1742 introduced a generation check to prevent `runOnNotReady` CJI jobs from using stale ClowdApp specs. However, the fix was insufficient because the CJI controller reads the ClowdApp from the **informer cache**, which can serve an entirely stale but internally consistent object — where both `metadata.generation` and `status.generation` match at old values. The generation check passes, and the job is created with the old image.

We confirmed this in stage: CJI `run-db-migrations-90cb9b7` was created for image `90cb9b7`, but the resulting Job used old image `1f8810c`. Both the CJI and Job share the same creation timestamp (`22:01:45Z`) — the controller never requeued, proving the cache served stale data that passed the generation check.

## Solution

Replace `r.Get()` (informer cache) with `r.APIReader.Get()` (direct API server / etcd read) when fetching the ClowdApp in the CJI controller. This guarantees the controller sees the latest spec.

Combined with the existing generation check, the flow is now:

1. APIReader reads ClowdApp from etcd → gets new spec (`generation=N`, `status.generation=N-1`)
2. Generation check detects mismatch → requeue
3. ClowdApp controller reconciles → `status.generation=N`
4. CJI retries → generation matches → job created with correct image

## Changes

- **`clowdjobinvocation_controller.go`**: Add `APIReader client.Reader` field; use `r.APIReader.Get()` for the ClowdApp fetch
- **`run.go`**: Wire `mgr.GetAPIReader()` into the CJI reconciler
- **`clowdjobinvocation_controller_test.go`**: New unit tests covering generation check (match, mismatch, backward compat), APIReader vs cache behavior, missing app, and early-exit paths
- **`02-json-asserts.sh`**: Fix namespace and path bugs introduced in #1742

## Test plan

- [x] `go vet ./controllers/cloud.redhat.com/...` passes
- [x] `go test -run TestCJI ./controllers/cloud.redhat.com/` — all 5 tests pass
- [x] `make test` — full suite passes (pre-existing `covdata` tool error only)