### PR TITLE
fix: retry ClowdApp status update on 409 Conflict

### DIFF
--- a/controllers/cloud.redhat.com/status.go
+++ b/controllers/cloud.redhat.com/status.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
 	cond "sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -554,7 +555,12 @@ func SetClowdAppConditions(ctx context.Context, client client.Client, o *crd.Clo
 	o.Status.Ready = deploymentStatus
 
 	if !equality.Semantic.DeepEqual(*oldStatus, o.Status) {
+		attempt := 0
 		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			if attempt > 0 {
+				ctrl.Log.Info("retrying ClowdApp status update after 409 conflict", "app", o.Name, "namespace", o.Namespace, "attempt", attempt)
+			}
+			attempt++
 			if getErr := client.Get(ctx, types.NamespacedName{Name: o.Name, Namespace: o.Namespace}, o); getErr != nil {
 				return getErr
 			}

--- a/controllers/cloud.redhat.com/status.go
+++ b/controllers/cloud.redhat.com/status.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	cond "sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -553,9 +554,17 @@ func SetClowdAppConditions(ctx context.Context, client client.Client, o *crd.Clo
 	o.Status.Ready = deploymentStatus
 
 	if !equality.Semantic.DeepEqual(*oldStatus, o.Status) {
-		if err := client.Status().Update(ctx, o); err != nil {
-			return err
-		}
+		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			if getErr := client.Get(ctx, types.NamespacedName{Name: o.Name, Namespace: o.Namespace}, o); getErr != nil {
+				return getErr
+			}
+			cond.Delete(o, "ReconciliationPartiallySuccessful")
+			for i := range conditions {
+				cond.Set(o, conditions[i])
+			}
+			o.Status.Ready = deploymentStatus
+			return client.Status().Update(ctx, o)
+		})
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Wraps the `ClowdApp` status update in `retry.RetryOnConflict` so that overlapping reconciliation loops no longer produce false reconciliation errors
- Re-fetches the `ClowdApp` and re-applies conditions on conflict before retrying (standard Kubernetes controller pattern)
- Adds an info-level log on each retry so pathologically high conflict rates remain observable

**Root cause:** Clowder reads the `ClowdApp` once at reconciliation start and writes the status at the end. If a second reconciliation loop completes in between, the `resourceVersion` is stale and Kubernetes rejects the write with a 409 Conflict. Previously this was treated as a real error, incrementing the error metric and triggering `ClowderReconciliationErrorRate` alerts in hccm-prod.

Resolves: ENGPROD-10303

## Test plan

- [ ] `make test` passes
- [ ] Deploy to minikube with `make deploy-minikube-quick` and run `make kuttl`
- [ ] Trigger rapid overlapping reconciliations on a ClowdApp and confirm the retry log line appears and no error metric is incremented

🤖 Generated with [Claude Code](https://claude.com/claude-code)