### PR TITLE
fix: update UBI base image from 9.7 to 9.8 to mitigate RPM vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN CGO_ENABLED=1 GOOS=linux GO111MODULE=on go build -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778562320
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1781496742
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/manifest.yaml .

--- a/build/Dockerfile-local
+++ b/build/Dockerfile-local
@@ -1,6 +1,6 @@
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1778562320
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1781496742
 WORKDIR /
 COPY bin/manager-cgo ./manager
 COPY jsons/ ./jsons/


### PR DESCRIPTION
Addresses ENGPROD-10067 — updates ubi-minimal from 9.7-1778562320 to 9.8-1781496742 in both Dockerfile and build/Dockerfile-local. 

This pulls in el9_8 RPM fixes for gnutls, glibc, openssl, krb5-libs, libarchive, libcap, libnghttp2, p11-kit, systemd-libs, and glib2. Go module vulnerabilities (caddy, go-jose, pgx, stdlib) are already fixed on master.