### PR TITLE
fix(cji): skip job invocation when ClowdJobInvocation spec.disabled is true

### DIFF
--- a/controllers/cloud.redhat.com/clowdjobinvocation_controller.go
+++ b/controllers/cloud.redhat.com/clowdjobinvocation_controller.go
@@ -123,11 +123,24 @@ func (r *ClowdJobInvocationReconciler) Reconcile(ctx context.Context, req ctrl.R
 		}
 		return ctrl.Result{}, nil
 	}
-	// This is a fresh CJI and needs to be invoked the first time unless it's disabled
-	if !cji.Spec.Disabled {
-		r.Log.Info("Reconciliation started", "ClowdJobInvocation", fmt.Sprintf("%s:%s", cji.Namespace, cji.Name))
-		ctx = context.WithValue(ctx, errors.ClowdKey("obj"), &cji)
+
+	if cji.Spec.Disabled {
+		r.Log.Info("ClowdJobInvocation is disabled, skipping job invocation",
+			"ClowdJobInvocation", fmt.Sprintf("%s:%s", cji.Namespace, cji.Name))
+		if cji.Status.JobMap == nil {
+			cji.Status.JobMap = map[string]crd.JobConditionState{}
+		}
+		r.Recorder.Eventf(&cji, "Normal", "ClowdJobInvocationDisabled",
+			"ClowdJobInvocation [%s] is disabled; no jobs will run", cji.Name)
+		if condErr := SetClowdJobInvocationConditions(ctx, r.Client, &cji, crd.ReconciliationSuccessful, nil); condErr != nil {
+			return ctrl.Result{}, condErr
+		}
+		return ctrl.Result{}, nil
 	}
+
+	// This is a fresh CJI and needs to be invoked the first time
+	r.Log.Info("Reconciliation started", "ClowdJobInvocation", fmt.Sprintf("%s:%s", cji.Namespace, cji.Name))
+	ctx = context.WithValue(ctx, errors.ClowdKey("obj"), &cji)
 
 	// Get the ClowdApp directly from the API server, bypassing the informer
 	// cache. When a ClowdApp update and CJI creation are applied together,
@@ -423,6 +436,9 @@ func UpdateInvokedJobStatus(jobs *batchv1.JobList, cji *crd.ClowdJobInvocation) 
 
 // GetJobsStatus returns true if all jobs in the ClowdJobInvocation have completed successfully
 func GetJobsStatus(jobs *batchv1.JobList, cji *crd.ClowdJobInvocation) bool {
+	if cji.Spec.Disabled {
+		return true
+	}
 
 	jobsRequired := len(cji.Spec.Jobs)
 	var emptyTesting crd.IqeJobSpec

--- a/controllers/cloud.redhat.com/clowdjobinvocation_controller_test.go
+++ b/controllers/cloud.redhat.com/clowdjobinvocation_controller_test.go
@@ -593,3 +593,65 @@ func TestCJINoAnnotationSkipsImageCheck(t *testing.T) {
 		assert.NotContains(t, err.Error(), "do not contain expected tag")
 	}
 }
+
+func TestCJIDisabledSkipsInvocation(t *testing.T) {
+	ns := "test-cji-disabled"
+
+	cji := &crd.ClowdJobInvocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "runner-cji-disabled",
+			Namespace: ns,
+		},
+		Spec: crd.ClowdJobInvocationSpec{
+			AppName:  "puptoo",
+			Disabled: true,
+			Jobs:     []string{"hello-cji"},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(Scheme).
+		WithObjects(cji).
+		WithStatusSubresource(&crd.ClowdJobInvocation{}).
+		Build()
+
+	reconciler := &ClowdJobInvocationReconciler{
+		Client:    client,
+		APIReader: client,
+		Log:       ctrl.Log.WithName("test"),
+		Scheme:    Scheme,
+		Recorder:  record.NewFakeRecorder(10),
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "runner-cji-disabled",
+			Namespace: ns,
+		},
+	})
+	assert.NoError(t, err)
+
+	updated := &crd.ClowdJobInvocation{}
+	assert.NoError(t, client.Get(context.Background(), types.NamespacedName{
+		Name:      "runner-cji-disabled",
+		Namespace: ns,
+	}, updated))
+
+	assert.True(t, updated.Status.Completed)
+	assert.Empty(t, updated.Status.JobMap)
+	assert.True(t, GetJobsStatus(&batchv1.JobList{}, updated))
+
+	jobList := &batchv1.JobList{}
+	assert.NoError(t, client.List(context.Background(), jobList))
+	assert.Empty(t, jobList.Items)
+}
+
+func TestGetJobsStatusWhenDisabled(t *testing.T) {
+	cji := &crd.ClowdJobInvocation{
+		Spec: crd.ClowdJobInvocationSpec{
+			Disabled: true,
+			Jobs:     []string{"hello-cji"},
+		},
+	}
+	assert.True(t, GetJobsStatus(&batchv1.JobList{}, cji))
+}

--- a/tests/kuttl/test-cji-disabled/01-assert.yaml
+++ b/tests/kuttl/test-cji-disabled/01-assert.yaml
@@ -28,6 +28,9 @@ spec:
   disabled: true
   jobs:
   - hello-cji
+status:
+  completed: true
+  jobMap: {}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Completes the ClowdJobInvocation spec.disabled path added in #1014. Today, spec.disabled only skips the reconciliation start log; the controller still walks the ClowdApp and tries to invoke jobs, so a disabled CJI never reaches a completed, ready state. Deploy wait logic in tools such as bonfire treats ClowdJobInvocations as ready only when JobInvocationComplete and ReconciliationSuccessful are true, so a disabled CJI that never finishes leaves
bonfire deploy waiting indefinitely even though no work should run.

This change returns early when spec.disabled is true: no batch Jobs are created, status.completed is set, and the success conditions are published. 

Unit tests and the test-cji-disabled kuttl assert are updated to match.