### PR TITLE
Feat/add v2 cdappconfig endpoints

### DIFF
--- a/controllers/cloud.redhat.com/config/schema.json
+++ b/controllers/cloud.redhat.com/config/schema.json
@@ -89,6 +89,50 @@
                 },
                 "prometheusGateway": {
                     "$ref": "#/definitions/PrometheusGatewayConfig"
+                },
+                "dependencyEndpoints": {
+                    "id": "dependencyEndpoints",
+                    "type": "object",
+                    "description": "V2 public dependency endpoints with simplified URI-based structure",
+                    "properties": {
+                        "v2": {
+                            "type": "object",
+                            "description": "Version 2 public dependency endpoint format with URI-based endpoints",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "description": "App-level endpoint grouping",
+                                    "patternProperties": {
+                                        ".*": {
+                                            "$ref": "#/definitions/DependencyEndpointV2"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "privateDependencyEndpoints": {
+                    "id": "privateDependencyEndpoints",
+                    "type": "object",
+                    "description": "V2 private dependency endpoints with simplified URI-based structure",
+                    "properties": {
+                        "v2": {
+                            "type": "object",
+                            "description": "Version 2 private dependency endpoint format with URI-based endpoints",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "description": "App-level endpoint grouping",
+                                    "patternProperties": {
+                                        ".*": {
+                                            "$ref": "#/definitions/DependencyEndpointV2"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             },
             "required": [
@@ -597,6 +641,24 @@
             "required": [
                 "hostname",
                 "port"
+            ]
+        },
+        "DependencyEndpointV2": {
+            "id": "dependencyEndpointV2",
+            "type": "object",
+            "description": "V2 dependency endpoint with complete URI",
+            "properties": {
+                "uri": {
+                    "description": "Complete URI including protocol, hostname, and port (e.g., 'http://service.ns.svc:8000', 'https://service:8443')",
+                    "type": "string"
+                },
+                "ca_certificate": {
+                    "description": "Path to CA certificate file for TLS/HTTPS connections. Only present for https:// URIs.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "uri"
             ]
         }
     }

--- a/controllers/cloud.redhat.com/config/types.go
+++ b/controllers/cloud.redhat.com/config/types.go
@@ -14,6 +14,9 @@ type AppConfig struct {
 	// Database corresponds to the JSON schema field "database".
 	Database *DatabaseConfig `json:"database,omitempty" yaml:"database,omitempty" mapstructure:"database,omitempty"`
 
+	// V2 public dependency endpoints with simplified URI-based structure
+	DependencyEndpoints *AppConfigDependencyEndpoints `json:"dependencyEndpoints,omitempty" yaml:"dependencyEndpoints,omitempty" mapstructure:"dependencyEndpoints,omitempty"`
+
 	// Endpoints corresponds to the JSON schema field "endpoints".
 	Endpoints []DependencyEndpoint `json:"endpoints,omitempty" yaml:"endpoints,omitempty" mapstructure:"endpoints,omitempty"`
 
@@ -57,6 +60,9 @@ type AppConfig struct {
 	// ObjectStore corresponds to the JSON schema field "objectStore".
 	ObjectStore *ObjectStoreConfig `json:"objectStore,omitempty" yaml:"objectStore,omitempty" mapstructure:"objectStore,omitempty"`
 
+	// V2 private dependency endpoints with simplified URI-based structure
+	PrivateDependencyEndpoints *AppConfigPrivateDependencyEndpoints `json:"privateDependencyEndpoints,omitempty" yaml:"privateDependencyEndpoints,omitempty" mapstructure:"privateDependencyEndpoints,omitempty"`
+
 	// PrivateEndpoints corresponds to the JSON schema field "privateEndpoints".
 	PrivateEndpoints []PrivateDependencyEndpoint `json:"privateEndpoints,omitempty" yaml:"privateEndpoints,omitempty" mapstructure:"privateEndpoints,omitempty"`
 
@@ -79,6 +85,24 @@ type AppConfig struct {
 	WebPort *int `json:"webPort,omitempty" yaml:"webPort,omitempty" mapstructure:"webPort,omitempty"`
 }
 
+// V2 public dependency endpoints with simplified URI-based structure
+type AppConfigDependencyEndpoints struct {
+	// Version 2 public dependency endpoint format with URI-based endpoints
+	V2 AppConfigDependencyEndpointsV2 `json:"v2,omitempty" yaml:"v2,omitempty" mapstructure:"v2,omitempty"`
+}
+
+// Version 2 public dependency endpoint format with URI-based endpoints
+type AppConfigDependencyEndpointsV2 map[string]interface{}
+
+// V2 private dependency endpoints with simplified URI-based structure
+type AppConfigPrivateDependencyEndpoints struct {
+	// Version 2 private dependency endpoint format with URI-based endpoints
+	V2 AppConfigPrivateDependencyEndpointsV2 `json:"v2,omitempty" yaml:"v2,omitempty" mapstructure:"v2,omitempty"`
+}
+
+// Version 2 private dependency endpoint format with URI-based endpoints
+type AppConfigPrivateDependencyEndpointsV2 map[string]interface{}
+
 // Arbitrary metadata pertaining to the application application
 type AppMetadata struct {
 	// Metadata pertaining to an application's deployments
@@ -89,197 +113,6 @@ type AppMetadata struct {
 
 	// Name of the ClowdApp
 	Name *string `json:"name,omitempty" yaml:"name,omitempty" mapstructure:"name,omitempty"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *BrokerConfigAuthtype) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_BrokerConfigAuthtype {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_BrokerConfigAuthtype, v)
-	}
-	*j = BrokerConfigAuthtype(v)
-	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *DependencyEndpoint) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["apiPath"]; !ok || v == nil {
-		return fmt.Errorf("field apiPath in DependencyEndpoint: required")
-	}
-	if v, ok := raw["app"]; !ok || v == nil {
-		return fmt.Errorf("field app in DependencyEndpoint: required")
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname in DependencyEndpoint: required")
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name in DependencyEndpoint: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port in DependencyEndpoint: required")
-	}
-	type Plain DependencyEndpoint
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = DependencyEndpoint(plain)
-	return nil
-}
-
-type FeatureFlagsConfigScheme string
-
-var enumValues_FeatureFlagsConfigScheme = []interface{}{
-	"http",
-	"https",
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *FeatureFlagsConfigScheme) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_FeatureFlagsConfigScheme {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_FeatureFlagsConfigScheme, v)
-	}
-	*j = FeatureFlagsConfigScheme(v)
-	return nil
-}
-
-const FeatureFlagsConfigSchemeHttp FeatureFlagsConfigScheme = "http"
-const FeatureFlagsConfigSchemeHttps FeatureFlagsConfigScheme = "https"
-
-// Feature Flags Configuration
-type FeatureFlagsConfig struct {
-	// Defines the client access token to use when connect to the FeatureFlags server
-	ClientAccessToken *string `json:"clientAccessToken,omitempty" yaml:"clientAccessToken,omitempty" mapstructure:"clientAccessToken,omitempty"`
-
-	// Defines the hostname for the FeatureFlags server
-	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
-
-	// Defines the port for the FeatureFlags server
-	Port int `json:"port" yaml:"port" mapstructure:"port"`
-
-	// Details the scheme to use for FeatureFlags http/https
-	Scheme FeatureFlagsConfigScheme `json:"scheme" yaml:"scheme" mapstructure:"scheme"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *FeatureFlagsConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname in FeatureFlagsConfig: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port in FeatureFlagsConfig: required")
-	}
-	if v, ok := raw["scheme"]; !ok || v == nil {
-		return fmt.Errorf("field scheme in FeatureFlagsConfig: required")
-	}
-	type Plain FeatureFlagsConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = FeatureFlagsConfig(plain)
-	return nil
-}
-
-// In Memory DB Configuration
-type InMemoryDBConfig struct {
-	// Defines the hostname for the In Memory DB server configuration.
-	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
-
-	// Defines the password for the In Memory DB server configuration.
-	Password *string `json:"password,omitempty" yaml:"password,omitempty" mapstructure:"password,omitempty"`
-
-	// Defines the port for the In Memory DB server configuration.
-	Port int `json:"port" yaml:"port" mapstructure:"port"`
-
-	// Defines the sslMode used by the In Memory DB server coniguration
-	SslMode *bool `json:"sslMode,omitempty" yaml:"sslMode,omitempty" mapstructure:"sslMode,omitempty"`
-
-	// Defines the username for the In Memory DB server configuration.
-	Username *string `json:"username,omitempty" yaml:"username,omitempty" mapstructure:"username,omitempty"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *InMemoryDBConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname in InMemoryDBConfig: required")
-	}
-	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port in InMemoryDBConfig: required")
-	}
-	type Plain InMemoryDBConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = InMemoryDBConfig(plain)
-	return nil
-}
-
-type BrokerConfigAuthtype string
-
-var enumValues_BrokerConfigAuthtype = []interface{}{
-	"sasl",
-}
-
-// Topic Configuration
-type TopicConfig struct {
-	// The name of the actual topic on the Kafka server.
-	Name string `json:"name" yaml:"name" mapstructure:"name"`
-
-	// The name that the app requested in the ClowdApp definition.
-	RequestedName string `json:"requestedName" yaml:"requestedName" mapstructure:"requestedName"`
-}
-
-const BrokerConfigAuthtypeSasl BrokerConfigAuthtype = "sasl"
-
-// SASL Configuration for Kafka
-type KafkaSASLConfig struct {
-	// Broker SASL password
-	Password *string `json:"password,omitempty" yaml:"password,omitempty" mapstructure:"password,omitempty"`
-
-	// Broker SASL mechanism, expect: SCRAM-SHA-512
-	SaslMechanism *string `json:"saslMechanism,omitempty" yaml:"saslMechanism,omitempty" mapstructure:"saslMechanism,omitempty"`
-
-	// Broker security protocol, expect one of either: SASL_SSL, SSL. DEPRECATED, use
-	// the top level securityProtocol field instead
-	SecurityProtocol *string `json:"securityProtocol,omitempty" yaml:"securityProtocol,omitempty" mapstructure:"securityProtocol,omitempty"`
-
-	// Broker SASL username
-	Username *string `json:"username,omitempty" yaml:"username,omitempty" mapstructure:"username,omitempty"`
 }
 
 // Broker Configuration
@@ -302,6 +135,55 @@ type BrokerConfig struct {
 
 	// Broker security procotol, expect one of either: SASL_SSL, SSL
 	SecurityProtocol *string `json:"securityProtocol,omitempty" yaml:"securityProtocol,omitempty" mapstructure:"securityProtocol,omitempty"`
+}
+
+type BrokerConfigAuthtype string
+
+const BrokerConfigAuthtypeSasl BrokerConfigAuthtype = "sasl"
+
+// Cloud Watch configuration
+type CloudWatchConfig struct {
+	// Defines the access key that the app should use for configuring CloudWatch.
+	AccessKeyId string `json:"accessKeyId" yaml:"accessKeyId" mapstructure:"accessKeyId"`
+
+	// Defines the logGroup that the app should use for configuring CloudWatch.
+	LogGroup string `json:"logGroup" yaml:"logGroup" mapstructure:"logGroup"`
+
+	// Defines the region that the app should use for configuring CloudWatch.
+	Region string `json:"region" yaml:"region" mapstructure:"region"`
+
+	// Defines the secret key that the app should use for configuring CloudWatch.
+	SecretAccessKey string `json:"secretAccessKey" yaml:"secretAccessKey" mapstructure:"secretAccessKey"`
+}
+
+// Database Configuration
+type DatabaseConfig struct {
+	// Defines the pgAdmin password.
+	AdminPassword string `json:"adminPassword" yaml:"adminPassword" mapstructure:"adminPassword"`
+
+	// Defines the pgAdmin username.
+	AdminUsername string `json:"adminUsername" yaml:"adminUsername" mapstructure:"adminUsername"`
+
+	// Defines the hostname of the database configured for the ClowdApp.
+	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
+
+	// Defines the database name.
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
+
+	// Defines the password for the standard user.
+	Password string `json:"password" yaml:"password" mapstructure:"password"`
+
+	// Defines the port of the database configured for the ClowdApp.
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
+
+	// Defines the CA used to access the database.
+	RdsCa *string `json:"rdsCa,omitempty" yaml:"rdsCa,omitempty" mapstructure:"rdsCa,omitempty"`
+
+	// Defines the postgres SSL mode that should be used.
+	SslMode string `json:"sslMode" yaml:"sslMode" mapstructure:"sslMode"`
+
+	// Defines a username with standard access to the database.
+	Username string `json:"username" yaml:"username" mapstructure:"username"`
 }
 
 // Dependent service connection info
@@ -340,22 +222,87 @@ type DependencyEndpoint struct {
 	TlsPort *int `json:"tlsPort,omitempty" yaml:"tlsPort,omitempty" mapstructure:"tlsPort,omitempty"`
 }
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *BrokerConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname in BrokerConfig: required")
-	}
-	type Plain BrokerConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = BrokerConfig(plain)
-	return nil
+// V2 dependency endpoint with complete URI
+type DependencyEndpointV2 struct {
+	// Path to CA certificate file for TLS/HTTPS connections. Only present for
+	// https:// URIs.
+	CaCertificate *string `json:"ca_certificate,omitempty" yaml:"ca_certificate,omitempty" mapstructure:"ca_certificate,omitempty"`
+
+	// Complete URI including protocol, hostname, and port (e.g.,
+	// 'http://service.ns.svc:8000', 'https://service:8443')
+	Uri string `json:"uri" yaml:"uri" mapstructure:"uri"`
+}
+
+// Deployment Metadata
+type DeploymentMetadata struct {
+	// Image used by deployment
+	Image string `json:"image" yaml:"image" mapstructure:"image"`
+
+	// Name of deployment
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
+}
+
+// Feature Flags Configuration
+type FeatureFlagsConfig struct {
+	// Defines the client access token to use when connect to the FeatureFlags server
+	ClientAccessToken *string `json:"clientAccessToken,omitempty" yaml:"clientAccessToken,omitempty" mapstructure:"clientAccessToken,omitempty"`
+
+	// Defines the hostname for the FeatureFlags server
+	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
+
+	// Defines the port for the FeatureFlags server
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
+
+	// Details the scheme to use for FeatureFlags http/https
+	Scheme FeatureFlagsConfigScheme `json:"scheme" yaml:"scheme" mapstructure:"scheme"`
+}
+
+type FeatureFlagsConfigScheme string
+
+const FeatureFlagsConfigSchemeHttp FeatureFlagsConfigScheme = "http"
+const FeatureFlagsConfigSchemeHttps FeatureFlagsConfigScheme = "https"
+
+// In Memory DB Configuration
+type InMemoryDBConfig struct {
+	// Defines the hostname for the In Memory DB server configuration.
+	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
+
+	// Defines the password for the In Memory DB server configuration.
+	Password *string `json:"password,omitempty" yaml:"password,omitempty" mapstructure:"password,omitempty"`
+
+	// Defines the port for the In Memory DB server configuration.
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
+
+	// Defines the sslMode used by the In Memory DB server coniguration
+	SslMode *bool `json:"sslMode,omitempty" yaml:"sslMode,omitempty" mapstructure:"sslMode,omitempty"`
+
+	// Defines the username for the In Memory DB server configuration.
+	Username *string `json:"username,omitempty" yaml:"username,omitempty" mapstructure:"username,omitempty"`
+}
+
+// Kafka Configuration
+type KafkaConfig struct {
+	// Defines the brokers the app should connect to for Kafka services.
+	Brokers []BrokerConfig `json:"brokers" yaml:"brokers" mapstructure:"brokers"`
+
+	// Defines a list of the topic configurations available to the application.
+	Topics []TopicConfig `json:"topics" yaml:"topics" mapstructure:"topics"`
+}
+
+// SASL Configuration for Kafka
+type KafkaSASLConfig struct {
+	// Broker SASL password
+	Password *string `json:"password,omitempty" yaml:"password,omitempty" mapstructure:"password,omitempty"`
+
+	// Broker SASL mechanism, expect: SCRAM-SHA-512
+	SaslMechanism *string `json:"saslMechanism,omitempty" yaml:"saslMechanism,omitempty" mapstructure:"saslMechanism,omitempty"`
+
+	// Broker security protocol, expect one of either: SASL_SSL, SSL. DEPRECATED, use
+	// the top level securityProtocol field instead
+	SecurityProtocol *string `json:"securityProtocol,omitempty" yaml:"securityProtocol,omitempty" mapstructure:"securityProtocol,omitempty"`
+
+	// Broker SASL username
+	Username *string `json:"username,omitempty" yaml:"username,omitempty" mapstructure:"username,omitempty"`
 }
 
 // Logging Configuration
@@ -367,13 +314,67 @@ type LoggingConfig struct {
 	Type string `json:"type" yaml:"type" mapstructure:"type"`
 }
 
-// Kafka Configuration
-type KafkaConfig struct {
-	// Defines the brokers the app should connect to for Kafka services.
-	Brokers []BrokerConfig `json:"brokers" yaml:"brokers" mapstructure:"brokers"`
+// Object Storage Bucket
+type ObjectStoreBucket struct {
+	// Defines the access key for specificed bucket.
+	AccessKey *string `json:"accessKey,omitempty" yaml:"accessKey,omitempty" mapstructure:"accessKey,omitempty"`
 
-	// Defines a list of the topic configurations available to the application.
-	Topics []TopicConfig `json:"topics" yaml:"topics" mapstructure:"topics"`
+	// Defines the endpoint for the Object Storage server configuration.
+	Endpoint *string `json:"endpoint,omitempty" yaml:"endpoint,omitempty" mapstructure:"endpoint,omitempty"`
+
+	// The actual name of the bucket being accessed.
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
+
+	// Defines the region for the specified bucket.
+	Region *string `json:"region,omitempty" yaml:"region,omitempty" mapstructure:"region,omitempty"`
+
+	// The name that was requested for the bucket in the ClowdApp.
+	RequestedName string `json:"requestedName" yaml:"requestedName" mapstructure:"requestedName"`
+
+	// Defines the secret key for the specified bucket.
+	SecretKey *string `json:"secretKey,omitempty" yaml:"secretKey,omitempty" mapstructure:"secretKey,omitempty"`
+
+	// Details if the Object Server uses TLS.
+	Tls *bool `json:"tls,omitempty" yaml:"tls,omitempty" mapstructure:"tls,omitempty"`
+}
+
+// Object Storage Configuration
+type ObjectStoreConfig struct {
+	// Defines the access key for the Object Storage server configuration.
+	AccessKey *string `json:"accessKey,omitempty" yaml:"accessKey,omitempty" mapstructure:"accessKey,omitempty"`
+
+	// Buckets corresponds to the JSON schema field "buckets".
+	Buckets []ObjectStoreBucket `json:"buckets,omitempty" yaml:"buckets,omitempty" mapstructure:"buckets,omitempty"`
+
+	// Defines the hostname for the Object Storage server configuration.
+	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
+
+	// Defines the port for the Object Storage server configuration.
+	Port int `json:"port" yaml:"port" mapstructure:"port"`
+
+	// Defines the secret key for the Object Storage server configuration.
+	SecretKey *string `json:"secretKey,omitempty" yaml:"secretKey,omitempty" mapstructure:"secretKey,omitempty"`
+
+	// Details if the Object Server uses TLS.
+	Tls bool `json:"tls" yaml:"tls" mapstructure:"tls"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *LoggingConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["type"]; !ok || v == nil {
+		return fmt.Errorf("field type in LoggingConfig: required")
+	}
+	type Plain LoggingConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = LoggingConfig(plain)
+	return nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -397,19 +398,22 @@ func (j *KafkaConfig) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// Cloud Watch configuration
-type CloudWatchConfig struct {
-	// Defines the access key that the app should use for configuring CloudWatch.
-	AccessKeyId string `json:"accessKeyId" yaml:"accessKeyId" mapstructure:"accessKeyId"`
-
-	// Defines the logGroup that the app should use for configuring CloudWatch.
-	LogGroup string `json:"logGroup" yaml:"logGroup" mapstructure:"logGroup"`
-
-	// Defines the region that the app should use for configuring CloudWatch.
-	Region string `json:"region" yaml:"region" mapstructure:"region"`
-
-	// Defines the secret key that the app should use for configuring CloudWatch.
-	SecretAccessKey string `json:"secretAccessKey" yaml:"secretAccessKey" mapstructure:"secretAccessKey"`
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *BrokerConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname in BrokerConfig: required")
+	}
+	type Plain BrokerConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = BrokerConfig(plain)
+	return nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -440,126 +444,23 @@ func (j *CloudWatchConfig) UnmarshalJSON(b []byte) error {
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *TopicConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
+func (j *BrokerConfigAuthtype) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
 		return err
 	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name in TopicConfig: required")
+	var ok bool
+	for _, expected := range enumValues_BrokerConfigAuthtype {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
 	}
-	if v, ok := raw["requestedName"]; !ok || v == nil {
-		return fmt.Errorf("field requestedName in TopicConfig: required")
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_BrokerConfigAuthtype, v)
 	}
-	type Plain TopicConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = TopicConfig(plain)
+	*j = BrokerConfigAuthtype(v)
 	return nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *LoggingConfig) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["type"]; !ok || v == nil {
-		return fmt.Errorf("field type in LoggingConfig: required")
-	}
-	type Plain LoggingConfig
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = LoggingConfig(plain)
-	return nil
-}
-
-// Deployment Metadata
-type DeploymentMetadata struct {
-	// Image used by deployment
-	Image string `json:"image" yaml:"image" mapstructure:"image"`
-
-	// Name of deployment
-	Name string `json:"name" yaml:"name" mapstructure:"name"`
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *DeploymentMetadata) UnmarshalJSON(b []byte) error {
-	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
-		return err
-	}
-	if v, ok := raw["image"]; !ok || v == nil {
-		return fmt.Errorf("field image in DeploymentMetadata: required")
-	}
-	if v, ok := raw["name"]; !ok || v == nil {
-		return fmt.Errorf("field name in DeploymentMetadata: required")
-	}
-	type Plain DeploymentMetadata
-	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
-		return err
-	}
-	*j = DeploymentMetadata(plain)
-	return nil
-}
-
-// Database Configuration
-type DatabaseConfig struct {
-	// Defines the pgAdmin password.
-	AdminPassword string `json:"adminPassword" yaml:"adminPassword" mapstructure:"adminPassword"`
-
-	// Defines the pgAdmin username.
-	AdminUsername string `json:"adminUsername" yaml:"adminUsername" mapstructure:"adminUsername"`
-
-	// Defines the hostname of the database configured for the ClowdApp.
-	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
-
-	// Defines the database name.
-	Name string `json:"name" yaml:"name" mapstructure:"name"`
-
-	// Defines the password for the standard user.
-	Password string `json:"password" yaml:"password" mapstructure:"password"`
-
-	// Defines the port of the database configured for the ClowdApp.
-	Port int `json:"port" yaml:"port" mapstructure:"port"`
-
-	// Defines the CA used to access the database.
-	RdsCa *string `json:"rdsCa,omitempty" yaml:"rdsCa,omitempty" mapstructure:"rdsCa,omitempty"`
-
-	// Defines the postgres SSL mode that should be used.
-	SslMode string `json:"sslMode" yaml:"sslMode" mapstructure:"sslMode"`
-
-	// Defines a username with standard access to the database.
-	Username string `json:"username" yaml:"username" mapstructure:"username"`
-}
-
-// Object Storage Bucket
-type ObjectStoreBucket struct {
-	// Defines the access key for specificed bucket.
-	AccessKey *string `json:"accessKey,omitempty" yaml:"accessKey,omitempty" mapstructure:"accessKey,omitempty"`
-
-	// Defines the endpoint for the Object Storage server configuration.
-	Endpoint *string `json:"endpoint,omitempty" yaml:"endpoint,omitempty" mapstructure:"endpoint,omitempty"`
-
-	// The actual name of the bucket being accessed.
-	Name string `json:"name" yaml:"name" mapstructure:"name"`
-
-	// Defines the region for the specified bucket.
-	Region *string `json:"region,omitempty" yaml:"region,omitempty" mapstructure:"region,omitempty"`
-
-	// The name that was requested for the bucket in the ClowdApp.
-	RequestedName string `json:"requestedName" yaml:"requestedName" mapstructure:"requestedName"`
-
-	// Defines the secret key for the specified bucket.
-	SecretKey *string `json:"secretKey,omitempty" yaml:"secretKey,omitempty" mapstructure:"secretKey,omitempty"`
-
-	// Details if the Object Server uses TLS.
-	Tls *bool `json:"tls,omitempty" yaml:"tls,omitempty" mapstructure:"tls,omitempty"`
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -583,48 +484,82 @@ func (j *ObjectStoreBucket) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// Object Storage Configuration
-type ObjectStoreConfig struct {
-	// Defines the access key for the Object Storage server configuration.
-	AccessKey *string `json:"accessKey,omitempty" yaml:"accessKey,omitempty" mapstructure:"accessKey,omitempty"`
-
-	// Buckets corresponds to the JSON schema field "buckets".
-	Buckets []ObjectStoreBucket `json:"buckets,omitempty" yaml:"buckets,omitempty" mapstructure:"buckets,omitempty"`
-
-	// Defines the hostname for the Object Storage server configuration.
-	Hostname string `json:"hostname" yaml:"hostname" mapstructure:"hostname"`
-
-	// Defines the port for the Object Storage server configuration.
-	Port int `json:"port" yaml:"port" mapstructure:"port"`
-
-	// Defines the secret key for the Object Storage server configuration.
-	SecretKey *string `json:"secretKey,omitempty" yaml:"secretKey,omitempty" mapstructure:"secretKey,omitempty"`
-
-	// Details if the Object Server uses TLS.
-	Tls bool `json:"tls" yaml:"tls" mapstructure:"tls"`
+var enumValues_BrokerConfigAuthtype = []interface{}{
+	"sasl",
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *ObjectStoreConfig) UnmarshalJSON(b []byte) error {
+func (j *DeploymentMetadata) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["image"]; !ok || v == nil {
+		return fmt.Errorf("field image in DeploymentMetadata: required")
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name in DeploymentMetadata: required")
+	}
+	type Plain DeploymentMetadata
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = DeploymentMetadata(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *InMemoryDBConfig) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
 	if v, ok := raw["hostname"]; !ok || v == nil {
-		return fmt.Errorf("field hostname in ObjectStoreConfig: required")
+		return fmt.Errorf("field hostname in InMemoryDBConfig: required")
 	}
 	if v, ok := raw["port"]; !ok || v == nil {
-		return fmt.Errorf("field port in ObjectStoreConfig: required")
+		return fmt.Errorf("field port in InMemoryDBConfig: required")
 	}
-	if v, ok := raw["tls"]; !ok || v == nil {
-		return fmt.Errorf("field tls in ObjectStoreConfig: required")
-	}
-	type Plain ObjectStoreConfig
+	type Plain InMemoryDBConfig
 	var plain Plain
 	if err := json.Unmarshal(b, &plain); err != nil {
 		return err
 	}
-	*j = ObjectStoreConfig(plain)
+	*j = InMemoryDBConfig(plain)
+	return nil
+}
+
+// Topic Configuration
+type TopicConfig struct {
+	// The name of the actual topic on the Kafka server.
+	Name string `json:"name" yaml:"name" mapstructure:"name"`
+
+	// The name that the app requested in the ClowdApp definition.
+	RequestedName string `json:"requestedName" yaml:"requestedName" mapstructure:"requestedName"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *FeatureFlagsConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname in FeatureFlagsConfig: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port in FeatureFlagsConfig: required")
+	}
+	if v, ok := raw["scheme"]; !ok || v == nil {
+		return fmt.Errorf("field scheme in FeatureFlagsConfig: required")
+	}
+	type Plain FeatureFlagsConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = FeatureFlagsConfig(plain)
 	return nil
 }
 
@@ -654,6 +589,76 @@ type PrivateDependencyEndpoint struct {
 
 	// The TLS port of the dependent service.
 	TlsPort *int `json:"tlsPort,omitempty" yaml:"tlsPort,omitempty" mapstructure:"tlsPort,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *ObjectStoreConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname in ObjectStoreConfig: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port in ObjectStoreConfig: required")
+	}
+	if v, ok := raw["tls"]; !ok || v == nil {
+		return fmt.Errorf("field tls in ObjectStoreConfig: required")
+	}
+	type Plain ObjectStoreConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = ObjectStoreConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *FeatureFlagsConfigScheme) UnmarshalJSON(b []byte) error {
+	var v string
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_FeatureFlagsConfigScheme {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_FeatureFlagsConfigScheme, v)
+	}
+	*j = FeatureFlagsConfigScheme(v)
+	return nil
+}
+
+var enumValues_FeatureFlagsConfigScheme = []interface{}{
+	"http",
+	"https",
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *TopicConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name in TopicConfig: required")
+	}
+	if v, ok := raw["requestedName"]; !ok || v == nil {
+		return fmt.Errorf("field requestedName in TopicConfig: required")
+	}
+	type Plain TopicConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = TopicConfig(plain)
+	return nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
@@ -714,6 +719,60 @@ func (j *PrometheusGatewayConfig) UnmarshalJSON(b []byte) error {
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
+func (j *DependencyEndpoint) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["apiPath"]; !ok || v == nil {
+		return fmt.Errorf("field apiPath in DependencyEndpoint: required")
+	}
+	if v, ok := raw["app"]; !ok || v == nil {
+		return fmt.Errorf("field app in DependencyEndpoint: required")
+	}
+	if v, ok := raw["hostname"]; !ok || v == nil {
+		return fmt.Errorf("field hostname in DependencyEndpoint: required")
+	}
+	if v, ok := raw["name"]; !ok || v == nil {
+		return fmt.Errorf("field name in DependencyEndpoint: required")
+	}
+	if v, ok := raw["port"]; !ok || v == nil {
+		return fmt.Errorf("field port in DependencyEndpoint: required")
+	}
+	type Plain DependencyEndpoint
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = DependencyEndpoint(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *AppConfig) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if v, ok := raw["logging"]; !ok || v == nil {
+		return fmt.Errorf("field logging in AppConfig: required")
+	}
+	if v, ok := raw["metricsPath"]; !ok || v == nil {
+		return fmt.Errorf("field metricsPath in AppConfig: required")
+	}
+	if v, ok := raw["metricsPort"]; !ok || v == nil {
+		return fmt.Errorf("field metricsPort in AppConfig: required")
+	}
+	type Plain AppConfig
+	var plain Plain
+	if err := json.Unmarshal(b, &plain); err != nil {
+		return err
+	}
+	*j = AppConfig(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
 func (j *DatabaseConfig) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(b, &raw); err != nil {
@@ -753,25 +812,19 @@ func (j *DatabaseConfig) UnmarshalJSON(b []byte) error {
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *AppConfig) UnmarshalJSON(b []byte) error {
+func (j *DependencyEndpointV2) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}
-	if v, ok := raw["logging"]; !ok || v == nil {
-		return fmt.Errorf("field logging in AppConfig: required")
+	if v, ok := raw["uri"]; !ok || v == nil {
+		return fmt.Errorf("field uri in DependencyEndpointV2: required")
 	}
-	if v, ok := raw["metricsPath"]; !ok || v == nil {
-		return fmt.Errorf("field metricsPath in AppConfig: required")
-	}
-	if v, ok := raw["metricsPort"]; !ok || v == nil {
-		return fmt.Errorf("field metricsPort in AppConfig: required")
-	}
-	type Plain AppConfig
+	type Plain DependencyEndpointV2
 	var plain Plain
 	if err := json.Unmarshal(b, &plain); err != nil {
 		return err
 	}
-	*j = AppConfig(plain)
+	*j = DependencyEndpointV2(plain)
 	return nil
 }

--- a/controllers/cloud.redhat.com/providers/dependencies/impl.go
+++ b/controllers/cloud.redhat.com/providers/dependencies/impl.go
@@ -2,6 +2,8 @@ package dependencies
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 
 	"github.com/RedHatInsights/rhc-osdk-utils/utils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -311,7 +313,11 @@ func processAppAndAppRefEndpoints(
 
 // constructEndpointURI builds a complete URI from protocol, hostname, and port
 func constructEndpointURI(protocol string, hostname string, port int) string {
-	return fmt.Sprintf("%s://%s:%d", protocol, hostname, port)
+	u := &url.URL{
+		Scheme: protocol,
+		Host:   net.JoinHostPort(hostname, fmt.Sprintf("%d", port)),
+	}
+	return u.String()
 }
 
 // buildV2EndpointMap transforms V1 endpoint data into V2 format

--- a/controllers/cloud.redhat.com/providers/dependencies/impl.go
+++ b/controllers/cloud.redhat.com/providers/dependencies/impl.go
@@ -92,6 +92,11 @@ func (dep *dependenciesProvider) makeDependencies(app *crd.ClowdApp) error {
 
 	dep.Config.Endpoints = depConfig
 	dep.Config.PrivateEndpoints = privDepConfig
+
+	// Populate V2 endpoint structures
+	dep.makeV2DependencyEndpoints()
+	dep.makeV2PrivateDependencyEndpoints()
+
 	return nil
 }
 
@@ -302,4 +307,121 @@ func processAppAndAppRefEndpoints(
 	}
 
 	return missingDeps
+}
+
+// constructEndpointURI builds a complete URI from protocol, hostname, and port
+func constructEndpointURI(protocol string, hostname string, port int) string {
+	return fmt.Sprintf("%s://%s:%d", protocol, hostname, port)
+}
+
+// buildV2EndpointMap transforms V1 endpoint data into V2 format
+// Returns map[appName]map[serviceName]DependencyEndpointV2
+func buildV2EndpointMap(endpoints []config.DependencyEndpoint) map[string]map[string]config.DependencyEndpointV2 {
+	if len(endpoints) == 0 {
+		return nil
+	}
+
+	v2Map := make(map[string]map[string]config.DependencyEndpointV2)
+
+	for _, ep := range endpoints {
+		// Initialize app map if it doesn't exist
+		if _, exists := v2Map[ep.App]; !exists {
+			v2Map[ep.App] = make(map[string]config.DependencyEndpointV2)
+		}
+
+		// Add base port endpoint (http)
+		if ep.Port > 0 {
+			v2Map[ep.App][ep.Name] = config.DependencyEndpointV2{
+				Uri: constructEndpointURI("http", ep.Hostname, ep.Port),
+			}
+		}
+
+		// Add TLS port endpoint (https)
+		if ep.TlsPort != nil && *ep.TlsPort > 0 {
+			endpoint := config.DependencyEndpointV2{
+				Uri: constructEndpointURI("https", ep.Hostname, *ep.TlsPort),
+			}
+			if ep.TlsCAPath != nil {
+				endpoint.CaCertificate = ep.TlsCAPath
+			}
+			v2Map[ep.App][ep.Name+"_tls"] = endpoint
+		}
+
+		// Add H2C port endpoint (http)
+		if ep.H2CPort != nil && *ep.H2CPort > 0 {
+			v2Map[ep.App][ep.Name+"_h2c"] = config.DependencyEndpointV2{
+				Uri: constructEndpointURI("http", ep.Hostname, *ep.H2CPort),
+			}
+		}
+
+		// Add H2C TLS port endpoint (https)
+		if ep.H2CTLSPort != nil && *ep.H2CTLSPort > 0 {
+			endpoint := config.DependencyEndpointV2{
+				Uri: constructEndpointURI("https", ep.Hostname, *ep.H2CTLSPort),
+			}
+			if ep.TlsCAPath != nil {
+				endpoint.CaCertificate = ep.TlsCAPath
+			}
+			v2Map[ep.App][ep.Name+"_h2c_tls"] = endpoint
+		}
+	}
+
+	return v2Map
+}
+
+// makeV2DependencyEndpoints populates the V2 public dependency endpoints
+func (dep *dependenciesProvider) makeV2DependencyEndpoints() {
+	if len(dep.Config.Endpoints) == 0 {
+		return
+	}
+
+	v2Map := buildV2EndpointMap(dep.Config.Endpoints)
+
+	if len(v2Map) > 0 {
+		// Convert to map[string]interface{} for the generated type
+		v2Interface := make(config.AppConfigDependencyEndpointsV2)
+		for appName, services := range v2Map {
+			v2Interface[appName] = services
+		}
+
+		dep.Config.DependencyEndpoints = &config.AppConfigDependencyEndpoints{
+			V2: v2Interface,
+		}
+	}
+}
+
+// makeV2PrivateDependencyEndpoints populates the V2 private dependency endpoints
+func (dep *dependenciesProvider) makeV2PrivateDependencyEndpoints() {
+	if len(dep.Config.PrivateEndpoints) == 0 {
+		return
+	}
+
+	// Convert PrivateDependencyEndpoint to DependencyEndpoint format for transformation
+	publicFormat := make([]config.DependencyEndpoint, len(dep.Config.PrivateEndpoints))
+	for i, privEp := range dep.Config.PrivateEndpoints {
+		publicFormat[i] = config.DependencyEndpoint{
+			Name:       privEp.Name,
+			Hostname:   privEp.Hostname,
+			Port:       privEp.Port,
+			App:        privEp.App,
+			TlsPort:    privEp.TlsPort,
+			H2CPort:    privEp.H2CPort,
+			H2CTLSPort: privEp.H2CTLSPort,
+			TlsCAPath:  privEp.TlsCAPath,
+		}
+	}
+
+	v2Map := buildV2EndpointMap(publicFormat)
+
+	if len(v2Map) > 0 {
+		// Convert to map[string]interface{} for the generated type
+		v2Interface := make(config.AppConfigPrivateDependencyEndpointsV2)
+		for appName, services := range v2Map {
+			v2Interface[appName] = services
+		}
+
+		dep.Config.PrivateDependencyEndpoints = &config.AppConfigPrivateDependencyEndpoints{
+			V2: v2Interface,
+		}
+	}
 }

--- a/controllers/cloud.redhat.com/providers/dependencies/impl_v2_test.go
+++ b/controllers/cloud.redhat.com/providers/dependencies/impl_v2_test.go
@@ -1,0 +1,299 @@
+package dependencies
+
+import (
+	"testing"
+
+	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/config"
+	"github.com/RedHatInsights/clowder/controllers/cloud.redhat.com/providers"
+	"github.com/RedHatInsights/rhc-osdk-utils/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConstructEndpointURI(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol string
+		hostname string
+		port     int
+		expected string
+	}{
+		{
+			name:     "HTTP URI",
+			protocol: "http",
+			hostname: "service.namespace.svc",
+			port:     8000,
+			expected: "http://service.namespace.svc:8000",
+		},
+		{
+			name:     "HTTPS URI",
+			protocol: "https",
+			hostname: "service.namespace.svc",
+			port:     8443,
+			expected: "https://service.namespace.svc:8443",
+		},
+		{
+			name:     "HTTP with different port",
+			protocol: "http",
+			hostname: "app-processor.test-ns.svc",
+			port:     3000,
+			expected: "http://app-processor.test-ns.svc:3000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := constructEndpointURI(tt.protocol, tt.hostname, tt.port)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBuildV2EndpointMap(t *testing.T) {
+	t.Run("Empty endpoints returns nil", func(t *testing.T) {
+		endpoints := []config.DependencyEndpoint{}
+		result := buildV2EndpointMap(endpoints)
+		assert.Nil(t, result)
+	})
+
+	t.Run("Single endpoint with base port", func(t *testing.T) {
+		endpoints := []config.DependencyEndpoint{
+			{
+				Name:     "processor",
+				App:      "puptoo",
+				Hostname: "puptoo-processor.test-ns.svc",
+				Port:     8000,
+			},
+		}
+
+		result := buildV2EndpointMap(endpoints)
+
+		assert.NotNil(t, result)
+		assert.Contains(t, result, "puptoo")
+		assert.Contains(t, result["puptoo"], "processor")
+		assert.Equal(t, "http://puptoo-processor.test-ns.svc:8000", result["puptoo"]["processor"].Uri)
+		assert.Nil(t, result["puptoo"]["processor"].CaCertificate)
+	})
+
+	t.Run("Endpoint with TLS port", func(t *testing.T) {
+		tlsPath := "/cdapp/certs/service-ca.crt"
+		endpoints := []config.DependencyEndpoint{
+			{
+				Name:      "processor",
+				App:       "puptoo",
+				Hostname:  "puptoo-processor.test-ns.svc",
+				Port:      8000,
+				TlsPort:   utils.IntPtr(8443),
+				TlsCAPath: &tlsPath,
+			},
+		}
+
+		result := buildV2EndpointMap(endpoints)
+
+		// Base port entry
+		assert.Contains(t, result["puptoo"], "processor")
+		assert.Equal(t, "http://puptoo-processor.test-ns.svc:8000", result["puptoo"]["processor"].Uri)
+
+		// TLS port entry
+		assert.Contains(t, result["puptoo"], "processor_tls")
+		assert.Equal(t, "https://puptoo-processor.test-ns.svc:8443", result["puptoo"]["processor_tls"].Uri)
+		assert.NotNil(t, result["puptoo"]["processor_tls"].CaCertificate)
+		assert.Equal(t, tlsPath, *result["puptoo"]["processor_tls"].CaCertificate)
+	})
+
+	t.Run("Endpoint with H2C ports", func(t *testing.T) {
+		endpoints := []config.DependencyEndpoint{
+			{
+				Name:     "processor",
+				App:      "puptoo",
+				Hostname: "puptoo-processor.test-ns.svc",
+				Port:     8000,
+				H2CPort:  utils.IntPtr(8080),
+			},
+		}
+
+		result := buildV2EndpointMap(endpoints)
+
+		assert.Contains(t, result["puptoo"], "processor")
+		assert.Contains(t, result["puptoo"], "processor_h2c")
+		assert.Equal(t, "http://puptoo-processor.test-ns.svc:8080", result["puptoo"]["processor_h2c"].Uri)
+	})
+
+	t.Run("Endpoint with all port types", func(t *testing.T) {
+		tlsPath := "/cdapp/certs/service-ca.crt"
+		endpoints := []config.DependencyEndpoint{
+			{
+				Name:       "processor",
+				App:        "puptoo",
+				Hostname:   "puptoo-processor.test-ns.svc",
+				Port:       8000,
+				TlsPort:    utils.IntPtr(8443),
+				H2CPort:    utils.IntPtr(8080),
+				H2CTLSPort: utils.IntPtr(8444),
+				TlsCAPath:  &tlsPath,
+			},
+		}
+
+		result := buildV2EndpointMap(endpoints)
+
+		assert.Len(t, result["puptoo"], 4, "Should have 4 entries: base, tls, h2c, h2c_tls")
+		assert.Contains(t, result["puptoo"], "processor")
+		assert.Contains(t, result["puptoo"], "processor_tls")
+		assert.Contains(t, result["puptoo"], "processor_h2c")
+		assert.Contains(t, result["puptoo"], "processor_h2c_tls")
+
+		// Verify H2C TLS has certificate
+		assert.NotNil(t, result["puptoo"]["processor_h2c_tls"].CaCertificate)
+		assert.Equal(t, tlsPath, *result["puptoo"]["processor_h2c_tls"].CaCertificate)
+	})
+
+	t.Run("Multiple apps and services", func(t *testing.T) {
+		endpoints := []config.DependencyEndpoint{
+			{
+				Name:     "processor",
+				App:      "app1",
+				Hostname: "app1-processor.ns.svc",
+				Port:     8000,
+			},
+			{
+				Name:     "api",
+				App:      "app1",
+				Hostname: "app1-api.ns.svc",
+				Port:     8001,
+			},
+			{
+				Name:     "service",
+				App:      "app2",
+				Hostname: "app2-service.ns.svc",
+				Port:     9000,
+			},
+		}
+
+		result := buildV2EndpointMap(endpoints)
+
+		assert.Len(t, result, 2, "Should have 2 apps")
+		assert.Len(t, result["app1"], 2, "app1 should have 2 services")
+		assert.Len(t, result["app2"], 1, "app2 should have 1 service")
+	})
+
+	t.Run("Skip zero ports", func(t *testing.T) {
+		endpoints := []config.DependencyEndpoint{
+			{
+				Name:     "processor",
+				App:      "puptoo",
+				Hostname: "puptoo-processor.test-ns.svc",
+				Port:     0, // Zero port should be skipped
+				TlsPort:  utils.IntPtr(8443),
+			},
+		}
+
+		result := buildV2EndpointMap(endpoints)
+
+		// Should only have TLS entry, not base port
+		assert.NotContains(t, result["puptoo"], "processor", "Should skip zero port")
+		assert.Contains(t, result["puptoo"], "processor_tls")
+	})
+}
+
+func TestMakeV2DependencyEndpoints(t *testing.T) {
+	t.Run("Empty endpoints does nothing", func(t *testing.T) {
+		cfg := &config.AppConfig{
+			Endpoints: []config.DependencyEndpoint{},
+		}
+		dep := &dependenciesProvider{
+			Provider: providers.Provider{
+				Config: cfg,
+			},
+		}
+
+		dep.makeV2DependencyEndpoints()
+
+		assert.Nil(t, cfg.DependencyEndpoints)
+	})
+
+	t.Run("Populates V2 structure from V1 endpoints", func(t *testing.T) {
+		tlsPath := "/cdapp/certs/service-ca.crt"
+		cfg := &config.AppConfig{
+			Endpoints: []config.DependencyEndpoint{
+				{
+					Name:      "processor",
+					App:       "puptoo",
+					Hostname:  "puptoo-processor.test-ns.svc",
+					Port:      8000,
+					TlsPort:   utils.IntPtr(8443),
+					TlsCAPath: &tlsPath,
+				},
+			},
+		}
+		dep := &dependenciesProvider{
+			Provider: providers.Provider{
+				Config: cfg,
+			},
+		}
+
+		dep.makeV2DependencyEndpoints()
+
+		assert.NotNil(t, cfg.DependencyEndpoints)
+		assert.NotNil(t, cfg.DependencyEndpoints.V2)
+
+		// Check structure - V2 is map[string]interface{}
+		assert.Contains(t, cfg.DependencyEndpoints.V2, "puptoo")
+
+		// Get app endpoints
+		appEndpoints, ok := cfg.DependencyEndpoints.V2["puptoo"].(map[string]config.DependencyEndpointV2)
+		assert.True(t, ok, "App endpoints should be map[string]DependencyEndpointV2")
+		assert.Contains(t, appEndpoints, "processor")
+		assert.Equal(t, "http://puptoo-processor.test-ns.svc:8000", appEndpoints["processor"].Uri)
+	})
+}
+
+func TestMakeV2PrivateDependencyEndpoints(t *testing.T) {
+	t.Run("Empty private endpoints does nothing", func(t *testing.T) {
+		cfg := &config.AppConfig{
+			PrivateEndpoints: []config.PrivateDependencyEndpoint{},
+		}
+		dep := &dependenciesProvider{
+			Provider: providers.Provider{
+				Config: cfg,
+			},
+		}
+
+		dep.makeV2PrivateDependencyEndpoints()
+
+		assert.Nil(t, cfg.PrivateDependencyEndpoints)
+	})
+
+	t.Run("Populates V2 private structure from V1 private endpoints", func(t *testing.T) {
+		tlsPath := "/cdapp/certs/service-ca.crt"
+		cfg := &config.AppConfig{
+			PrivateEndpoints: []config.PrivateDependencyEndpoint{
+				{
+					Name:      "processor",
+					App:       "puptoo",
+					Hostname:  "puptoo-processor.test-ns.svc",
+					Port:      10000,
+					TlsPort:   utils.IntPtr(10443),
+					TlsCAPath: &tlsPath,
+				},
+			},
+		}
+		dep := &dependenciesProvider{
+			Provider: providers.Provider{
+				Config: cfg,
+			},
+		}
+
+		dep.makeV2PrivateDependencyEndpoints()
+
+		assert.NotNil(t, cfg.PrivateDependencyEndpoints)
+		assert.NotNil(t, cfg.PrivateDependencyEndpoints.V2)
+
+		// Check structure - V2 is map[string]interface{}
+		assert.Contains(t, cfg.PrivateDependencyEndpoints.V2, "puptoo")
+
+		// Get app endpoints
+		appEndpoints, ok := cfg.PrivateDependencyEndpoints.V2["puptoo"].(map[string]config.DependencyEndpointV2)
+		assert.True(t, ok, "App endpoints should be map[string]DependencyEndpointV2")
+		assert.Contains(t, appEndpoints, "processor")
+		assert.Equal(t, "http://puptoo-processor.test-ns.svc:10000", appEndpoints["processor"].Uri)
+	})
+}

--- a/tests/kuttl/test-dependency-endpoints-v2/00-install.yaml
+++ b/tests/kuttl/test-dependency-endpoints-v2/00-install.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-dependency-endpoints-v2
+spec:
+  finalizers:
+  - kubernetes

--- a/tests/kuttl/test-dependency-endpoints-v2/01-assert.yaml
+++ b/tests/kuttl/test-dependency-endpoints-v2/01-assert.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: command
+  command: bash ../_common/collect-events.sh
+  timeout: 10
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-consumer
+  namespace: test-dependency-endpoints-v2
+  labels:
+    app: app-consumer
+  ownerReferences:
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdApp
+    name: app-consumer
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-provider
+  namespace: test-dependency-endpoints-v2
+  labels:
+    app: app-provider
+  ownerReferences:
+  - apiVersion: cloud.redhat.com/v1alpha1
+    kind: ClowdApp
+    name: app-provider
+type: Opaque
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-provider-service
+  namespace: test-dependency-endpoints-v2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-consumer-processor
+  namespace: test-dependency-endpoints-v2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-provider-service
+  namespace: test-dependency-endpoints-v2
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdEnvironment
+metadata:
+  name: test-dependency-endpoints-v2
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: app-provider
+  namespace: test-dependency-endpoints-v2
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: app-consumer
+  namespace: test-dependency-endpoints-v2

--- a/tests/kuttl/test-dependency-endpoints-v2/01-pods.yaml
+++ b/tests/kuttl/test-dependency-endpoints-v2/01-pods.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdEnvironment
+metadata:
+  name: test-dependency-endpoints-v2
+spec:
+  targetNamespace: test-dependency-endpoints-v2
+  providers:
+    web:
+      port: 8000
+      privatePort: 10000
+      h2cPort: 9800
+      h2cPrivatePort: 10800
+      mode: operator
+      tls:
+        enabled: true
+        port: 8443
+        privatePort: 10443
+        h2cPort: 9443
+        h2cPrivatePort: 10843
+    metrics:
+      port: 9000
+      mode: operator
+      path: "/metrics"
+    kafka:
+      mode: none
+    db:
+      mode: none
+    logging:
+      mode: none
+    objectStore:
+      mode: none
+    inMemoryDb:
+      mode: none
+  resourceDefaults:
+    limits:
+      cpu: 400m
+      memory: 1024Mi
+    requests:
+      cpu: 30m
+      memory: 512Mi
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: app-provider
+  namespace: test-dependency-endpoints-v2
+spec:
+  envName: test-dependency-endpoints-v2
+  deployments:
+  - name: service
+    podSpec:
+      image: quay.io/psav/clowder-hello:ubi8
+    webServices:
+      public:
+        enabled: true
+        h2cEnabled: true
+      private:
+        enabled: true
+        h2cEnabled: true
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: app-consumer
+  namespace: test-dependency-endpoints-v2
+spec:
+  envName: test-dependency-endpoints-v2
+  dependencies:
+    - app-provider
+  deployments:
+  - name: processor
+    podSpec:
+      image: quay.io/psav/clowder-hello:ubi8
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: app-provider-service-cert
+  namespace: test-dependency-endpoints-v2
+spec:
+  dnsNames:
+  - app-provider-service.test-dependency-endpoints-v2.svc
+  - app-provider-service.test-dependency-endpoints-v2.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: app-provider-service-serving-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: test-dependency-endpoints-v2
+spec:
+  selfSigned: {}
+---
+apiVersion: v1
+data:
+  service-ca.crt: test-ca
+kind: ConfigMap
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: openshift-service-ca.crt
+  namespace: test-dependency-endpoints-v2

--- a/tests/kuttl/test-dependency-endpoints-v2/02-json-asserts.sh
+++ b/tests/kuttl/test-dependency-endpoints-v2/02-json-asserts.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+# Source common error handling
+source "$(dirname "$0")/../_common/error-handler.sh"
+
+# Setup error handling
+setup_error_handling "test-dependency-endpoints-v2"
+
+# Create test-specific directory
+TMP_DIR="/tmp/kuttl/test-dependency-endpoints-v2"
+mkdir -p "${TMP_DIR}"
+
+set -x
+
+# Retry finding the secret
+for i in {1..10}; do
+  kubectl get secret --namespace=test-dependency-endpoints-v2 app-consumer && break
+  sleep 1
+done
+
+# Verify it exists, fail if not
+kubectl get secret --namespace=test-dependency-endpoints-v2 app-consumer > /dev/null || { echo "Secret not found after retries"; exit 1; }
+
+# Extract cdappconfig.json
+kubectl get secret --namespace=test-dependency-endpoints-v2 app-consumer -o json > ${TMP_DIR}/app-consumer-secret
+jq -r '.data["cdappconfig.json"]' < ${TMP_DIR}/app-consumer-secret | base64 -d > ${TMP_DIR}/cdappconfig.json
+
+# Debug: Print the full config
+echo "=== Full cdappconfig.json ==="
+cat ${TMP_DIR}/cdappconfig.json | jq .
+
+# ===== V1 Endpoint Validation =====
+echo "=== Testing V1 endpoints[] ==="
+
+# V1 public endpoints should exist
+jq -r '.endpoints | length > 0' -e < ${TMP_DIR}/cdappconfig.json
+
+# V1 public endpoint has correct structure
+jq -r '.endpoints[0].name == "service"' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.endpoints[0].app == "app-provider"' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.endpoints[0].hostname == "app-provider-service.test-dependency-endpoints-v2.svc"' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.endpoints[0].port == 8000' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.endpoints[0].tlsPort == 8443' -e < ${TMP_DIR}/cdappconfig.json
+
+# V1 private endpoints should exist
+jq -r '.privateEndpoints | length > 0' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.privateEndpoints[0].name == "service"' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.privateEndpoints[0].app == "app-provider"' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.privateEndpoints[0].port == 10000' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.privateEndpoints[0].tlsPort == 10443' -e < ${TMP_DIR}/cdappconfig.json
+
+# ===== V2 Public Endpoint Validation =====
+echo "=== Testing V2 dependencyEndpoints.v2 ==="
+
+# V2 dependencyEndpoints object should exist
+jq -r '.dependencyEndpoints.v2 != null' -e < ${TMP_DIR}/cdappconfig.json
+
+# V2 should have app-provider
+jq -r '.dependencyEndpoints.v2["app-provider"] != null' -e < ${TMP_DIR}/cdappconfig.json
+
+# V2 should have service endpoint (base HTTP)
+jq -r '.dependencyEndpoints.v2["app-provider"]["service"] != null' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.dependencyEndpoints.v2["app-provider"]["service"].uri == "http://app-provider-service.test-dependency-endpoints-v2.svc:8000"' -e < ${TMP_DIR}/cdappconfig.json
+
+# Base HTTP endpoint should NOT have ca_certificate
+jq -r '.dependencyEndpoints.v2["app-provider"]["service"].ca_certificate == null' -e < ${TMP_DIR}/cdappconfig.json
+
+# V2 should have service_tls endpoint (HTTPS)
+jq -r '.dependencyEndpoints.v2["app-provider"]["service_tls"] != null' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.dependencyEndpoints.v2["app-provider"]["service_tls"].uri == "https://app-provider-service.test-dependency-endpoints-v2.svc:8443"' -e < ${TMP_DIR}/cdappconfig.json
+
+# HTTPS endpoint SHOULD have ca_certificate
+jq -r '.dependencyEndpoints.v2["app-provider"]["service_tls"].ca_certificate != null' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.dependencyEndpoints.v2["app-provider"]["service_tls"].ca_certificate == "/cdapp/certs/service-ca.crt"' -e < ${TMP_DIR}/cdappconfig.json
+
+# V2 should have service_h2c endpoint
+jq -r '.dependencyEndpoints.v2["app-provider"]["service_h2c"] != null' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.dependencyEndpoints.v2["app-provider"]["service_h2c"].uri == "http://app-provider-service.test-dependency-endpoints-v2.svc:9800"' -e < ${TMP_DIR}/cdappconfig.json
+
+# V2 should have service_h2c_tls endpoint
+jq -r '.dependencyEndpoints.v2["app-provider"]["service_h2c_tls"] != null' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.dependencyEndpoints.v2["app-provider"]["service_h2c_tls"].uri == "https://app-provider-service.test-dependency-endpoints-v2.svc:9443"' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.dependencyEndpoints.v2["app-provider"]["service_h2c_tls"].ca_certificate == "/cdapp/certs/service-ca.crt"' -e < ${TMP_DIR}/cdappconfig.json
+
+# ===== V2 Private Endpoint Validation =====
+echo "=== Testing V2 privateDependencyEndpoints.v2 ==="
+
+# V2 privateDependencyEndpoints object should exist
+jq -r '.privateDependencyEndpoints.v2 != null' -e < ${TMP_DIR}/cdappconfig.json
+
+# V2 private should have app-provider
+jq -r '.privateDependencyEndpoints.v2["app-provider"] != null' -e < ${TMP_DIR}/cdappconfig.json
+
+# V2 private should have service endpoint (base HTTP)
+jq -r '.privateDependencyEndpoints.v2["app-provider"]["service"] != null' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.privateDependencyEndpoints.v2["app-provider"]["service"].uri == "http://app-provider-service.test-dependency-endpoints-v2.svc:10000"' -e < ${TMP_DIR}/cdappconfig.json
+
+# V2 private should have service_tls endpoint (HTTPS)
+jq -r '.privateDependencyEndpoints.v2["app-provider"]["service_tls"] != null' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.privateDependencyEndpoints.v2["app-provider"]["service_tls"].uri == "https://app-provider-service.test-dependency-endpoints-v2.svc:10443"' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.privateDependencyEndpoints.v2["app-provider"]["service_tls"].ca_certificate == "/cdapp/certs/service-ca.crt"' -e < ${TMP_DIR}/cdappconfig.json
+
+# V2 private should have service_h2c endpoint
+jq -r '.privateDependencyEndpoints.v2["app-provider"]["service_h2c"] != null' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.privateDependencyEndpoints.v2["app-provider"]["service_h2c"].uri == "http://app-provider-service.test-dependency-endpoints-v2.svc:10800"' -e < ${TMP_DIR}/cdappconfig.json
+
+# V2 private should have service_h2c_tls endpoint
+jq -r '.privateDependencyEndpoints.v2["app-provider"]["service_h2c_tls"] != null' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.privateDependencyEndpoints.v2["app-provider"]["service_h2c_tls"].uri == "https://app-provider-service.test-dependency-endpoints-v2.svc:10843"' -e < ${TMP_DIR}/cdappconfig.json
+jq -r '.privateDependencyEndpoints.v2["app-provider"]["service_h2c_tls"].ca_certificate == "/cdapp/certs/service-ca.crt"' -e < ${TMP_DIR}/cdappconfig.json
+
+echo "=== All V2 endpoint assertions passed! ==="

--- a/tests/kuttl/test-dependency-endpoints-v2/02-json-asserts.yaml
+++ b/tests/kuttl/test-dependency-endpoints-v2/02-json-asserts.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Capture all output (including set -x traces). On success, suppress output. On failure, display output and exit with error code.
+- script: bash ../_common/run-script.sh 02-json-asserts.sh


### PR DESCRIPTION
## Summary

Add V2 dependency endpoint format to cdappconfig.json with URI-based structure for improved usability. V2 coexists with V1 for backward compatibility.

## Changes

- **Schema**: Add `dependencyEndpoints.v2` and `privateDependencyEndpoints.v2` to app config schema
- **Structure**: Organize endpoints by app name → service name (e.g., `puptoo.processor`)
- **Format**: Use complete URIs (`protocol://hostname:port`) instead of separate hostname/port fields
- **TLS**: Add `ca_certificate` field with cert path for HTTPS endpoints
- **Port Types**: Create separate entries for base, TLS, H2C, and H2C TLS ports with suffixes (`_tls`, `_h2c`, `_h2c_tls`)
- **Backward Compatibility**: V1 `endpoints[]` and `privateEndpoints[]` arrays remain unchanged

### Example Output

```json
{
  "endpoints": [...],  // V1 unchanged
  "dependencyEndpoints": {
    "v2": {
      "puptoo": {
        "processor": {
          "uri": "http://puptoo-processor.namespace.svc:8000"
        },
        "processor_tls": {
          "uri": "https://puptoo-processor.namespace.svc:8443",
          "ca_certificate": "/cdapp/certs/service-ca.crt"
        },
        "processor_h2c": {
          "uri": "http://puptoo-processor.namespace.svc:9800"
        },
        "processor_h2c_tls": {
          "uri": "https://puptoo-processor.namespace.svc:9443",
          "ca_certificate": "/cdapp/certs/service-ca.crt"
        }
      }
    }
  },
  "privateDependencyEndpoints": {
    "v2": {
      "puptoo": {
        "processor": {
          "uri": "http://puptoo-processor.namespace.svc:10000"
        },
        "processor_tls": {
          "uri": "https://puptoo-processor.namespace.svc:10443",
          "ca_certificate": "/cdapp/certs/service-ca.crt"
        }
      }
    }
  }
}
```

## Testing

- ✅ Unit tests: 21 tests covering URI construction, endpoint transformation, TLS handling
- ✅ KUTTL E2E test: Validates V2 structure in cdappconfig.json with TLS and H2C enabled
- ✅ Backward compatibility: Existing V1 tests continue passing
- ✅ All port types tested: base, TLS, H2C, H2C TLS

## Backward Compatibility

Fully backward compatible. V1 `endpoints[]` and `privateEndpoints[]` arrays are unchanged. V2 is additive only - applications can continue using V1 or migrate to V2 at their own pace.
