### PR TITLE
fix(deps): bump Go to 1.26.7 to resolve critical/important CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1785791459 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.7-1788409979 AS builder
 USER 0
 ENV GOSUMDB=off
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RedHatInsights/clowder
 
-go 1.26.5
+go 1.26.7
 
 require (
 	github.com/RedHatInsights/crc-caddy-plugin v0.7.2


### PR DESCRIPTION
## Summary
- Bumps Go from 1.26.5 to 1.26.7 in `go.mod` and the Dockerfile builder image
- Resolves 8 important stdlib CVEs (CVE-2026-46600, CVE-2026-56858, CVE-2026-56862, CVE-2026-56853, CVE-2026-56859, CVE-2026-39821, CVE-2026-56860, CVE-2026-33818) identified in the FedRAMP compliance scan

## Details
The FedRAMP compliance scan (2026-09-02) of `quay.io/redhat-services-prod/hcm-eng-prod-tenant/clowder:9390112` flagged 15 critical/important CVEs. Of these:
- **1 critical** (CVE-2026-56854, golang.org/x/crypto) — already fixed at v0.55.0 in go.mod
- **8 important** (stdlib) — fixed by this PR (Go 1.26.7 includes Go 1.26.6 fixes)
- **6 important** (curl-minimal/libcurl-minimal RPMs) — no upstream fix available

## Test plan
- [ ] CI lint passes (uses `go-version-file: go.mod`, picks up 1.26.7 automatically)
- [ ] Container image builds successfully with the new go-toolset base image
- [ ] No regressions in unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)