### PR TITLE
Engprod 10109 optimize clowder resource configs

### DIFF
--- a/controllers/cloud.redhat.com/providers/featureflags/localfeatureflags.go
+++ b/controllers/cloud.redhat.com/providers/featureflags/localfeatureflags.go
@@ -155,12 +155,12 @@ func (ff *localFeatureFlagsProvider) EnvProvide() error {
 
 	res := core.ResourceRequirements{
 		Limits: core.ResourceList{
-			"memory": resource.MustParse("200Mi"),
-			"cpu":    resource.MustParse("100m"),
+			"memory": resource.MustParse("137Mi"),
+			"cpu":    resource.MustParse("42m"),
 		},
 		Requests: core.ResourceList{
-			"memory": resource.MustParse("100Mi"),
-			"cpu":    resource.MustParse("50m"),
+			"memory": resource.MustParse("59Mi"),
+			"cpu":    resource.MustParse("16m"),
 		},
 	}
 
@@ -483,12 +483,12 @@ func makeLocalFeatureFlagsEdge(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMa
 		ImagePullPolicy: core.PullIfNotPresent,
 		Resources: core.ResourceRequirements{
 			Requests: core.ResourceList{
-				"memory": resource.MustParse("200Mi"),
-				"cpu":    resource.MustParse("100m"),
+				"memory": resource.MustParse("24Mi"),
+				"cpu":    resource.MustParse("7m"),
 			},
 			Limits: core.ResourceList{
-				"memory": resource.MustParse("400Mi"),
-				"cpu":    resource.MustParse("200m"),
+				"memory": resource.MustParse("72Mi"),
+				"cpu":    resource.MustParse("16m"),
 			},
 		},
 	}

--- a/controllers/cloud.redhat.com/providers/web/resources_keycloak.go
+++ b/controllers/cloud.redhat.com/providers/web/resources_keycloak.go
@@ -105,12 +105,12 @@ func configureKeycloakDB(web *localWebProvider) error {
 
 	res := core.ResourceRequirements{
 		Limits: core.ResourceList{
-			"memory": resource.MustParse("128Mi"),
-			"cpu":    resource.MustParse("65m"),
+			"memory": resource.MustParse("136Mi"),
+			"cpu":    resource.MustParse("57m"),
 		},
 		Requests: core.ResourceList{
-			"memory": resource.MustParse("128Mi"),
-			"cpu":    resource.MustParse("33m"),
+			"memory": resource.MustParse("58Mi"),
+			"cpu":    resource.MustParse("23m"),
 		},
 	}
 

--- a/controllers/cloud.redhat.com/providers/web/resources_keycloak.go
+++ b/controllers/cloud.redhat.com/providers/web/resources_keycloak.go
@@ -105,12 +105,12 @@ func configureKeycloakDB(web *localWebProvider) error {
 
 	res := core.ResourceRequirements{
 		Limits: core.ResourceList{
-			"memory": resource.MustParse("200Mi"),
-			"cpu":    resource.MustParse("100m"),
+			"memory": resource.MustParse("128Mi"),
+			"cpu":    resource.MustParse("65m"),
 		},
 		Requests: core.ResourceList{
-			"memory": resource.MustParse("100Mi"),
-			"cpu":    resource.MustParse("50m"),
+			"memory": resource.MustParse("128Mi"),
+			"cpu":    resource.MustParse("33m"),
 		},
 	}
 

--- a/controllers/cloud.redhat.com/providers/web/resources_mbop.go
+++ b/controllers/cloud.redhat.com/providers/web/resources_mbop.go
@@ -257,12 +257,12 @@ func makeBOP(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMap providers.Object
 		ReadinessProbe: &readinessProbe,
 		Resources: core.ResourceRequirements{
 			Limits: core.ResourceList{
-				"memory": resource.MustParse("200Mi"),
-				"cpu":    resource.MustParse("100m"),
+				"memory": resource.MustParse("55Mi"),
+				"cpu":    resource.MustParse("3m"),
 			},
 			Requests: core.ResourceList{
-				"memory": resource.MustParse("100Mi"),
-				"cpu":    resource.MustParse("50m"),
+				"memory": resource.MustParse("20Mi"),
+				"cpu":    resource.MustParse("1m"),
 			},
 		},
 		TerminationMessagePath:   "/dev/termination-log",

--- a/controllers/cloud.redhat.com/providers/web/resources_mocktitlements.go
+++ b/controllers/cloud.redhat.com/providers/web/resources_mocktitlements.go
@@ -244,12 +244,12 @@ func makeMocktitlements(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMap provi
 		ReadinessProbe: &readinessProbe,
 		Resources: core.ResourceRequirements{
 			Limits: core.ResourceList{
-				"memory": resource.MustParse("200Mi"),
-				"cpu":    resource.MustParse("100m"),
+				"memory": resource.MustParse("23Mi"),
+				"cpu":    resource.MustParse("1m"),
 			},
 			Requests: core.ResourceList{
-				"memory": resource.MustParse("100Mi"),
-				"cpu":    resource.MustParse("50m"),
+				"memory": resource.MustParse("12Mi"),
+				"cpu":    resource.MustParse("1m"),
 			},
 		},
 		TerminationMessagePath:   "/dev/termination-log",


### PR DESCRIPTION
<p>Right-size hard-coded CPU/memory requests and limits for ephemeral-only containers deployed by Clowder. These containers only run when <code>web.mode: local</code>, <code>featureFlags.mode: local</code>, or <code>reverseProxy.mode: ephemeral</code> — so changes do not affect production or staging.</p>
<p>Resource values were determined using <code>recommend_resources_v6.py</code>, which queries the same Prometheus metrics behind the <a href="https://grafana.app-sre.devshift.net/d/jRY7KLnVz/" class="external-link" target="_blank" rel="noopener nofollow" aria-label="https://grafana.app-sre.devshift.net/d/jRY7KLnVz/" data-tooltip-position="top">Grafana Container Resource Rightsizing dashboard</a>. Data covers a <strong>30-day window across 355 ephemeral namespaces</strong>, with the ADR-046 formula applied:</p>
<ul>
<li><strong>CPU request</strong> = P95 usage * 1.2 / 2</li>
<li><strong>CPU limit</strong> = max usage * 1.2</li>
<li><strong>Memory request</strong> = P95 usage * 1.2</li>
<li><strong>Memory limit</strong> = max usage * 1.2</li>
</ul>
<h2 data-heading="Changes Applied">Changes Applied</h2>

Container | CPU Req | CPU Limit | Mem Req | Mem Limit
-- | -- | -- | -- | --
keycloak-db | 50m → 23m | 100m → 57m | 100Mi → 58Mi | 200Mi → 136Mi
mbop | 50m → 1m | 100m → 3m | 100Mi → 20Mi | 200Mi → 55Mi
mocktitlements | 50m → 1m | 100m → 1m | 100Mi → 12Mi | 200Mi → 23Mi
featureflags-db | 50m → 16m | 100m → 42m | 100Mi → 59Mi | 200Mi → 137Mi
featureflags-edge | 100m → 7m | 200m → 16m | 200Mi → 24Mi | 400Mi → 72Mi


<h2 data-heading="Not included (pending discussion)">Not included (pending discussion)</h2>
<p><strong>MinIO</strong> currently has zero resource constraints and is not ephemeral-only (<code>objectStore.mode: minio</code> can be set in any environment). Adding limits requires team discussion.</p>

<p>🤖 Co-written with <a href="https://claude.ai/code" class="external-link" target="_blank" rel="noopener nofollow" aria-label="https://claude.ai/code" data-tooltip-position="top">Claude Code</a>