### PR TITLE
Engprod 10109 right size ephemeral resources

### DIFF
--- a/controllers/cloud.redhat.com/providers/featureflags/localfeatureflags.go
+++ b/controllers/cloud.redhat.com/providers/featureflags/localfeatureflags.go
@@ -155,12 +155,12 @@ func (ff *localFeatureFlagsProvider) EnvProvide() error {
 
 	res := core.ResourceRequirements{
 		Limits: core.ResourceList{
-			"memory": resource.MustParse("200Mi"),
-			"cpu":    resource.MustParse("100m"),
+			"memory": resource.MustParse("262Mi"),
+			"cpu":    resource.MustParse("77m"),
 		},
 		Requests: core.ResourceList{
-			"memory": resource.MustParse("100Mi"),
-			"cpu":    resource.MustParse("50m"),
+			"memory": resource.MustParse("58Mi"),
+			"cpu":    resource.MustParse("17m"),
 		},
 	}
 
@@ -377,12 +377,12 @@ func makeLocalFeatureFlags(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMap pr
 		ImagePullPolicy:          core.PullIfNotPresent,
 		Resources: core.ResourceRequirements{
 			Limits: core.ResourceList{
-				"memory": resource.MustParse("200Mi"),
-				"cpu":    resource.MustParse("100m"),
+				"memory": resource.MustParse("423Mi"),
+				"cpu":    resource.MustParse("118m"),
 			},
 			Requests: core.ResourceList{
-				"memory": resource.MustParse("100Mi"),
-				"cpu":    resource.MustParse("50m"),
+				"memory": resource.MustParse("240Mi"),
+				"cpu":    resource.MustParse("40m"),
 			},
 		},
 	}
@@ -483,12 +483,12 @@ func makeLocalFeatureFlagsEdge(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMa
 		ImagePullPolicy: core.PullIfNotPresent,
 		Resources: core.ResourceRequirements{
 			Requests: core.ResourceList{
-				"memory": resource.MustParse("200Mi"),
-				"cpu":    resource.MustParse("100m"),
+				"memory": resource.MustParse("24Mi"),
+				"cpu":    resource.MustParse("7m"),
 			},
 			Limits: core.ResourceList{
-				"memory": resource.MustParse("400Mi"),
-				"cpu":    resource.MustParse("200m"),
+				"memory": resource.MustParse("139Mi"),
+				"cpu":    resource.MustParse("20m"),
 			},
 		},
 	}

--- a/controllers/cloud.redhat.com/providers/featureflags/localfeatureflags.go
+++ b/controllers/cloud.redhat.com/providers/featureflags/localfeatureflags.go
@@ -155,12 +155,12 @@ func (ff *localFeatureFlagsProvider) EnvProvide() error {
 
 	res := core.ResourceRequirements{
 		Limits: core.ResourceList{
-			"memory": resource.MustParse("262Mi"),
-			"cpu":    resource.MustParse("77m"),
+			"memory": resource.MustParse("137Mi"),
+			"cpu":    resource.MustParse("39m"),
 		},
 		Requests: core.ResourceList{
-			"memory": resource.MustParse("58Mi"),
-			"cpu":    resource.MustParse("17m"),
+			"memory": resource.MustParse("137Mi"),
+			"cpu":    resource.MustParse("19m"),
 		},
 	}
 
@@ -377,12 +377,12 @@ func makeLocalFeatureFlags(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMap pr
 		ImagePullPolicy:          core.PullIfNotPresent,
 		Resources: core.ResourceRequirements{
 			Limits: core.ResourceList{
-				"memory": resource.MustParse("423Mi"),
-				"cpu":    resource.MustParse("118m"),
+				"memory": resource.MustParse("366Mi"),
+				"cpu":    resource.MustParse("99m"),
 			},
 			Requests: core.ResourceList{
-				"memory": resource.MustParse("240Mi"),
-				"cpu":    resource.MustParse("40m"),
+				"memory": resource.MustParse("366Mi"),
+				"cpu":    resource.MustParse("49m"),
 			},
 		},
 	}
@@ -483,12 +483,12 @@ func makeLocalFeatureFlagsEdge(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMa
 		ImagePullPolicy: core.PullIfNotPresent,
 		Resources: core.ResourceRequirements{
 			Requests: core.ResourceList{
-				"memory": resource.MustParse("24Mi"),
-				"cpu":    resource.MustParse("7m"),
+				"memory": resource.MustParse("72Mi"),
+				"cpu":    resource.MustParse("8m"),
 			},
 			Limits: core.ResourceList{
-				"memory": resource.MustParse("139Mi"),
-				"cpu":    resource.MustParse("20m"),
+				"memory": resource.MustParse("72Mi"),
+				"cpu":    resource.MustParse("17m"),
 			},
 		},
 	}

--- a/controllers/cloud.redhat.com/providers/web/resources_keycloak.go
+++ b/controllers/cloud.redhat.com/providers/web/resources_keycloak.go
@@ -105,12 +105,12 @@ func configureKeycloakDB(web *localWebProvider) error {
 
 	res := core.ResourceRequirements{
 		Limits: core.ResourceList{
-			"memory": resource.MustParse("200Mi"),
-			"cpu":    resource.MustParse("100m"),
+			"memory": resource.MustParse("258Mi"),
+			"cpu":    resource.MustParse("70m"),
 		},
 		Requests: core.ResourceList{
-			"memory": resource.MustParse("100Mi"),
-			"cpu":    resource.MustParse("50m"),
+			"memory": resource.MustParse("57Mi"),
+			"cpu":    resource.MustParse("23m"),
 		},
 	}
 
@@ -355,12 +355,12 @@ func makeKeycloak(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMap providers.O
 		ReadinessProbe: &readinessProbe,
 		Resources: core.ResourceRequirements{
 			Limits: core.ResourceList{
-				"memory": resource.MustParse("750Mi"),
-				"cpu":    resource.MustParse("1"),
+				"memory": resource.MustParse("1434Mi"),
+				"cpu":    resource.MustParse("1201m"),
 			},
 			Requests: core.ResourceList{
-				"memory": resource.MustParse("400Mi"),
-				"cpu":    resource.MustParse("100m"),
+				"memory": resource.MustParse("728Mi"),
+				"cpu":    resource.MustParse("598m"),
 			},
 		},
 		TerminationMessagePath:   "/dev/termination-log",

--- a/controllers/cloud.redhat.com/providers/web/resources_keycloak.go
+++ b/controllers/cloud.redhat.com/providers/web/resources_keycloak.go
@@ -105,12 +105,12 @@ func configureKeycloakDB(web *localWebProvider) error {
 
 	res := core.ResourceRequirements{
 		Limits: core.ResourceList{
-			"memory": resource.MustParse("258Mi"),
-			"cpu":    resource.MustParse("70m"),
+			"memory": resource.MustParse("257Mi"),
+			"cpu":    resource.MustParse("53m"),
 		},
 		Requests: core.ResourceList{
-			"memory": resource.MustParse("57Mi"),
-			"cpu":    resource.MustParse("23m"),
+			"memory": resource.MustParse("257Mi"),
+			"cpu":    resource.MustParse("26m"),
 		},
 	}
 
@@ -355,12 +355,12 @@ func makeKeycloak(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMap providers.O
 		ReadinessProbe: &readinessProbe,
 		Resources: core.ResourceRequirements{
 			Limits: core.ResourceList{
-				"memory": resource.MustParse("1434Mi"),
-				"cpu":    resource.MustParse("1201m"),
+				"memory": resource.MustParse("1089Mi"),
+				"cpu":    resource.MustParse("1200m"),
 			},
 			Requests: core.ResourceList{
-				"memory": resource.MustParse("728Mi"),
-				"cpu":    resource.MustParse("598m"),
+				"memory": resource.MustParse("1089Mi"),
+				"cpu":    resource.MustParse("600m"),
 			},
 		},
 		TerminationMessagePath:   "/dev/termination-log",

--- a/controllers/cloud.redhat.com/providers/web/resources_mbop.go
+++ b/controllers/cloud.redhat.com/providers/web/resources_mbop.go
@@ -257,12 +257,12 @@ func makeBOP(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMap providers.Object
 		ReadinessProbe: &readinessProbe,
 		Resources: core.ResourceRequirements{
 			Limits: core.ResourceList{
-				"memory": resource.MustParse("113Mi"),
-				"cpu":    resource.MustParse("6m"),
+				"memory": resource.MustParse("111Mi"),
+				"cpu":    resource.MustParse("3m"),
 			},
 			Requests: core.ResourceList{
-				"memory": resource.MustParse("18Mi"),
-				"cpu":    resource.MustParse("1m"),
+				"memory": resource.MustParse("111Mi"),
+				"cpu":    resource.MustParse("2m"),
 			},
 		},
 		TerminationMessagePath:   "/dev/termination-log",

--- a/controllers/cloud.redhat.com/providers/web/resources_mbop.go
+++ b/controllers/cloud.redhat.com/providers/web/resources_mbop.go
@@ -257,12 +257,12 @@ func makeBOP(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMap providers.Object
 		ReadinessProbe: &readinessProbe,
 		Resources: core.ResourceRequirements{
 			Limits: core.ResourceList{
-				"memory": resource.MustParse("200Mi"),
-				"cpu":    resource.MustParse("100m"),
+				"memory": resource.MustParse("113Mi"),
+				"cpu":    resource.MustParse("6m"),
 			},
 			Requests: core.ResourceList{
-				"memory": resource.MustParse("100Mi"),
-				"cpu":    resource.MustParse("50m"),
+				"memory": resource.MustParse("18Mi"),
+				"cpu":    resource.MustParse("1m"),
 			},
 		},
 		TerminationMessagePath:   "/dev/termination-log",

--- a/controllers/cloud.redhat.com/providers/web/resources_mocktitlements.go
+++ b/controllers/cloud.redhat.com/providers/web/resources_mocktitlements.go
@@ -244,11 +244,11 @@ func makeMocktitlements(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMap provi
 		ReadinessProbe: &readinessProbe,
 		Resources: core.ResourceRequirements{
 			Limits: core.ResourceList{
-				"memory": resource.MustParse("40Mi"),
-				"cpu":    resource.MustParse("3m"),
+				"memory": resource.MustParse("24Mi"),
+				"cpu":    resource.MustParse("2m"),
 			},
 			Requests: core.ResourceList{
-				"memory": resource.MustParse("10Mi"),
+				"memory": resource.MustParse("24Mi"),
 				"cpu":    resource.MustParse("1m"),
 			},
 		},

--- a/controllers/cloud.redhat.com/providers/web/resources_mocktitlements.go
+++ b/controllers/cloud.redhat.com/providers/web/resources_mocktitlements.go
@@ -244,12 +244,12 @@ func makeMocktitlements(_ *crd.ClowdEnvironment, o obj.ClowdObject, objMap provi
 		ReadinessProbe: &readinessProbe,
 		Resources: core.ResourceRequirements{
 			Limits: core.ResourceList{
-				"memory": resource.MustParse("200Mi"),
-				"cpu":    resource.MustParse("100m"),
+				"memory": resource.MustParse("40Mi"),
+				"cpu":    resource.MustParse("3m"),
 			},
 			Requests: core.ResourceList{
-				"memory": resource.MustParse("100Mi"),
-				"cpu":    resource.MustParse("50m"),
+				"memory": resource.MustParse("10Mi"),
+				"cpu":    resource.MustParse("1m"),
 			},
 		},
 		TerminationMessagePath:   "/dev/termination-log",


### PR DESCRIPTION
## Summary

Right-size CPU and memory requests/limits for all 7 Clowder-managed ephemeral containers based on June 2026 Prometheus usage data.

Values are computed using the **ADR-046 formula** (same as app-interface-recommendations):

| Parameter | Formula |
|-----------|---------|
| CPU limit | Max usage × 1.2 |
| CPU request | CPU limit / 2 |
| Memory limit | Max usage × 1.2 |
| Memory request | Memory limit |

## Over-provisioned (reduced)

5 containers were significantly over-provisioned — some by 90%+ on CPU:

| Container | CPU Req | CPU Lim | Mem Req | Mem Lim |
|-----------|---------|---------|---------|---------|
| **keycloak-db** | 50m → 26m | 100m → 53m | 100Mi → 257Mi | 200Mi → 257Mi |
| **featureflags-db** | 50m → 19m | 100m → 39m | 100Mi → 137Mi | 200Mi → 137Mi |
| **featureflags-edge** | 100m → 8m | 200m → 17m | 200Mi → 72Mi | 400Mi → 72Mi |
| **mbop** | 50m → 2m | 100m → 3m | 100Mi → 111Mi | 200Mi → 111Mi |
| **mocktitlements** | 50m → 1m | 100m → 2m | 100Mi → 24Mi | 200Mi → 24Mi |

> Note: keycloak-db and mbop memory *requests* were raised because the formula sets mem req = mem lim, and observed max usage (214Mi, 92Mi) was close to or above the old 100Mi request.

## Under-provisioned (raised)

2 containers were running at or above their limits:

| Container | CPU Req | CPU Lim | Mem Req | Mem Lim |
|-----------|---------|---------|---------|---------|
| **keycloak** | 100m → 600m | 1000m → 1200m | 400Mi → 1089Mi | 750Mi → 1089Mi |
| **featureflags** | 50m → 49m | 100m → 99m | 100Mi → 366Mi | 200Mi → 366Mi |

Keycloak's max CPU hit 1000m against a 1000m limit, and max memory was 907Mi against a 750Mi limit — already exceeding its limit. Featureflags max memory was 305Mi against a 200Mi limit.

## Net impact per namespace

| Resource | Before (all 7) | After | Delta |
|----------|---------------|-------|-------|
| CPU request | 450m | 706m | +256m |
| CPU limit | 1700m | 1413m | −287m |
| Memory request | 1.1Gi | 2.0Gi | +956Mi |
| Memory limit | 2.1Gi | 2.0Gi | −94Mi |

Overall CPU limits decrease. Memory requests increase because the formula sets req = lim (safer scheduling). Memory limits decrease slightly net. The 2 under-provisioned containers (keycloak, featureflags) account for all the increases — the other 5 are pure savings.

## Data source

- **Window:** June 2026 (full month)
- **Script:** `recommend_clowder.py --month 2026-06`
- **Formula:** ADR-046 (same as app-interface-recommendations)
- **Prometheus:** per-container range queries with `namespace=~"ephemeral-.*"`
- **Dashboard:** [[Grafana — Container Resource Rightsizing](https://grafana.app-sre.devshift.net/d/jRY7KLnVz/container-resource-limit-request-rightsizing?orgId=1&from=now-30d&to=now&timezone=UTC&var-namespace_regex=ephemeral-.%2A&var-datasource=P0226E6921DAF4CC1)](https://grafana.app-sre.devshift.net/d/jRY7KLnVz/container-resource-limit-request-rightsizing?orgId=1&from=now-30d&to=now&timezone=UTC&var-namespace_regex=ephemeral-.%2A&var-datasource=P0226E6921DAF4CC1)

## Files changed

- `controllers/cloud.redhat.com/providers/web/resources_keycloak.go` — keycloak-db, keycloak
- `controllers/cloud.redhat.com/providers/featureflags/localfeatureflags.go` — featureflags-db, featureflags, featureflags-edge
- `controllers/cloud.redhat.com/providers/web/resources_mbop.go` — mbop
- `controllers/cloud.redhat.com/providers/web/resources_mocktitlements.go` — mocktitlements