### PR TITLE
Remove hostname-based fallback in app-interface DB provider

### DIFF
--- a/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
+++ b/apis/cloud.redhat.com/v1alpha1/clowdapp_types.go
@@ -63,9 +63,8 @@ type DatabaseSpec struct {
 
 	// Defines the Name of the database used by this app. This will be used as the
 	// name of the logical database created by Clowder when the DB provider is in (*_local_*) mode.
-	// In (*_app-interface_*) mode, the name here is used to locate the DB secret as a fallback mechanism
-	// in cases where there is no 'clowder/database: <app-name>' annotation set on any secrets by looking
-	// for a secret with 'db.host' starting with '<name>-<env>' where env is usually 'stage' or 'prod'
+	// In (*_app-interface_*) mode, a secret with the annotation 'clowder/database: <app-name>'
+	// must exist in the namespace. Clowder will fail reconciliation if no such annotated secret is found.
 	Name string `json:"name,omitempty"`
 
 	// Defines the Name of the app to share a database from

--- a/config/crd/bases/cloud.redhat.com_clowdapps.yaml
+++ b/config/crd/bases/cloud.redhat.com_clowdapps.yaml
@@ -108,9 +108,8 @@ spec:
                     description: |-
                       Defines the Name of the database used by this app. This will be used as the
                       name of the logical database created by Clowder when the DB provider is in (*_local_*) mode.
-                      In (*_app-interface_*) mode, the name here is used to locate the DB secret as a fallback mechanism
-                      in cases where there is no 'clowder/database: <app-name>' annotation set on any secrets by looking
-                      for a secret with 'db.host' starting with '<name>-<env>' where env is usually 'stage' or 'prod'
+                      In (*_app-interface_*) mode, a secret with the annotation 'clowder/database: <app-name>'
+                      must exist in the namespace. Clowder will fail reconciliation if no such annotated secret is found.
                     type: string
                   sharedDbAppName:
                     description: Defines the Name of the app to share a database from

--- a/controllers/cloud.redhat.com/providers/database/appinterface.go
+++ b/controllers/cloud.redhat.com/providers/database/appinterface.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/go-logr/logr"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,6 +24,8 @@ import (
 var rdsCaBundles = make(map[string]string)
 
 const defaultCaBundleURL string = "https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem"
+
+const DatabaseAnnotationKey = "clowder/database"
 
 type appInterface struct {
 	providers.Provider
@@ -89,12 +92,10 @@ func (a *appInterface) Provide(app *crd.ClowdApp) error {
 		return errors.NewClowderError("Cannot set dbName & shared db app name")
 	}
 
-	var dbSpec crd.DatabaseSpec
 	var namespace string
 	var searchAppName string
 
 	if app.Spec.Database.Name != "" {
-		dbSpec = app.Spec.Database
 		namespace = app.Namespace
 		searchAppName = app.Name
 	} else if app.Spec.Database.SharedDBAppName != "" {
@@ -109,13 +110,12 @@ func (a *appInterface) Provide(app *crd.ClowdApp) error {
 			return err
 		}
 
-		dbSpec = refApp.Spec.Database
 		namespace = refApp.Namespace
 		searchAppName = refApp.Name
 	}
 
 	rdsCaBundleURL := a.Env.Spec.Providers.Database.CaBundleURL
-	matched, err := GetDbConfig(a.Ctx, a.Client, namespace, searchAppName, dbSpec, rdsCaBundleURL)
+	matched, err := GetDbConfig(a.Ctx, a.Client, a.Log, namespace, searchAppName, rdsCaBundleURL)
 
 	if err != nil {
 		return err
@@ -128,7 +128,7 @@ func (a *appInterface) Provide(app *crd.ClowdApp) error {
 
 // GetDbConfig retrieves database configuration from app-interface
 func GetDbConfig(
-	ctx context.Context, pClient client.Client, namespace, searchAppName string, dbSpec crd.DatabaseSpec, rdsCaBundleURL string,
+	ctx context.Context, pClient client.Client, logger logr.Logger, namespace, searchAppName string, rdsCaBundleURL string,
 ) (*config.DatabaseConfigContainer, error) {
 	secrets := core.SecretList{}
 	err := pClient.List(ctx, &secrets, client.InNamespace(namespace))
@@ -142,6 +142,8 @@ func GetDbConfig(
 		return secrets.Items[i].Name < secrets.Items[j].Name
 	})
 
+	logger.Info("searching for database secret", "namespace", namespace, "app", searchAppName, "secretCount", len(secrets.Items))
+
 	var matched config.DatabaseConfigContainer
 
 	matches, err := searchAnnotationSecret(searchAppName, secrets.Items)
@@ -151,25 +153,24 @@ func GetDbConfig(
 	}
 
 	if len(matches) == 0 {
-
-		dbConfigs, err := genDbConfigs(secrets.Items, false)
-
-		if err != nil {
-			return nil, err
-		}
-
-		matched = resolveDb(dbSpec, dbConfigs)
-
-		if matched == (config.DatabaseConfigContainer{}) {
-			missingDep := errors.MakeMissingDependencies(errors.MissingDependency{
-				Source:  "database",
-				Details: fmt.Sprintf("DB secret matching app '%s' not found in namespace '%s'", searchAppName, namespace),
-			})
-			return nil, &missingDep
-		}
-	} else {
-		matched = matches[0]
+		logger.Info("no secret found with matching annotation",
+			"annotation", DatabaseAnnotationKey,
+			"expectedValue", searchAppName,
+			"namespace", namespace,
+		)
+		missingDep := errors.MakeMissingDependencies(errors.MissingDependency{
+			Source: "database",
+			Details: fmt.Sprintf(
+				"no secret with annotation '%s: %s' found in namespace '%s'; "+
+					"add this annotation to the Kubernetes secret containing database credentials",
+				DatabaseAnnotationKey, searchAppName, namespace,
+			),
+		})
+		return nil, &missingDep
 	}
+
+	matched = matches[0]
+	logger.Info("found database secret via annotation", "secret", matched.Ref.Name, "namespace", matched.Ref.Namespace)
 
 	// The creds given by app-interface have elevated privileges
 	matched.Config.AdminPassword = matched.Config.Password
@@ -181,27 +182,6 @@ func GetDbConfig(
 	matched.Config.RdsCa = &bundle
 
 	return &matched, nil
-}
-
-func resolveDb(spec crd.DatabaseSpec, c []config.DatabaseConfigContainer) config.DatabaseConfigContainer {
-	for _, config := range c {
-		hostname := strings.Split(config.Config.Hostname, ".")[0]
-		nameSegments := strings.Split(hostname, "-")
-		segLen := len(nameSegments)
-		lastSegment := nameSegments[segLen-1]
-
-		if lastSegment == "readonly" {
-			continue
-		}
-
-		dbName := strings.Join(nameSegments[:segLen-1], "-")
-
-		if dbName == spec.Name {
-			return config
-		}
-	}
-
-	return config.DatabaseConfigContainer{}
 }
 
 func genDbConfigs(secrets []core.Secret, verify bool) ([]config.DatabaseConfigContainer, error) {
@@ -248,7 +228,7 @@ func genDbConfigs(secrets []core.Secret, verify bool) ([]config.DatabaseConfigCo
 func searchAnnotationSecret(appName string, secrets []core.Secret) ([]config.DatabaseConfigContainer, error) {
 	for _, secret := range secrets {
 		anno := secret.GetAnnotations()
-		if v, ok := anno["clowder/database"]; ok && v == appName {
+		if v, ok := anno[DatabaseAnnotationKey]; ok && v == appName {
 			configs, err := genDbConfigs([]core.Secret{secret}, true)
 			return configs, err
 		}

--- a/controllers/cloud.redhat.com/providers/database/appinterface.go
+++ b/controllers/cloud.redhat.com/providers/database/appinterface.go
@@ -25,6 +25,7 @@ var rdsCaBundles = make(map[string]string)
 
 const defaultCaBundleURL string = "https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem"
 
+// DatabaseAnnotationKey is the annotation used to match secrets to ClowdApps for database configuration.
 const DatabaseAnnotationKey = "clowder/database"
 
 type appInterface struct {

--- a/controllers/cloud.redhat.com/providers/database/appinterface_test.go
+++ b/controllers/cloud.redhat.com/providers/database/appinterface_test.go
@@ -1,35 +1,172 @@
 package database
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	core "k8s.io/api/core/v1"
-
-	crd "github.com/RedHatInsights/clowder/apis/cloud.redhat.com/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestAppInterfaceDb(t *testing.T) {
-	dbName := "test-db"
-	secrets := []core.Secret{{
-		Data: map[string][]byte{
-			"db.host":     []byte(fmt.Sprintf("%s-prod.amazing.aws.amazon.com", dbName)),
-			"db.port":     []byte("5432"),
-			"db.user":     []byte("user"),
-			"db.password": []byte("password"),
-			"db.name":     []byte(dbName),
+func TestSearchAnnotationSecret_MatchFound(t *testing.T) {
+	secrets := []core.Secret{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myapp-db-prod",
+				Namespace: "test-ns",
+				Annotations: map[string]string{
+					DatabaseAnnotationKey: "myapp",
+				},
+			},
+			Data: map[string][]byte{
+				"db.host":     []byte("myapp-db-prod.rds.example.com"),
+				"db.port":     []byte("5432"),
+				"db.user":     []byte("admin"),
+				"db.password": []byte("secret"),
+				"db.name":     []byte("myappdb"),
+			},
 		},
-	}}
+	}
+
+	configs, err := searchAnnotationSecret("myapp", secrets)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(configs))
+	assert.Equal(t, "myapp-db-prod.rds.example.com", configs[0].Config.Hostname)
+	assert.Equal(t, 5432, configs[0].Config.Port)
+	assert.Equal(t, "admin", configs[0].Config.Username)
+	assert.Equal(t, "secret", configs[0].Config.Password)
+	assert.Equal(t, "myappdb", configs[0].Config.Name)
+	assert.Equal(t, "myapp-db-prod", configs[0].Ref.Name)
+	assert.Equal(t, "test-ns", configs[0].Ref.Namespace)
+}
+
+func TestSearchAnnotationSecret_NoMatch(t *testing.T) {
+	secrets := []core.Secret{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "other-db",
+				Namespace: "test-ns",
+				Annotations: map[string]string{
+					DatabaseAnnotationKey: "other-app",
+				},
+			},
+			Data: map[string][]byte{
+				"db.host":     []byte("other-db.rds.example.com"),
+				"db.port":     []byte("5432"),
+				"db.user":     []byte("user"),
+				"db.password": []byte("pass"),
+				"db.name":     []byte("otherdb"),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "no-annotation-db",
+				Namespace: "test-ns",
+			},
+			Data: map[string][]byte{
+				"db.host":     []byte("no-annotation.rds.example.com"),
+				"db.port":     []byte("5432"),
+				"db.user":     []byte("user"),
+				"db.password": []byte("pass"),
+				"db.name":     []byte("nodb"),
+			},
+		},
+	}
+
+	configs, err := searchAnnotationSecret("myapp", secrets)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(configs))
+}
+
+func TestSearchAnnotationSecret_MultipleSecrets(t *testing.T) {
+	secrets := []core.Secret{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myapp-db-arestore",
+				Namespace: "test-ns",
+			},
+			Data: map[string][]byte{
+				"db.host":     []byte("myapp-db-arestore.rds.example.com"),
+				"db.port":     []byte("5432"),
+				"db.user":     []byte("restore-user"),
+				"db.password": []byte("restore-pass"),
+				"db.name":     []byte("myappdb"),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "myapp-db-prod",
+				Namespace: "test-ns",
+				Annotations: map[string]string{
+					DatabaseAnnotationKey: "myapp",
+				},
+			},
+			Data: map[string][]byte{
+				"db.host":     []byte("myapp-db-prod.rds.example.com"),
+				"db.port":     []byte("5432"),
+				"db.user":     []byte("prod-user"),
+				"db.password": []byte("prod-pass"),
+				"db.name":     []byte("myappdb"),
+			},
+		},
+	}
+
+	configs, err := searchAnnotationSecret("myapp", secrets)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(configs))
+	assert.Equal(t, "myapp-db-prod.rds.example.com", configs[0].Config.Hostname)
+	assert.Equal(t, "prod-user", configs[0].Config.Username)
+	assert.Equal(t, "myapp-db-prod", configs[0].Ref.Name)
+}
+
+func TestGenDbConfigs_ValidSecret(t *testing.T) {
+	secrets := []core.Secret{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-db",
+				Namespace: "test-ns",
+			},
+			Data: map[string][]byte{
+				"db.host":     []byte("test-db-prod.rds.example.com"),
+				"db.port":     []byte("5432"),
+				"db.user":     []byte("user"),
+				"db.password": []byte("password"),
+				"db.name":     []byte("testdb"),
+			},
+		},
+	}
 
 	configs, err := genDbConfigs(secrets, false)
 
-	assert.NoError(t, err, "failed to gen db config")
-	assert.Equal(t, len(configs), 1, "wrong number of configs")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(configs))
+	assert.Equal(t, "test-db-prod.rds.example.com", configs[0].Config.Hostname)
+	assert.Equal(t, 5432, configs[0].Config.Port)
+	assert.Equal(t, "user", configs[0].Config.Username)
+	assert.Equal(t, "password", configs[0].Config.Password)
+	assert.Equal(t, "testdb", configs[0].Config.Name)
+	assert.Equal(t, "verify-full", configs[0].Config.SslMode)
+}
 
-	spec := crd.DatabaseSpec{Name: dbName}
+func TestGenDbConfigs_MissingKeys(t *testing.T) {
+	secrets := []core.Secret{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "incomplete-db",
+				Namespace: "test-ns",
+			},
+			Data: map[string][]byte{
+				"db.host": []byte("incomplete.rds.example.com"),
+				"db.port": []byte("5432"),
+			},
+		},
+	}
 
-	resolved := resolveDb(spec, configs)
+	configs, err := genDbConfigs(secrets, false)
 
-	assert.Equal(t, configs[0], resolved, "resolveDb did not match given config")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(configs))
 }

--- a/controllers/cloud.redhat.com/providers/kafka/cyndi.go
+++ b/controllers/cloud.redhat.com/providers/kafka/cyndi.go
@@ -171,7 +171,7 @@ func getDbSecretInSameEnv(s prov.RootProvider, app *crd.ClowdApp, name string) (
 		case "app-interface":
 			if app.Spec.Database.Name != "" {
 				rdsCaBundleURL := s.GetEnv().Spec.Providers.Database.CaBundleURL
-				dbConfig, err := db.GetDbConfig(s.GetCtx(), s.GetClient(), app.Namespace, app.Name, app.Spec.Database, rdsCaBundleURL)
+				dbConfig, err := db.GetDbConfig(s.GetCtx(), s.GetClient(), s.GetLog(), app.Namespace, app.Name, rdsCaBundleURL)
 
 				if err != nil {
 					return nil, errors.Wrap("could not get database config", err)

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -543,7 +543,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `version` _integer_ | Defines the Version of the PostGreSQL database, defaults to 12. |  | Enum: [12 13 14 15 16] <br /> |
-| `name` _string_ | Defines the Name of the database used by this app. This will be used as the<br />name of the logical database created by Clowder when the DB provider is in (*_local_*) mode.<br />In (*_app-interface_*) mode, the name here is used to locate the DB secret as a fallback mechanism<br />in cases where there is no 'clowder/database: <app-name>' annotation set on any secrets by looking<br />for a secret with 'db.host' starting with '<name>-<env>' where env is usually 'stage' or 'prod' |  |  |
+| `name` _string_ | Defines the Name of the database used by this app. This will be used as the<br />name of the logical database created by Clowder when the DB provider is in (*_local_*) mode.<br />In (*_app-interface_*) mode, a secret with the annotation 'clowder/database: <app-name>'<br />must exist in the namespace. Clowder will fail reconciliation if no such annotated secret is found. |  |  |
 | `sharedDbAppName` _string_ | Defines the Name of the app to share a database from |  |  |
 | `dbVolumeSize` _string_ | T-shirt size, one of small, medium, large |  | Enum: [small medium large] <br /> |
 | `dbResourceSize` _string_ | T-shirt size, one of small, medium, large |  | Enum: [small medium large] <br /> |

--- a/tests/kuttl/test-multi-app-interface-db/01-pods.yaml
+++ b/tests/kuttl/test-multi-app-interface-db/01-pods.yaml
@@ -84,6 +84,8 @@ kind: Secret
 metadata:
   name: app-b-readonly-db
   namespace: test-multi-app-interface-db
+  annotations:
+    clowder/database: app-b
 type: Opaque
 data:
   db.host: YXBwLWItc3RhZ2UucmRzLmV4YW1wbGUuY29t  # app-b-stage.rds.example.com


### PR DESCRIPTION
## Summary
- Remove the `resolveDb()` hostname-based fallback mechanism that selected database secrets by parsing `db.host` values when the `clowder/database` annotation was missing. This fallback could silently connect apps to wrong databases (e.g., a restore DB `myapp-db-arestore` sorting alphabetically before `myapp-db-prod`).
- The `clowder/database` annotation is now **required** on secrets for app-interface mode. Reconciliation fails with a clear, actionable error message if no matching annotated secret is found.
- Added structured logging (`logr`) for DB secret lookup: logs when search starts, when a match is found, and when no match exists.

## Breaking Change
This is a **breaking change** for teams relying on the hostname fallback. All database secrets in app-interface mode must have the `clowder/database: <app-name>` annotation. The error message guides users on how to fix it.

## Files Changed
- `appinterface.go` — Removed fallback block and `resolveDb()`, added `DatabaseAnnotationKey` constant, added `logr.Logger` parameter to `GetDbConfig`, added logging
- `appinterface_test.go` — Replaced old `resolveDb` test with 5 new tests for `searchAnnotationSecret` and `genDbConfigs`
- `cyndi.go` — Updated `GetDbConfig` call signature
- `clowdapp_types.go` — Updated `DatabaseSpec.Name` comment to reflect annotation requirement
- `01-pods.yaml` (kuttl) — Added `clowder/database: app-b` annotation to `app-b-readonly-db` secret

## Test plan
- [x] `go build ./...` passes
- [x] Unit tests pass (`go test ./controllers/cloud.redhat.com/providers/database/...`)
- [ ] KUTTL integration test `test-multi-app-interface-db` passes in CI
- [ ] CI pipeline passes (lint, vet, full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)