### PR TITLE
fix: update crc-caddy-plugin to version built with Go 1.26

### DIFF
--- a/controllers/cloud.redhat.com/providers/utils/utils.go
+++ b/controllers/cloud.redhat.com/providers/utils/utils.go
@@ -24,7 +24,7 @@ import (
 	"github.com/RedHatInsights/rhc-osdk-utils/utils"
 )
 
-var defaultImageCaddySideCar = "quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:dd207a6"
+var defaultImageCaddySideCar = "quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:ec15821"
 var defaultImageCaddyGateway = defaultImageCaddySideCar
 var defaultImageMBOP = "quay.io/redhat-services-prod/hcc-fr-tenant/mbop/mbop:fbf8212"
 var defaultImageMocktitlements = "quay.io/redhat-services-prod/hcm-eng-prod-tenant/mocktitlements-master/mocktitlements-master:27dadf8"

--- a/tests/kuttl/test-ephemeral-gateway/01-assert.yaml
+++ b/tests/kuttl/test-ephemeral-gateway/01-assert.yaml
@@ -89,7 +89,7 @@ spec:
       annotations:
         clowder/authsidecar-config: caddy-config-mocktitlements
         clowder/authsidecar-enabled: "true"
-        clowder/authsidecar-image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:dd207a6
+        clowder/authsidecar-image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:ec15821
         clowder/authsidecar-port: "8090"
     spec:
       containers:

--- a/tests/kuttl/test-ephemeral-gateway/03-assert.yaml
+++ b/tests/kuttl/test-ephemeral-gateway/03-assert.yaml
@@ -25,7 +25,7 @@ spec:
         clowder/authsidecar-config: caddy-config-puptoo-processor
         clowder/authsidecar-enabled: "true"
         clowder/authsidecar-port: "8000"
-        clowder/authsidecar-image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:dd207a6
+        clowder/authsidecar-image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:ec15821
     spec:
       serviceAccountName: puptoo-processor
 status:
@@ -43,7 +43,7 @@ spec:
         clowder/authsidecar-config: caddy-config-puptoo-2paths-processor
         clowder/authsidecar-enabled: "true"
         clowder/authsidecar-port: "8000"
-        clowder/authsidecar-image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:dd207a6
+        clowder/authsidecar-image: quay.io/redhat-services-prod/hcm-eng-prod-tenant/crc-caddy-plugin:ec15821
     spec:
       serviceAccountName: puptoo-2paths-processor
 status:


### PR DESCRIPTION
## Summary
- The previous crc-caddy-plugin image (`dd207a6`) was built with Go 1.25.9, which panics on `GODEBUG=fips140=auto` set by the updated `caddy-ubi` base image
- This is blocking the entire ephemeral default pool — 0 ready namespaces, all 12 stuck in "creating" due to mbop and mocktitlements pods in CrashLoopBackOff
- The new image (`ec15821`) is built with Go 1.26.5, which handles `fips140=auto` correctly

## Root cause
The `caddy-ubi` base image was updated (commit `c463605` in crc-caddy-plugin) to a version that sets `GODEBUG=fips140=auto`. Go 1.25.9 does not recognize `auto` as a valid value for `fips140` and panics at startup. Go 1.26 (Red Hat build) added support for `fips140=auto` in `crypto/internal/fips140deps/godebug/godebug.go`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)