### PR TITLE
chore(deps): Update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN CGO_ENABLED=1 GOOS=linux GO111MODULE=on go build -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1781496742
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782797275 
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/manifest.yaml .

--- a/build/Dockerfile-local
+++ b/build/Dockerfile-local
@@ -1,6 +1,6 @@
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1781496742
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782797275
 WORKDIR /
 COPY bin/manager-cgo ./manager
 COPY jsons/ ./jsons/


### PR DESCRIPTION
Updated base image has released with additional package updates. This moves the base image to that newer Universal Base Image.

Signedoff-by: Chris Mitchell <cmitchel@redhat.com>