### PR TITLE
Fix: Add featureflags-edge deployment to serviceaccount provider list

### DIFF
--- a/controllers/cloud.redhat.com/providers/serviceaccount/default.go
+++ b/controllers/cloud.redhat.com/providers/serviceaccount/default.go
@@ -65,6 +65,7 @@ func (sa *serviceaccountProvider) EnvProvide() error {
 	resourceIdentsToUpdate := []rc.ResourceIdent{
 		featureflags.LocalFFDBDeployment,
 		featureflags.LocalFFDeployment,
+		featureflags.LocalFFEdgeDeployment,
 		objectstore.MinioDeployment,
 		database.SharedDBDeployment,
 	}


### PR DESCRIPTION
# Fix: Add featureflags-edge deployment to serviceaccount provider list

## Problem

The `featureflags-edge` deployment was experiencing `ImagePullBackOff` errors when attempting to pull the image `quay.io/app-sre/unleash-edge:v19.6.3` from the private Quay registry.

**Error:**
```
unauthorized: access to the requested resource is not authorized
```

**Root Cause:**

The `featureflags-edge` deployment does not specify a `serviceAccountName` in its pod template spec, causing it to default to the `default` ServiceAccount. The `default` SA only contains pull secrets for the OpenShift internal registry, not for external registries like `quay.io/app-sre`.

## Solution

Add `featureflags.LocalFFEdgeDeployment` to the `resourceIdentsToUpdate` list in the serviceaccount provider's `EnvProvide()` method.

This ensures that the featureflags-edge deployment receives the correct `serviceAccountName` assignment (`{env-name}-env`) which already contains the necessary pull secrets for private Quay registries.