### PR TITLE
fix: move UI sidecars to initContainers for RestartPolicy support

### DIFF
--- a/controllers/cloud.redhat.com/providers/iqe/impl.go
+++ b/controllers/cloud.redhat.com/providers/iqe/impl.go
@@ -370,19 +370,25 @@ func CreateIqeJobResource(ctx context.Context, cache *rc.ObjectCache, cji *crd.C
 		return err
 	}
 
-	containers := []core.Container{*iqeContainer}
+	// Main IQE container goes in containers array
+	j.Spec.Template.Spec.Containers = []core.Container{*iqeContainer}
+
+	// UI sidecars (Selenium/Playwright) go in initContainers with RestartPolicy: Always
+	// This makes them native Kubernetes sidecars (K8s 1.29+) that run concurrently with
+	// the main container and auto-terminate when the main container exits
+	initContainers := []core.Container{}
 
 	if cji.Spec.Testing.Iqe.UI.Selenium.Deploy {
 		selContainer := createSeleniumContainer(j, cji, env)
-		containers = append(containers, *selContainer)
+		initContainers = append(initContainers, *selContainer)
 	}
 
 	if cji.Spec.Testing.Iqe.UI.Playwright.Deploy {
 		pwContainer := createPlaywrightContainer(j, cji, env)
-		containers = append(containers, *pwContainer)
+		initContainers = append(initContainers, *pwContainer)
 	}
 
-	j.Spec.Template.Spec.Containers = containers
+	j.Spec.Template.Spec.InitContainers = initContainers
 
 	utils.UpdateAnnotations(&j.Spec.Template, provutils.KubeLinterAnnotations)
 	utils.UpdateAnnotations(j, provutils.KubeLinterAnnotations)

--- a/tests/kuttl/test-iqe-jobs-playwright/01-assert.yaml
+++ b/tests/kuttl/test-iqe-jobs-playwright/01-assert.yaml
@@ -46,6 +46,22 @@ spec:
       - emptyDir:
           medium: Memory
         name: shm
+      initContainers:
+        - image: quay.io/redhat-services-prod/insights-management-tenant/playwright-images/playwright-vnc-chromium:latest
+          env:
+            - name: PW_HEADLESS
+              value: "true"
+          resources:
+            limits:
+              cpu: 1500m
+              memory: 3Gi
+            requests:
+              cpu: "1"
+              memory: 1Gi
+          restartPolicy: Always
+          volumeMounts:
+          - mountPath: /dev/shm
+            name: shm
       containers:
         - args:
           - "clowder"
@@ -86,21 +102,6 @@ spec:
             name: cdenvconfig
           - mountPath: /cdapp
             name: config-secret
-        - image: quay.io/redhat-services-prod/insights-management-tenant/playwright-images/playwright-vnc-chromium:latest
-          env:
-            - name: PW_HEADLESS
-              value: "true"
-          resources:
-            limits:
-              cpu: 1500m
-              memory: 3Gi
-            requests:
-              cpu: "1"
-              memory: 1Gi
-          restartPolicy: Always
-          volumeMounts:
-          - mountPath: /dev/shm
-            name: shm
 ---
 apiVersion: v1
 kind: Secret

--- a/tests/kuttl/test-iqe-jobs-selenium/01-assert.yaml
+++ b/tests/kuttl/test-iqe-jobs-selenium/01-assert.yaml
@@ -50,6 +50,21 @@ spec:
           medium: Memory
           sizeLimit: 64Mi
         name: sel-downloads
+      initContainers:
+        - image: quay.io/psav/clowder-hello:latest
+          resources:
+            limits:
+              cpu: 400m
+              memory: 200Mi
+            requests:
+              cpu: 200m
+              memory: 100Mi
+          restartPolicy: Always
+          volumeMounts:
+          - mountPath: /dev/shm
+            name: shm
+          - mountPath: /home/selenium/Downloads
+            name: sel-downloads
       containers:
         - args:
           - "clowder"
@@ -96,20 +111,6 @@ spec:
             name: cdenvconfig
           - mountPath: /cdapp
             name: config-secret
-        - image: quay.io/psav/clowder-hello:latest
-          resources:
-            limits:
-              cpu: 400m
-              memory: 200Mi
-            requests:
-              cpu: 200m
-              memory: 100Mi
-          restartPolicy: Always
-          volumeMounts:
-          - mountPath: /dev/shm
-            name: shm
-          - mountPath: /home/selenium/Downloads
-            name: sel-downloads
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Container-level restartPolicy is only supported for init containers in K8s. Native sidecar pattern (K8s 1.29+) requires:
- Init container with restartPolicy: Always
- Starts concurrently with main container (not before)
- Auto-terminates when main container exits

Previous commit set restartPolicy: Always but left containers in spec.containers, where the field is ignored by the API server. This fix moves Selenium and Playwright containers to spec.initContainers where restartPolicy works.

Fixes Job hang issue where UI sidecars prevented Job completion.