### PR TITLE
fix: add RestartPolicy Always to UI sidecar containers to prevent Job…

### DIFF
--- a/controllers/cloud.redhat.com/providers/iqe/impl.go
+++ b/controllers/cloud.redhat.com/providers/iqe/impl.go
@@ -176,6 +176,7 @@ func createSeleniumContainer(j *batchv1.Job, cji *crd.ClowdJobInvocation, env *c
 	// create pod container
 	pod := crd.PodSpec{Resources: env.Spec.Providers.Testing.Iqe.UI.Selenium.Resources}
 
+	restartPolicyAlways := core.ContainerRestartPolicyAlways
 	c := core.Container{
 		Name:                     fmt.Sprintf("%s-%s", j.Name, "sel"),
 		Image:                    fmt.Sprintf("%s:%s", image, tag),
@@ -183,6 +184,7 @@ func createSeleniumContainer(j *batchv1.Job, cji *crd.ClowdJobInvocation, env *c
 		ImagePullPolicy:          core.PullIfNotPresent,
 		TerminationMessagePath:   "/dev/termination-log",
 		TerminationMessagePolicy: core.TerminationMessageReadFile,
+		RestartPolicy:            &restartPolicyAlways,
 	}
 
 	// attach /dev/shm volume
@@ -235,6 +237,7 @@ func createPlaywrightContainer(j *batchv1.Job, cji *crd.ClowdJobInvocation, env 
 	// create pod container
 	pod := crd.PodSpec{Resources: env.Spec.Providers.Testing.Iqe.UI.Playwright.Resources}
 
+	restartPolicyAlways := core.ContainerRestartPolicyAlways
 	c := core.Container{
 		Name:                     fmt.Sprintf("%s-%s", j.Name, "pw"),
 		Image:                    fmt.Sprintf("%s:%s", image, tag),
@@ -242,6 +245,7 @@ func createPlaywrightContainer(j *batchv1.Job, cji *crd.ClowdJobInvocation, env 
 		ImagePullPolicy:          core.PullIfNotPresent,
 		TerminationMessagePath:   "/dev/termination-log",
 		TerminationMessagePolicy: core.TerminationMessageReadFile,
+		RestartPolicy:            &restartPolicyAlways,
 		Env: []core.EnvVar{
 			{Name: "PW_HEADLESS", Value: "true"},
 		},

--- a/tests/kuttl/test-iqe-jobs-playwright/01-assert.yaml
+++ b/tests/kuttl/test-iqe-jobs-playwright/01-assert.yaml
@@ -97,6 +97,7 @@ spec:
             requests:
               cpu: "1"
               memory: 1Gi
+          restartPolicy: Always
           volumeMounts:
           - mountPath: /dev/shm
             name: shm

--- a/tests/kuttl/test-iqe-jobs-selenium/01-assert.yaml
+++ b/tests/kuttl/test-iqe-jobs-selenium/01-assert.yaml
@@ -104,6 +104,7 @@ spec:
             requests:
               cpu: 200m
               memory: 100Mi
+          restartPolicy: Always
           volumeMounts:
           - mountPath: /dev/shm
             name: shm


### PR DESCRIPTION
… hang

Adds RestartPolicy: Always to both Selenium and Playwright sidecar containers to fix Job completion deadlock issue where UI containers would run forever after IQE tests complete.

**Problem:**
- UI containers (Selenium/Playwright) run long-lived services (VNC + browser)
- After main test container exits, Job waits for all containers to complete
- Sidecar containers never exit on their own → Job hangs forever
- CJI never completes, namespace cleanup never happens

**Solution:**
- Use Kubernetes 1.29+ native sidecar support via RestartPolicy: Always
- Kubernetes automatically terminates sidecar when main container exits
- Job completes immediately after tests finish

**Changes:**
1. controllers/cloud.redhat.com/providers/iqe/impl.go:
   - Add RestartPolicy: Always to createSeleniumContainer()
   - Add RestartPolicy: Always to createPlaywrightContainer()

2. Update test assertions to verify RestartPolicy is set:
   - tests/kuttl/test-iqe-jobs-selenium/01-assert.yaml
   - tests/kuttl/test-iqe-jobs-playwright/01-assert.yaml

**Compatibility:**
- Requires Kubernetes 1.29+ (production cluster is 1.34+)
- Backward compatible - field ignored on older clusters