### PR TITLE
fix: use Data instead of StringData for config Secret to prevent reconciliation loop

### DIFF
--- a/controllers/cloud.redhat.com/providers/confighash/config.go
+++ b/controllers/cloud.redhat.com/providers/confighash/config.go
@@ -202,8 +202,8 @@ func (ch *confighashProvider) persistConfig(app *crd.ClowdApp) (string, error) {
 	h.Write([]byte(jsonData))
 	hash := fmt.Sprintf("%x", h.Sum(nil))
 
-	secret.StringData = map[string]string{
-		"cdappconfig.json": string(jsonData),
+	secret.Data = map[string][]byte{
+		"cdappconfig.json": jsonData,
 	}
 
 	app.SetObjectMeta(secret)


### PR DESCRIPTION
## Summary

- Fixes infinite reconciliation loop affecting **all ClowdApps** caused by using `secret.StringData` instead of `secret.Data` when writing the config Secret (`cdappconfig.json`)
- `StringData` is write-only in Kubernetes — always `nil` when fetched from the API server — so the resource cache's `DeepEqual` check never matches, causing the Secret to be updated on every reconciliation even when content is unchanged
- Each unnecessary Secret update triggers the `alwaysFilter` watch, re-enqueuing the owning ClowdApp in a tight loop (~3-10 reconciliations/second per app)

## Root Cause

In `controllers/cloud.redhat.com/providers/confighash/config.go:205-207`:

```go
// Before: StringData is always nil on fetched Secrets, so DeepEqual always fails
secret.StringData = map[string]string{
    "cdappconfig.json": string(jsonData),
}

// After: Data matches what was fetched from k8s when content is unchanged
secret.Data = map[string][]byte{
    "cdappconfig.json": jsonData,
}
```

## Evidence

- Config Secret was **never skipped** across 1000+ log lines (0 skips out of 24 reconciliations)
- Config content is **stable** between reconciliations (two snapshots 2s apart showed zero diff)
- `configHash` annotation on Deployments is **stable** — the actual config isn't changing
- Multiple apps confirmed in tight loops: `image-builder`, `patchman`

## Test plan

- [ ] `go vet ./...` passes
- [ ] `make test` passes
- [ ] Deploy to minikube and verify config Secret updates are skipped when content hasn't changed (look for `APPLY resource (skipped)` with `provider:confighash` in controller logs)
- [ ] Verify existing ClowdApp reconciliation still works correctly after deploying

Resolves: [ENGPROD-10082](https://redhat.atlassian.net/browse/ENGPROD-10082)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENGPROD-10082]: https://redhat.atlassian.net/browse/ENGPROD-10082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ