### PR TITLE
Adding Disaster Recovery exercise testing scenarios

### DIFF
--- a/tests/kuttl/test-db-dr-secret-update/00-install.yaml
+++ b/tests/kuttl/test-db-dr-secret-update/00-install.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-db-dr-secret-update
+spec:
+  finalizers:
+  - kubernetes

--- a/tests/kuttl/test-db-dr-secret-update/01-assert.yaml
+++ b/tests/kuttl/test-db-dr-secret-update/01-assert.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: command
+  command: bash ../_common/collect-events.sh
+  timeout: 10
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp-service
+  namespace: test-db-dr-secret-update
+spec:
+  template:
+    spec:
+      containers:
+        - image: quay.io/psav/clowder-hello

--- a/tests/kuttl/test-db-dr-secret-update/01-pods.yaml
+++ b/tests/kuttl/test-db-dr-secret-update/01-pods.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdEnvironment
+metadata:
+  name: test-db-dr-secret-update
+spec:
+  targetNamespace: test-db-dr-secret-update
+  providers:
+    web:
+      port: 8000
+      mode: operator
+    metrics:
+      port: 9000
+      mode: operator
+      path: "/metrics"
+    kafka:
+      mode: none
+    db:
+      mode: app-interface
+      caBundleURL: https://truststore.pki.rds.amazonaws.com/us-east-1/us-east-1-bundle.pem
+    logging:
+      mode: none
+    objectStore:
+      mode: none
+    inMemoryDb:
+      mode: none
+  resourceDefaults:
+    limits:
+      cpu: 400m
+      memory: 1024Mi
+    requests:
+      cpu: 30m
+      memory: 512Mi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: myapp-db
+  namespace: test-db-dr-secret-update
+  annotations:
+    clowder/database: myapp
+type: Opaque
+data:
+  db.host: bXlhcHAucmRzLmV4YW1wbGUuY29t  # myapp.rds.example.com
+  db.name: bXlhcHBkYg==  # myappdb
+  db.port: NTQzMg==  # 5432
+  db.user: bXlhcHB1c2Vy  # myappuser
+  db.password: aW5pdGlhbC1wYXNzd29yZA==  # initial-password
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: myapp
+  namespace: test-db-dr-secret-update
+spec:
+  envName: test-db-dr-secret-update
+  deployments:
+  - name: service
+    podSpec:
+      image: quay.io/psav/clowder-hello
+  database:
+    name: myapp
+    version: 13

--- a/tests/kuttl/test-db-dr-secret-update/02-json-asserts.sh
+++ b/tests/kuttl/test-db-dr-secret-update/02-json-asserts.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Source common error handling
+source "$(dirname "$0")/../_common/error-handler.sh"
+
+# Setup error handling
+setup_error_handling "test-db-dr-secret-update"
+
+# Create test-specific directory
+TMP_DIR="/tmp/kuttl/test-db-dr-secret-update"
+mkdir -p "${TMP_DIR}"
+
+set -x
+
+# Retry finding the secret
+for i in {1..30}; do
+  kubectl get secret --namespace=test-db-dr-secret-update myapp && break
+  sleep 1
+done
+
+# Verify it exists, fail if not
+kubectl get secret --namespace=test-db-dr-secret-update myapp > /dev/null || { echo "Secret not found"; exit 1; }
+
+# Extract cdappconfig.json
+kubectl get secret --namespace=test-db-dr-secret-update myapp -o json > ${TMP_DIR}/secret-before.json
+jq -r '.data["cdappconfig.json"]' < ${TMP_DIR}/secret-before.json | base64 -d > ${TMP_DIR}/cdappconfig-before.json
+
+# Verify initial database values
+jq -r '.database.hostname == "myapp.rds.example.com"' -e < ${TMP_DIR}/cdappconfig-before.json
+jq -r '.database.password == "initial-password"' -e < ${TMP_DIR}/cdappconfig-before.json
+jq -r '.database.username == "myappuser"' -e < ${TMP_DIR}/cdappconfig-before.json
+
+# Save hashCache for later comparison
+jq -r '.hashCache' -e < ${TMP_DIR}/cdappconfig-before.json > ${TMP_DIR}/hash-cache-before

--- a/tests/kuttl/test-db-dr-secret-update/02-json-asserts.yaml
+++ b/tests/kuttl/test-db-dr-secret-update/02-json-asserts.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: bash ../_common/run-script.sh 02-json-asserts.sh

--- a/tests/kuttl/test-db-dr-secret-update/03-assert.yaml
+++ b/tests/kuttl/test-db-dr-secret-update/03-assert.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: command
+  command: bash ../_common/collect-events.sh
+  timeout: 10
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp-service
+  namespace: test-db-dr-secret-update

--- a/tests/kuttl/test-db-dr-secret-update/03-pods.yaml
+++ b/tests/kuttl/test-db-dr-secret-update/03-pods.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: myapp-db
+  namespace: test-db-dr-secret-update
+  annotations:
+    clowder/database: myapp
+type: Opaque
+data:
+  db.host: bXlhcHAtcmVzdG9yZWQucmRzLmV4YW1wbGUuY29t  # myapp-restored.rds.example.com
+  db.name: bXlhcHBkYg==  # myappdb
+  db.port: NTQzMg==  # 5432
+  db.user: bXlhcHB1c2Vy  # myappuser
+  db.password: cmVzdG9yZWQtcGFzc3dvcmQ=  # restored-password

--- a/tests/kuttl/test-db-dr-secret-update/04-json-asserts.sh
+++ b/tests/kuttl/test-db-dr-secret-update/04-json-asserts.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Source common error handling
+source "$(dirname "$0")/../_common/error-handler.sh"
+
+# Setup error handling
+setup_error_handling "test-db-dr-secret-update"
+
+# Create test-specific directory
+TMP_DIR="/tmp/kuttl/test-db-dr-secret-update"
+mkdir -p "${TMP_DIR}"
+
+set -x
+
+# Wait for the deployment to roll (generation bump from 1 to 2)
+sh ../_common/wait_for_generation.sh myapp-service "2" test-db-dr-secret-update
+
+# Extract cdappconfig.json after mutation
+kubectl get secret --namespace=test-db-dr-secret-update myapp -o json > ${TMP_DIR}/secret-after.json
+jq -r '.data["cdappconfig.json"]' < ${TMP_DIR}/secret-after.json | base64 -d > ${TMP_DIR}/cdappconfig-after.json
+
+# Verify updated database values
+jq -r '.database.hostname == "myapp-restored.rds.example.com"' -e < ${TMP_DIR}/cdappconfig-after.json
+jq -r '.database.password == "restored-password"' -e < ${TMP_DIR}/cdappconfig-after.json
+jq -r '.database.username == "myappuser"' -e < ${TMP_DIR}/cdappconfig-after.json
+
+# Verify hashCache changed (proves deployment was bounced)
+jq -r '.hashCache' -e < ${TMP_DIR}/cdappconfig-after.json > ${TMP_DIR}/hash-cache-after
+diff ${TMP_DIR}/hash-cache-before ${TMP_DIR}/hash-cache-after > /dev/null || exit 0 && exit 1

--- a/tests/kuttl/test-db-dr-secret-update/04-json-asserts.yaml
+++ b/tests/kuttl/test-db-dr-secret-update/04-json-asserts.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: bash ../_common/run-script.sh 04-json-asserts.sh

--- a/tests/kuttl/test-db-dr-secret-update/05-delete.yaml
+++ b/tests/kuttl/test-db-dr-secret-update/05-delete.yaml
@@ -1,0 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: v1
+  kind: Namespace
+  name: test-db-dr-secret-update
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdEnvironment
+  name: test-db-dr-secret-update

--- a/tests/kuttl/test-db-dr-shared-secret-update/00-install.yaml
+++ b/tests/kuttl/test-db-dr-shared-secret-update/00-install.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-db-dr-shared-secret-update
+spec:
+  finalizers:
+  - kubernetes

--- a/tests/kuttl/test-db-dr-shared-secret-update/01-assert.yaml
+++ b/tests/kuttl/test-db-dr-shared-secret-update/01-assert.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: command
+  command: bash ../_common/collect-events.sh
+  timeout: 10
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: owner-app-service
+  namespace: test-db-dr-shared-secret-update
+spec:
+  template:
+    spec:
+      containers:
+        - image: quay.io/psav/clowder-hello
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: consumer-app-service
+  namespace: test-db-dr-shared-secret-update
+spec:
+  template:
+    spec:
+      containers:
+        - image: quay.io/psav/clowder-hello

--- a/tests/kuttl/test-db-dr-shared-secret-update/01-pods.yaml
+++ b/tests/kuttl/test-db-dr-shared-secret-update/01-pods.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdEnvironment
+metadata:
+  name: test-db-dr-shared-secret-update
+spec:
+  targetNamespace: test-db-dr-shared-secret-update
+  providers:
+    web:
+      port: 8000
+      mode: operator
+    metrics:
+      port: 9000
+      mode: operator
+      path: "/metrics"
+    kafka:
+      mode: none
+    db:
+      mode: app-interface
+      caBundleURL: https://truststore.pki.rds.amazonaws.com/us-east-1/us-east-1-bundle.pem
+    logging:
+      mode: none
+    objectStore:
+      mode: none
+    inMemoryDb:
+      mode: none
+  resourceDefaults:
+    limits:
+      cpu: 400m
+      memory: 1024Mi
+    requests:
+      cpu: 30m
+      memory: 512Mi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: owner-app-db
+  namespace: test-db-dr-shared-secret-update
+  annotations:
+    clowder/database: owner-app
+type: Opaque
+data:
+  db.host: b3duZXItYXBwLnJkcy5leGFtcGxlLmNvbQ==  # owner-app.rds.example.com
+  db.name: b3duZXItYXBwZGI=  # owner-appdb
+  db.port: NTQzMg==  # 5432
+  db.user: bXlhcHB1c2Vy  # myappuser
+  db.password: aW5pdGlhbC1wYXNzd29yZA==  # initial-password
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: owner-app
+  namespace: test-db-dr-shared-secret-update
+spec:
+  envName: test-db-dr-shared-secret-update
+  deployments:
+  - name: service
+    podSpec:
+      image: quay.io/psav/clowder-hello
+  database:
+    name: owner-app
+    version: 13
+---
+apiVersion: cloud.redhat.com/v1alpha1
+kind: ClowdApp
+metadata:
+  name: consumer-app
+  namespace: test-db-dr-shared-secret-update
+spec:
+  envName: test-db-dr-shared-secret-update
+  deployments:
+  - name: service
+    podSpec:
+      image: quay.io/psav/clowder-hello
+  database:
+    sharedDbAppName: owner-app
+    version: 13
+  dependencies:
+  - owner-app

--- a/tests/kuttl/test-db-dr-shared-secret-update/02-json-asserts.sh
+++ b/tests/kuttl/test-db-dr-shared-secret-update/02-json-asserts.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Source common error handling
+source "$(dirname "$0")/../_common/error-handler.sh"
+
+# Setup error handling
+setup_error_handling "test-db-dr-shared-secret-update"
+
+# Create test-specific directory
+TMP_DIR="/tmp/kuttl/test-db-dr-shared-secret-update"
+mkdir -p "${TMP_DIR}"
+
+set -x
+
+# Retry finding both generated secrets
+for i in {1..30}; do
+  kubectl get secret --namespace=test-db-dr-shared-secret-update owner-app && \
+  kubectl get secret --namespace=test-db-dr-shared-secret-update consumer-app && break
+  sleep 1
+done
+
+kubectl get secret --namespace=test-db-dr-shared-secret-update owner-app > /dev/null || { echo "owner-app secret not found"; exit 1; }
+kubectl get secret --namespace=test-db-dr-shared-secret-update consumer-app > /dev/null || { echo "consumer-app secret not found"; exit 1; }
+
+# Extract cdappconfig.json from owner-app
+kubectl get secret --namespace=test-db-dr-shared-secret-update owner-app -o json > ${TMP_DIR}/owner-secret-before.json
+jq -r '.data["cdappconfig.json"]' < ${TMP_DIR}/owner-secret-before.json | base64 -d > ${TMP_DIR}/owner-cdappconfig-before.json
+
+# Verify owner-app initial database values
+jq -r '.database.hostname == "owner-app.rds.example.com"' -e < ${TMP_DIR}/owner-cdappconfig-before.json
+jq -r '.database.password == "initial-password"' -e < ${TMP_DIR}/owner-cdappconfig-before.json
+jq -r '.database.username == "myappuser"' -e < ${TMP_DIR}/owner-cdappconfig-before.json
+
+# Save owner-app hashCache
+jq -r '.hashCache' -e < ${TMP_DIR}/owner-cdappconfig-before.json > ${TMP_DIR}/hash-cache-owner-before
+
+# Extract cdappconfig.json from consumer-app
+kubectl get secret --namespace=test-db-dr-shared-secret-update consumer-app -o json > ${TMP_DIR}/consumer-secret-before.json
+jq -r '.data["cdappconfig.json"]' < ${TMP_DIR}/consumer-secret-before.json | base64 -d > ${TMP_DIR}/consumer-cdappconfig-before.json
+
+# Verify consumer-app has same initial database values (shared from owner)
+jq -r '.database.hostname == "owner-app.rds.example.com"' -e < ${TMP_DIR}/consumer-cdappconfig-before.json
+jq -r '.database.password == "initial-password"' -e < ${TMP_DIR}/consumer-cdappconfig-before.json
+jq -r '.database.username == "myappuser"' -e < ${TMP_DIR}/consumer-cdappconfig-before.json
+
+# Save consumer-app hashCache
+jq -r '.hashCache' -e < ${TMP_DIR}/consumer-cdappconfig-before.json > ${TMP_DIR}/hash-cache-consumer-before

--- a/tests/kuttl/test-db-dr-shared-secret-update/02-json-asserts.yaml
+++ b/tests/kuttl/test-db-dr-shared-secret-update/02-json-asserts.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: bash ../_common/run-script.sh 02-json-asserts.sh

--- a/tests/kuttl/test-db-dr-shared-secret-update/03-assert.yaml
+++ b/tests/kuttl/test-db-dr-shared-secret-update/03-assert.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+- type: command
+  command: bash ../_common/collect-events.sh
+  timeout: 10
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: owner-app-service
+  namespace: test-db-dr-shared-secret-update
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: consumer-app-service
+  namespace: test-db-dr-shared-secret-update

--- a/tests/kuttl/test-db-dr-shared-secret-update/03-pods.yaml
+++ b/tests/kuttl/test-db-dr-shared-secret-update/03-pods.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: owner-app-db
+  namespace: test-db-dr-shared-secret-update
+  annotations:
+    clowder/database: owner-app
+type: Opaque
+data:
+  db.host: b3duZXItYXBwLXJlc3RvcmVkLnJkcy5leGFtcGxlLmNvbQ==  # owner-app-restored.rds.example.com
+  db.name: b3duZXItYXBwZGI=  # owner-appdb
+  db.port: NTQzMg==  # 5432
+  db.user: bXlhcHB1c2Vy  # myappuser
+  db.password: cmVzdG9yZWQtcGFzc3dvcmQ=  # restored-password

--- a/tests/kuttl/test-db-dr-shared-secret-update/04-json-asserts.sh
+++ b/tests/kuttl/test-db-dr-shared-secret-update/04-json-asserts.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Source common error handling
+source "$(dirname "$0")/../_common/error-handler.sh"
+
+# Setup error handling
+setup_error_handling "test-db-dr-shared-secret-update"
+
+# Create test-specific directory
+TMP_DIR="/tmp/kuttl/test-db-dr-shared-secret-update"
+mkdir -p "${TMP_DIR}"
+
+set -x
+
+# Wait for both deployments to roll (generation bump from 1 to 2)
+sh ../_common/wait_for_generation.sh owner-app-service "2" test-db-dr-shared-secret-update
+sh ../_common/wait_for_generation.sh consumer-app-service "2" test-db-dr-shared-secret-update
+
+# Extract cdappconfig.json from owner-app after mutation
+kubectl get secret --namespace=test-db-dr-shared-secret-update owner-app -o json > ${TMP_DIR}/owner-secret-after.json
+jq -r '.data["cdappconfig.json"]' < ${TMP_DIR}/owner-secret-after.json | base64 -d > ${TMP_DIR}/owner-cdappconfig-after.json
+
+# Verify owner-app updated database values
+jq -r '.database.hostname == "owner-app-restored.rds.example.com"' -e < ${TMP_DIR}/owner-cdappconfig-after.json
+jq -r '.database.password == "restored-password"' -e < ${TMP_DIR}/owner-cdappconfig-after.json
+jq -r '.database.username == "myappuser"' -e < ${TMP_DIR}/owner-cdappconfig-after.json
+
+# Verify owner-app hashCache changed
+jq -r '.hashCache' -e < ${TMP_DIR}/owner-cdappconfig-after.json > ${TMP_DIR}/hash-cache-owner-after
+diff ${TMP_DIR}/hash-cache-owner-before ${TMP_DIR}/hash-cache-owner-after > /dev/null || exit 0 && exit 1
+
+# Extract cdappconfig.json from consumer-app after mutation
+kubectl get secret --namespace=test-db-dr-shared-secret-update consumer-app -o json > ${TMP_DIR}/consumer-secret-after.json
+jq -r '.data["cdappconfig.json"]' < ${TMP_DIR}/consumer-secret-after.json | base64 -d > ${TMP_DIR}/consumer-cdappconfig-after.json
+
+# Verify consumer-app also got updated database values
+jq -r '.database.hostname == "owner-app-restored.rds.example.com"' -e < ${TMP_DIR}/consumer-cdappconfig-after.json
+jq -r '.database.password == "restored-password"' -e < ${TMP_DIR}/consumer-cdappconfig-after.json
+jq -r '.database.username == "myappuser"' -e < ${TMP_DIR}/consumer-cdappconfig-after.json
+
+# Verify consumer-app hashCache also changed
+jq -r '.hashCache' -e < ${TMP_DIR}/consumer-cdappconfig-after.json > ${TMP_DIR}/hash-cache-consumer-after
+diff ${TMP_DIR}/hash-cache-consumer-before ${TMP_DIR}/hash-cache-consumer-after > /dev/null || exit 0 && exit 1

--- a/tests/kuttl/test-db-dr-shared-secret-update/04-json-asserts.yaml
+++ b/tests/kuttl/test-db-dr-shared-secret-update/04-json-asserts.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+- script: bash ../_common/run-script.sh 04-json-asserts.sh

--- a/tests/kuttl/test-db-dr-shared-secret-update/05-delete.yaml
+++ b/tests/kuttl/test-db-dr-shared-secret-update/05-delete.yaml
@@ -1,0 +1,9 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: v1
+  kind: Namespace
+  name: test-db-dr-shared-secret-update
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdEnvironment
+  name: test-db-dr-shared-secret-update


### PR DESCRIPTION
## Change Details
- Adding 2 test case scenarios to cover requested Disaster Recovery exercise use cases where the `cdappconfig.json` for a ClowdApp did not get updated during qontract reconciliation of a bounced pod
  - **Scenario A** - covers changing the `db.host` and `db.password` of an external RDS instance, Clowder successfully propagates the new credentials into the `cdappconfig.json` and bumps the deploy
  - **Scenario B** - covers successful cred updates in the `cdappconfig.json` for applications that share a `sharedDbAppName` (some apps have an owner/consumer relationship which must be accounted for, so both config files need to be updated by Clowder)