### PR TITLE
Update IQE CJI logic to accept envVar.ValueFrom

### DIFF
--- a/controllers/cloud.redhat.com/providers/iqe/impl.go
+++ b/controllers/cloud.redhat.com/providers/iqe/impl.go
@@ -50,15 +50,18 @@ func joinNullableSlice(s *[]string) string {
 
 func updateEnvVars(existingEnvVars []core.EnvVar, newEnvVars []core.EnvVar) []core.EnvVar {
 	for _, newEnvVar := range newEnvVars {
-		if newEnvVar.Value == "" {
-			// do not update value of an env var if the new value is empty
+		if newEnvVar.Value == "" && newEnvVar.ValueFrom == nil {
+			// do not update value of an env var if the new value is empty and no valueFrom is set
 			continue
 		}
 		replaced := false
 		for idx, existingEnvVar := range existingEnvVars {
 			if existingEnvVar.Name == newEnvVar.Name {
 				p := &existingEnvVars[idx]
+				// Assign both fields and clear the other so the result satisfies the
+				// Kubernetes constraint that Value and ValueFrom are mutually exclusive.
 				p.Value = newEnvVar.Value
+				p.ValueFrom = newEnvVar.ValueFrom
 				replaced = true
 			}
 		}

--- a/controllers/cloud.redhat.com/providers/iqe/impl_test.go
+++ b/controllers/cloud.redhat.com/providers/iqe/impl_test.go
@@ -1,0 +1,167 @@
+package iqe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	core "k8s.io/api/core/v1"
+)
+
+func configMapKeyRef(name, key string) *core.EnvVarSource {
+	return &core.EnvVarSource{
+		ConfigMapKeyRef: &core.ConfigMapKeySelector{
+			LocalObjectReference: core.LocalObjectReference{Name: name},
+			Key:                  key,
+		},
+	}
+}
+
+func secretKeyRef(name, key string) *core.EnvVarSource {
+	return &core.EnvVarSource{
+		SecretKeyRef: &core.SecretKeySelector{
+			LocalObjectReference: core.LocalObjectReference{Name: name},
+			Key:                  key,
+		},
+	}
+}
+
+func TestUpdateEnvVars_ValueReplacesValue(t *testing.T) {
+	existing := []core.EnvVar{
+		{Name: "FOO", Value: "old"},
+	}
+	updated := updateEnvVars(existing, []core.EnvVar{
+		{Name: "FOO", Value: "new"},
+	})
+
+	assert.Len(t, updated, 1)
+	assert.Equal(t, "new", updated[0].Value)
+	assert.Nil(t, updated[0].ValueFrom)
+}
+
+func TestUpdateEnvVars_ValueFromReplacesValue(t *testing.T) {
+	existing := []core.EnvVar{
+		{Name: "FOO", Value: "old"},
+	}
+	ref := configMapKeyRef("my-config", "MY_KEY")
+	updated := updateEnvVars(existing, []core.EnvVar{
+		{Name: "FOO", ValueFrom: ref},
+	})
+
+	assert.Len(t, updated, 1)
+	assert.Equal(t, "", updated[0].Value)
+	assert.Equal(t, ref, updated[0].ValueFrom)
+}
+
+func TestUpdateEnvVars_ValueReplacesValueFrom(t *testing.T) {
+	existing := []core.EnvVar{
+		{Name: "FOO", ValueFrom: secretKeyRef("my-secret", "MY_KEY")},
+	}
+	updated := updateEnvVars(existing, []core.EnvVar{
+		{Name: "FOO", Value: "literal"},
+	})
+
+	assert.Len(t, updated, 1)
+	assert.Equal(t, "literal", updated[0].Value)
+	assert.Nil(t, updated[0].ValueFrom)
+}
+
+func TestUpdateEnvVars_ValueFromReplacesValueFrom(t *testing.T) {
+	existing := []core.EnvVar{
+		{Name: "FOO", ValueFrom: secretKeyRef("old-secret", "OLD_KEY")},
+	}
+	newRef := configMapKeyRef("new-config", "NEW_KEY")
+	updated := updateEnvVars(existing, []core.EnvVar{
+		{Name: "FOO", ValueFrom: newRef},
+	})
+
+	assert.Len(t, updated, 1)
+	assert.Equal(t, "", updated[0].Value)
+	assert.Equal(t, newRef, updated[0].ValueFrom)
+}
+
+func TestUpdateEnvVars_EmptyValueAndNilValueFromSkipped(t *testing.T) {
+	existing := []core.EnvVar{
+		{Name: "FOO", Value: "keep"},
+	}
+	updated := updateEnvVars(existing, []core.EnvVar{
+		{Name: "FOO", Value: ""},
+	})
+
+	assert.Len(t, updated, 1)
+	assert.Equal(t, "keep", updated[0].Value)
+}
+
+func TestUpdateEnvVars_NewValueAppended(t *testing.T) {
+	existing := []core.EnvVar{
+		{Name: "FOO", Value: "bar"},
+	}
+	updated := updateEnvVars(existing, []core.EnvVar{
+		{Name: "BAZ", Value: "qux"},
+	})
+
+	assert.Len(t, updated, 2)
+	assert.Equal(t, "FOO", updated[0].Name)
+	assert.Equal(t, "BAZ", updated[1].Name)
+	assert.Equal(t, "qux", updated[1].Value)
+}
+
+func TestUpdateEnvVars_NewValueFromAppended(t *testing.T) {
+	existing := []core.EnvVar{
+		{Name: "FOO", Value: "bar"},
+	}
+	ref := secretKeyRef("ibutsu-token", "IBUTSU_TOKEN")
+	updated := updateEnvVars(existing, []core.EnvVar{
+		{Name: "IBUTSU_TOKEN", ValueFrom: ref},
+	})
+
+	assert.Len(t, updated, 2)
+	assert.Equal(t, "FOO", updated[0].Name)
+	assert.Equal(t, "IBUTSU_TOKEN", updated[1].Name)
+	assert.Equal(t, ref, updated[1].ValueFrom)
+	assert.Equal(t, "", updated[1].Value)
+}
+
+func TestUpdateEnvVars_MultipleUpdatesAndAppends(t *testing.T) {
+	existing := []core.EnvVar{
+		{Name: "A", Value: "1"},
+		{Name: "B", Value: "2"},
+	}
+	cmRef := configMapKeyRef("ibutsu-config", "IBUTSU_MODE")
+	updated := updateEnvVars(existing, []core.EnvVar{
+		{Name: "A", Value: "updated"},
+		{Name: "B", ValueFrom: cmRef},
+		{Name: "C", Value: "new"},
+	})
+
+	assert.Len(t, updated, 3)
+
+	assert.Equal(t, "updated", updated[0].Value)
+	assert.Nil(t, updated[0].ValueFrom)
+
+	assert.Equal(t, "", updated[1].Value)
+	assert.Equal(t, cmRef, updated[1].ValueFrom)
+
+	assert.Equal(t, "C", updated[2].Name)
+	assert.Equal(t, "new", updated[2].Value)
+}
+
+func TestUpdateEnvVars_EmptyExisting(t *testing.T) {
+	ref := secretKeyRef("my-secret", "KEY")
+	updated := updateEnvVars([]core.EnvVar{}, []core.EnvVar{
+		{Name: "NEW_VAR", ValueFrom: ref},
+	})
+
+	assert.Len(t, updated, 1)
+	assert.Equal(t, "NEW_VAR", updated[0].Name)
+	assert.Equal(t, ref, updated[0].ValueFrom)
+}
+
+func TestUpdateEnvVars_EmptyNew(t *testing.T) {
+	existing := []core.EnvVar{
+		{Name: "FOO", Value: "bar"},
+	}
+	updated := updateEnvVars(existing, []core.EnvVar{})
+
+	assert.Len(t, updated, 1)
+	assert.Equal(t, "bar", updated[0].Value)
+}


### PR DESCRIPTION
Intent is to use valueFrom references in the default bonfire template to include some configmap and secret values from ephemeral-base deployments.

## Related
* https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/185300 (Add to ephemeral-base target)
* https://github.com/RedHatInsights/bonfire/pull/552 (include valueFrom for config and secret in bonfire default)

## Review
 Would very much appreciate human review from contributors, this is my first `go` contribution.
 
 ## Test Results

### E2E test pipeline failure

I don't believe the failure is related. The IQE related resource tests passed
```
        <...>
        --- PASS: kuttl/harness/test-iqe-jobs-selenium (23.63s)
        --- PASS: kuttl/harness/test-iqe-jobs-vault (30.99s)
        --- PASS: kuttl/harness/test-iqe-jobs (20.16s)
        <...>
        --- FAIL: kuttl/harness/test-sidecars (621.93s)
FAIL
Collecting logs and metrics...
Error from server (BadRequest): previous terminated container "manager" in pod "clowder-controller-manager-554bdb6848-c2kwc" not found
```

