### PR TITLE
Implementing namespace argument for wait_for_generation.sh test utility

### DIFF
--- a/tests/kuttl/_common/wait_for_generation.sh
+++ b/tests/kuttl/_common/wait_for_generation.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
-# Usage: ./wait_for_generation.sh <deployment_name> <desired_generation> <namespace>
+# Usage: ./wait_for_generation.sh <deployment_name> <desired_generation> [namespace]
 # Example: ./wait_for_generation.sh my-app 6 test-my-feature
 
-if [ $# -lt 3 ]; then
-    echo "Usage: $0 <deployment_name> <desired_generation> <namespace>"
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <deployment_name> <desired_generation> [namespace]"
     echo "Example: $0 my-app 6 test-my-feature"
     exit 1
 fi
 
 DEPLOYMENT_NAME="$1"
 DESIRED_GENERATION="$2"
-NAMESPACE="$3"
+NAMESPACE="${3:-default}"
 MAX_ATTEMPTS=30
 DELAY=2
 

--- a/tests/kuttl/_common/wait_for_generation.sh
+++ b/tests/kuttl/_common/wait_for_generation.sh
@@ -1,18 +1,17 @@
 #!/bin/bash
 
-# Script to wait for a deployment's observedGeneration to reach or exceed the specified value
-# Usage: ./wait_for_generation <deployment_name> <desired_generation>
-# Example: ./wait_for_generation my-app 6
+# Usage: ./wait_for_generation.sh <deployment_name> <desired_generation> <namespace>
+# Example: ./wait_for_generation.sh my-app 6 test-my-feature
 
-if [ $# -ne 2 ]; then
-    echo "Usage: $0 <deployment_name> <desired_generation>"
-    echo "Example: $0 my-app 6"
+if [ $# -lt 3 ]; then
+    echo "Usage: $0 <deployment_name> <desired_generation> <namespace>"
+    echo "Example: $0 my-app 6 test-my-feature"
     exit 1
 fi
 
 DEPLOYMENT_NAME="$1"
 DESIRED_GENERATION="$2"
-NAMESPACE="test-config-secret-restarter"
+NAMESPACE="$3"
 MAX_ATTEMPTS=30
 DELAY=2
 

--- a/tests/kuttl/test-config-secret-restarter/04-json-asserts.sh
+++ b/tests/kuttl/test-config-secret-restarter/04-json-asserts.sh
@@ -13,7 +13,7 @@ mkdir -p "${TMP_DIR}"
 set -x
 
 # Test commands from original yaml file
-sh wait_for_generation.sh puptoo-processor "2"
+sh ../_common/wait_for_generation.sh puptoo-processor "2" test-config-secret-restarter
 kubectl get secret --namespace=test-config-secret-restarter puptoo -o json > ${TMP_DIR}/test-config-secret-restarter
 jq -r '.data["cdappconfig.json"]' < ${TMP_DIR}/test-config-secret-restarter | base64 -d > ${TMP_DIR}/test-config-secret-restarter-json
 jq -r '.hashCache == "8c851988a320473f01d513a34f78e4640ea6fb788b2cb3d0db742b23d46f2c53e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"' -e < ${TMP_DIR}/test-config-secret-restarter-json

--- a/tests/kuttl/test-config-secret-restarter/06-json-asserts.sh
+++ b/tests/kuttl/test-config-secret-restarter/06-json-asserts.sh
@@ -13,7 +13,7 @@ mkdir -p "${TMP_DIR}"
 set -x
 
 # Test commands from original yaml file
-sh wait_for_generation.sh puptoo-processor "3"
+sh ../_common/wait_for_generation.sh puptoo-processor "3" test-config-secret-restarter
 kubectl get secret --namespace=test-config-secret-restarter puptoo -o json > ${TMP_DIR}/test-config-secret-restarter
 jq -r '.data["cdappconfig.json"]' < ${TMP_DIR}/test-config-secret-restarter | base64 -d > ${TMP_DIR}/test-config-secret-restarter-json
 jq -r '.hashCache == "a1c3e654937f58a3b14f8257a51db175fc25e82df820104dea4d9f68d5ba9eabe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"' -e < ${TMP_DIR}/test-config-secret-restarter-json

--- a/tests/kuttl/test-config-secret-restarter/08-json-asserts.sh
+++ b/tests/kuttl/test-config-secret-restarter/08-json-asserts.sh
@@ -13,7 +13,7 @@ mkdir -p "${TMP_DIR}"
 set -x
 
 # Test commands from original yaml file
-sh wait_for_generation.sh puptoo-processor "4"
+sh ../_common/wait_for_generation.sh puptoo-processor "4" test-config-secret-restarter
 kubectl get secret --namespace=test-config-secret-restarter puptoo -o json > ${TMP_DIR}/test-config-secret-restarter
 jq -r '.data["cdappconfig.json"]' < ${TMP_DIR}/test-config-secret-restarter | base64 -d > ${TMP_DIR}/test-config-secret-restarter-json
 jq -r '.hashCache == "50c45165a261d17c43a6125311b11339cec335fa4b39e2691cad8059035d1272e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"' -e < ${TMP_DIR}/test-config-secret-restarter-json

--- a/tests/kuttl/test-config-secret-restarter/11-json-asserts.sh
+++ b/tests/kuttl/test-config-secret-restarter/11-json-asserts.sh
@@ -13,7 +13,7 @@ mkdir -p "${TMP_DIR}"
 set -x
 
 # Test commands from original yaml file
-sh wait_for_generation.sh puptoo-processor "5"
+sh ../_common/wait_for_generation.sh puptoo-processor "5" test-config-secret-restarter
 kubectl get secret --namespace=test-config-secret-restarter puptoo -o json > ${TMP_DIR}/test-config-secret-restarter
 jq -r '.data["cdappconfig.json"]' < ${TMP_DIR}/test-config-secret-restarter | base64 -d > ${TMP_DIR}/test-config-secret-restarter-json
 jq -r '.hashCache == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"' -e < ${TMP_DIR}/test-config-secret-restarter-json

--- a/tests/kuttl/test-config-secret-restarter/13-json-asserts.sh
+++ b/tests/kuttl/test-config-secret-restarter/13-json-asserts.sh
@@ -13,7 +13,7 @@ mkdir -p "${TMP_DIR}"
 set -x
 
 # Test commands from original yaml file
-sh wait_for_generation.sh puptoo-processor "6"
+sh ../_common/wait_for_generation.sh puptoo-processor "6" test-config-secret-restarter
 sleep 3
 kubectl get secret --namespace=test-config-secret-restarter puptoo -o json > ${TMP_DIR}/test-config-secret-restarter
 jq -r '.data["cdappconfig.json"]' < ${TMP_DIR}/test-config-secret-restarter | base64 -d > ${TMP_DIR}/test-config-secret-restarter-json


### PR DESCRIPTION
## Change Details
- Adds a third argument to `wait_for_generation.sh` to specify the name of the namespace to use for a given Kuttl test, defaults to `default` namespace if not specified
- Migrates `wait_for_generation.sh` test utility to the `tests/kuttl/_common` directory