### PR TITLE
Fix ignored k8s.io packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,10 @@
   "ignoreDeps": [
     "github.com/kedacore/keda/v2",
     "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring",
-    "k8s.io/*",
+    "k8s.io/api",
+    "k8s.io/apiextensions-apiserver",
+    "k8s.io/apimachinery",
+    "k8s.io/client-go",
     "sigs.k8s.io/controller-runtime",
     "sigs.k8s.io/controller-tools",
     "sigs.k8s.io/kustomize/kustomize/v5",


### PR DESCRIPTION
The 'ignoreDeps' renovate config doesn't support regex, remove it and add all the k8s.io packages we have to exclude them.