### PR TITLE
Bumping caddy-ubi base images to address CVE-2026-52845

### DIFF
--- a/controllers/cloud.redhat.com/providers/utils/utils.go
+++ b/controllers/cloud.redhat.com/providers/utils/utils.go
@@ -24,12 +24,12 @@ import (
 	"github.com/RedHatInsights/rhc-osdk-utils/utils"
 )
 
-var defaultImageCaddySideCar = "quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:0768503"
+var defaultImageCaddySideCar = "quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:e3fe6c0"
 var defaultImageCaddyGateway = defaultImageCaddySideCar
 var defaultImageMBOP = "quay.io/redhat-services-prod/hcc-fr-tenant/mbop/mbop:fbf8212"
 var defaultImageMocktitlements = "quay.io/redhat-services-prod/hcm-eng-prod-tenant/mocktitlements-master/mocktitlements-master:27dadf8"
 var defaultKeyCloakVersion = "23.0.1"
-var defaultImageCaddyProxy = "quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:094d8a9"
+var defaultImageCaddyProxy = "quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:ab3a7e3"
 var defaultImageKeyCloak = fmt.Sprintf("quay.io/keycloak/keycloak:%s", defaultKeyCloakVersion)
 var defaultImageDatabasePG12 = "quay.io/cloudservices/postgresql-rds:12-2318dee"
 var defaultImageDatabasePG13 = "quay.io/cloudservices/postgresql-rds:13-2318dee"

--- a/controllers/cloud.redhat.com/providers/utils/utils.go
+++ b/controllers/cloud.redhat.com/providers/utils/utils.go
@@ -24,12 +24,12 @@ import (
 	"github.com/RedHatInsights/rhc-osdk-utils/utils"
 )
 
-var defaultImageCaddySideCar = "quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:e3fe6c0"
+var defaultImageCaddySideCar = "quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:dd207a6"
 var defaultImageCaddyGateway = defaultImageCaddySideCar
 var defaultImageMBOP = "quay.io/redhat-services-prod/hcc-fr-tenant/mbop/mbop:fbf8212"
 var defaultImageMocktitlements = "quay.io/redhat-services-prod/hcm-eng-prod-tenant/mocktitlements-master/mocktitlements-master:27dadf8"
 var defaultKeyCloakVersion = "23.0.1"
-var defaultImageCaddyProxy = "quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:ab3a7e3"
+var defaultImageCaddyProxy = "quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:dd37f62"
 var defaultImageKeyCloak = fmt.Sprintf("quay.io/keycloak/keycloak:%s", defaultKeyCloakVersion)
 var defaultImageDatabasePG12 = "quay.io/cloudservices/postgresql-rds:12-2318dee"
 var defaultImageDatabasePG13 = "quay.io/cloudservices/postgresql-rds:13-2318dee"

--- a/tests/kuttl/test-ephemeral-gateway/01-assert.yaml
+++ b/tests/kuttl/test-ephemeral-gateway/01-assert.yaml
@@ -89,7 +89,7 @@ spec:
       annotations:
         clowder/authsidecar-config: caddy-config-mocktitlements
         clowder/authsidecar-enabled: "true"
-        clowder/authsidecar-image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:0768503
+        clowder/authsidecar-image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:e3fe6c0
         clowder/authsidecar-port: "8090"
     spec:
       containers:

--- a/tests/kuttl/test-ephemeral-gateway/01-assert.yaml
+++ b/tests/kuttl/test-ephemeral-gateway/01-assert.yaml
@@ -89,7 +89,7 @@ spec:
       annotations:
         clowder/authsidecar-config: caddy-config-mocktitlements
         clowder/authsidecar-enabled: "true"
-        clowder/authsidecar-image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:e3fe6c0
+        clowder/authsidecar-image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:dd207a6
         clowder/authsidecar-port: "8090"
     spec:
       containers:

--- a/tests/kuttl/test-ephemeral-gateway/03-assert.yaml
+++ b/tests/kuttl/test-ephemeral-gateway/03-assert.yaml
@@ -25,7 +25,7 @@ spec:
         clowder/authsidecar-config: caddy-config-puptoo-processor
         clowder/authsidecar-enabled: "true"
         clowder/authsidecar-port: "8000"
-        clowder/authsidecar-image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:e3fe6c0
+        clowder/authsidecar-image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:dd207a6
     spec:
       serviceAccountName: puptoo-processor
 status:
@@ -43,7 +43,7 @@ spec:
         clowder/authsidecar-config: caddy-config-puptoo-2paths-processor
         clowder/authsidecar-enabled: "true"
         clowder/authsidecar-port: "8000"
-        clowder/authsidecar-image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:e3fe6c0
+        clowder/authsidecar-image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:dd207a6
     spec:
       serviceAccountName: puptoo-2paths-processor
 status:

--- a/tests/kuttl/test-ephemeral-gateway/03-assert.yaml
+++ b/tests/kuttl/test-ephemeral-gateway/03-assert.yaml
@@ -25,7 +25,7 @@ spec:
         clowder/authsidecar-config: caddy-config-puptoo-processor
         clowder/authsidecar-enabled: "true"
         clowder/authsidecar-port: "8000"
-        clowder/authsidecar-image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:0768503
+        clowder/authsidecar-image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:e3fe6c0
     spec:
       serviceAccountName: puptoo-processor
 status:
@@ -43,7 +43,7 @@ spec:
         clowder/authsidecar-config: caddy-config-puptoo-2paths-processor
         clowder/authsidecar-enabled: "true"
         clowder/authsidecar-port: "8000"
-        clowder/authsidecar-image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:0768503
+        clowder/authsidecar-image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:e3fe6c0
     spec:
       serviceAccountName: puptoo-2paths-processor
 status:

--- a/tests/kuttl/test-h2c-web-services/01-assert.yaml
+++ b/tests/kuttl/test-h2c-web-services/01-assert.yaml
@@ -36,7 +36,7 @@ spec:
           - /etc/caddy/caddy.json
         command:
           - /usr/bin/caddy
-        image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:ab3a7e3
+        image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:dd37f62
         name: caddy-tls
         ports:
           - containerPort: 8800

--- a/tests/kuttl/test-h2c-web-services/01-assert.yaml
+++ b/tests/kuttl/test-h2c-web-services/01-assert.yaml
@@ -36,7 +36,7 @@ spec:
           - /etc/caddy/caddy.json
         command:
           - /usr/bin/caddy
-        image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:094d8a9
+        image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:ab3a7e3
         name: caddy-tls
         ports:
           - containerPort: 8800

--- a/tests/kuttl/test-tls-web-services-app-overrides/01-assert.yaml
+++ b/tests/kuttl/test-tls-web-services-app-overrides/01-assert.yaml
@@ -36,7 +36,7 @@ spec:
           - /etc/caddy/caddy.json
         command:
           - /usr/bin/caddy
-        image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:ab3a7e3
+        image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:dd37f62
         name: caddy-tls
         ports:
           - containerPort: 8800

--- a/tests/kuttl/test-tls-web-services-app-overrides/01-assert.yaml
+++ b/tests/kuttl/test-tls-web-services-app-overrides/01-assert.yaml
@@ -36,7 +36,7 @@ spec:
           - /etc/caddy/caddy.json
         command:
           - /usr/bin/caddy
-        image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:094d8a9
+        image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:ab3a7e3
         name: caddy-tls
         ports:
           - containerPort: 8800

--- a/tests/kuttl/test-tls-web-services/01-assert.yaml
+++ b/tests/kuttl/test-tls-web-services/01-assert.yaml
@@ -48,7 +48,7 @@ spec:
           - /etc/caddy/caddy.json
         command:
           - /usr/bin/caddy
-        image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:094d8a9
+        image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:ab3a7e3
         name: caddy-tls
         ports:
           - containerPort: 8800

--- a/tests/kuttl/test-tls-web-services/01-assert.yaml
+++ b/tests/kuttl/test-tls-web-services/01-assert.yaml
@@ -48,7 +48,7 @@ spec:
           - /etc/caddy/caddy.json
         command:
           - /usr/bin/caddy
-        image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:ab3a7e3
+        image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:dd37f62
         name: caddy-tls
         ports:
           - containerPort: 8800


### PR DESCRIPTION
## Change Details
- Bumps `caddy-ubi` base image to latest ref in `redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi`
- Bumps `crc-caddy-plugin` base image to latest ref in `redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin`
- Updates appropriate image references in kuttl tests