### PR TITLE
feat: auto-create frontend-pushcache bucket when reverse proxy

### DIFF
--- a/controllers/cloud.redhat.com/providers/objectstore/minio.go
+++ b/controllers/cloud.redhat.com/providers/objectstore/minio.go
@@ -92,7 +92,39 @@ func NewMinIO(p *providers.Provider) (providers.ClowderProvider, error) {
 		return nil, raisedErr
 	}
 
+	if err := mp.createReverseProxyBucket(); err != nil {
+		return nil, err
+	}
+
 	return mp, nil
+}
+
+func (m *minioProvider) createReverseProxyBucket() error {
+	if m.Env.Spec.Providers.ReverseProxy.Mode != "ephemeral" {
+		return nil
+	}
+
+	bucketName := m.Env.Spec.Providers.ReverseProxy.BucketPathPrefix
+	if bucketName == "" {
+		bucketName = "frontend-pushcache"
+	}
+
+	found, err := m.BucketHandler.Exists(m.Ctx, bucketName)
+	if err != nil {
+		raisedErr := errors.Wrap("Couldn't check reverse proxy bucket", err)
+		raisedErr.Requeue = true
+		return raisedErr
+	}
+
+	if !found {
+		if err := m.BucketHandler.Make(m.Ctx, bucketName); err != nil {
+			raisedErr := errors.Wrap("Couldn't create reverse proxy bucket", err)
+			raisedErr.Requeue = true
+			return raisedErr
+		}
+	}
+
+	return nil
 }
 
 func (m *minioProvider) EnvProvide() error {

--- a/controllers/cloud.redhat.com/providers/objectstore/minio_test.go
+++ b/controllers/cloud.redhat.com/providers/objectstore/minio_test.go
@@ -97,6 +97,29 @@ func getTestProvider(t *testing.T) providers.Provider {
 	}
 }
 
+func getTestProviderWithReverseProxy(t *testing.T, mode crd.ReverseProxyMode, bucketPathPrefix string) providers.Provider {
+	t.Helper()
+	return providers.Provider{
+		Ctx: context.TODO(),
+		Env: &crd.ClowdEnvironment{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "test",
+			},
+			Spec: crd.ClowdEnvironmentSpec{
+				Providers: crd.ProvidersConfig{
+					ReverseProxy: crd.ReverseProxyConfig{
+						Mode:             mode,
+						BucketPathPrefix: bucketPathPrefix,
+					},
+				},
+			},
+		},
+		Client:    &FakeClient{},
+		Config:    &config.AppConfig{},
+		HashCache: &hashcache.HashCache{},
+	}
+}
+
 func getTestMinioProvider(t *testing.T) *minioProvider {
 	t.Helper()
 	testMinioProvider := &minioProvider{
@@ -434,5 +457,71 @@ func TestMinio(t *testing.T) {
 		assert.Len(mp.Config.ObjectStore.Buckets, 1)
 		wantBucketConfig := config.ObjectStoreBucket{Name: b1, RequestedName: b1, Endpoint: &mp.Config.ObjectStore.Hostname}
 		assert.Contains(mp.Config.ObjectStore.Buckets, wantBucketConfig)
+	})
+}
+
+func TestReverseProxyBucket(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("reverseProxyEphemeralCreatesBucket", func(t *testing.T) {
+		handler := &mockBucketHandler{
+			MockBuckets: []mockBucket{{Name: "frontend-pushcache", Exists: false}},
+		}
+		p := getTestProviderWithReverseProxy(t, "ephemeral", "")
+		mp := &minioProvider{
+			Provider:      p,
+			BucketHandler: handler,
+		}
+
+		err := mp.createReverseProxyBucket()
+		assert.NoError(err)
+		assert.Contains(handler.ExistsCalls, "frontend-pushcache")
+		assert.Contains(handler.MakeCalls, "frontend-pushcache")
+	})
+
+	t.Run("reverseProxyEphemeralCustomPrefix", func(t *testing.T) {
+		handler := &mockBucketHandler{
+			MockBuckets: []mockBucket{{Name: "custom-bucket", Exists: false}},
+		}
+		p := getTestProviderWithReverseProxy(t, "ephemeral", "custom-bucket")
+		mp := &minioProvider{
+			Provider:      p,
+			BucketHandler: handler,
+		}
+
+		err := mp.createReverseProxyBucket()
+		assert.NoError(err)
+		assert.Contains(handler.ExistsCalls, "custom-bucket")
+		assert.Contains(handler.MakeCalls, "custom-bucket")
+	})
+
+	t.Run("reverseProxyEphemeralBucketAlreadyExists", func(t *testing.T) {
+		handler := &mockBucketHandler{
+			MockBuckets: []mockBucket{{Name: "frontend-pushcache", Exists: true}},
+		}
+		p := getTestProviderWithReverseProxy(t, "ephemeral", "")
+		mp := &minioProvider{
+			Provider:      p,
+			BucketHandler: handler,
+		}
+
+		err := mp.createReverseProxyBucket()
+		assert.NoError(err)
+		assert.Contains(handler.ExistsCalls, "frontend-pushcache")
+		assert.Len(handler.MakeCalls, 0)
+	})
+
+	t.Run("reverseProxyNonEphemeralSkipsBucket", func(t *testing.T) {
+		handler := &mockBucketHandler{}
+		p := getTestProviderWithReverseProxy(t, "none", "")
+		mp := &minioProvider{
+			Provider:      p,
+			BucketHandler: handler,
+		}
+
+		err := mp.createReverseProxyBucket()
+		assert.NoError(err)
+		assert.Len(handler.ExistsCalls, 0)
+		assert.Len(handler.MakeCalls, 0)
 	})
 }


### PR DESCRIPTION
## Summary

  When the reverse proxy provider is in `ephemeral` mode, it expects a MinIO bucket (default: frontend-pushcache) to exist for serving frontend assets. However, nothing was creating this bucket — it's not owned by any ClowdApp's objectStore list, and the reverse proxy provider itself only reads from it.

  This caused frontend asset population via `valpop` to fail with `The specified bucket does not exist,` requiring manual bucket creation (mc mb) in every ephemeral namespace.

##  What changed

  - Added `createReverseProxyBucket()` method to **minioProvider** in `minio.go`
  - Called during NewMinIO (environment-level setup), before any ClowdApp reconciliation
  - Checks `if ReverseProxy.Mode == "ephemeral"` — if so, creates the bucket using `BucketPathPrefix` from the ClowdEnvironment spec (defaults to frontend-pushcache)
  - Skips creation if the bucket already exists
  - Added 4 tests: default bucket name, custom prefix, bucket already exists, non-ephemeral mode skipped

##  How it works

  1. Clowder provisions MinIO for a new ephemeral environment
  2. NewMinIO detects reverse proxy mode is ephemeral
  3. Reads `BucketPathPrefix` from `ClowdEnvironment.Spec.Providers.ReverseProxy` (default: frontend-pushcache)
  4. Creates the bucket via the MinIO S3 API if it doesn't exist
  5. The Frontend Operator (FEO) can now use valpop to populate this bucket with frontend assets
  6. The reverse proxy serves assets from the bucket

