### PR TITLE
RHCLOUD-48946: adds clowdappref related roles following existing patterns

### DIFF
--- a/config/rbac/clowdappref_editor_role.yaml
+++ b/config/rbac/clowdappref_editor_role.yaml
@@ -1,0 +1,27 @@
+# permissions for end users to edit clowdapprefs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    managed.openshift.io/aggregate-to-dedicated-admins: "cluster"
+  name: clowdappref-editor-role
+rules:
+- apiGroups:
+  - cloud.redhat.com
+  resources:
+  - clowdapprefs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cloud.redhat.com
+  resources:
+  - clowdapprefs/status
+  verbs:
+  - get

--- a/config/rbac/clowdappref_viewer_role.yaml
+++ b/config/rbac/clowdappref_viewer_role.yaml
@@ -1,0 +1,22 @@
+# permissions for end users to view clowdapprefs.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clowdappref-viewer-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+- apiGroups:
+  - cloud.redhat.com
+  resources:
+  - clowdapprefs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cloud.redhat.com
+  resources:
+  - clowdapprefs/status
+  verbs:
+  - get

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -19,9 +19,11 @@ resources:
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
 - clowdapp_editor_role.yaml
+- clowdappref_editor_role.yaml
 - clowdenvironment_editor_role.yaml
 - clowdjobinvocation_editor_role.yaml
 - clowdapp_viewer_role.yaml
+- clowdappref_viewer_role.yaml
 - clowdenvironment_viewer_role.yaml
 - clowdjobinvocation_viewer_role.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
* Adds roles to grant access to ClowdAppRefs similar to other CRD realated roles
* Follows existing pattern including use of Kustomize for prefix and aggregration annotations
